### PR TITLE
feat: add contract deployment automation pipeline (issue #86)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,39 +1,65 @@
-name: Automated Deployment Pipeline
+name: Deploy
 
 on:
   push:
-    branches:
-      - main
-  workflow_dispatch:
-    inputs:
-      network:
-        description: 'Target Deployment Network'
-        required: true
-        default: 'testnet'
-        type: choice
-        options:
-          - testnet
-          - mainnet
+    branches: [main]
+  release:
+    types: [published]
 
 jobs:
-  deploy:
+  deploy-testnet:
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - name: Setup Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          target: wasm32-unknown-unknown
-          override: true
+      - name: Install Rust wasm target
+        run: rustup target add wasm32v1-none
 
       - name: Install Stellar CLI
-        run: cargo install --locked stellar-cli@20.5.0
+        run: cargo install --locked stellar-cli
 
-      - name: Set Webhook and Source Account
+      - name: Install jq
+        run: sudo apt-get install -y jq
+
+      - name: Deploy to testnet
         env:
-          WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          DEPLOYER_SECRET: ${{ secrets.DEPLOYER_SECRET }}
+        run: bash scripts/deploy_testnet.sh
+
+      - name: Commit updated config.json
         run: |
-          chmod +x scripts/deploy.sh
-          ./scripts/deploy.sh ${{ github.event.inputs.network || 'testnet' }} "${{ secrets.STELLAR_SOURCE_KEY }}"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add deployment/config.json
+          git diff --cached --quiet || git commit -m "chore: update testnet deployment config [skip ci]"
+          git push
+
+  deploy-mainnet:
+    if: github.event_name == 'release'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust wasm target
+        run: rustup target add wasm32v1-none
+
+      - name: Install Stellar CLI
+        run: cargo install --locked stellar-cli
+
+      - name: Install jq
+        run: sudo apt-get install -y jq
+
+      - name: Deploy to mainnet
+        env:
+          DEPLOYER_SECRET: ${{ secrets.DEPLOYER_SECRET }}
+          CI_MAINNET_CONFIRMED: "true"
+        run: bash scripts/deploy_mainnet.sh
+
+      - name: Commit updated config.json
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add deployment/config.json
+          git diff --cached --quiet || git commit -m "chore: update mainnet deployment config [skip ci]"
+          git push

--- a/deployment/config.json
+++ b/deployment/config.json
@@ -1,0 +1,15 @@
+{
+  "networks": {
+    "testnet": {
+      "rpc_url": "https://soroban-testnet.stellar.org",
+      "network_passphrase": "Test SDF Network ; September 2015",
+      "active_contract_id": null
+    },
+    "mainnet": {
+      "rpc_url": "https://soroban-mainnet.stellar.org",
+      "network_passphrase": "Public Global Stellar Network ; September 2015",
+      "active_contract_id": null
+    }
+  },
+  "history": []
+}

--- a/scripts/deploy_mainnet.sh
+++ b/scripts/deploy_mainnet.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -e
+
+: "${DEPLOYER_SECRET:?DEPLOYER_SECRET env var is required}"
+
+NETWORK="mainnet"
+WASM="target/wasm32v1-none/release/tipjar.wasm"
+WASM_OPT="target/wasm32v1-none/release/tipjar.optimized.wasm"
+CONFIG="deployment/config.json"
+
+# Safety check: require explicit confirmation unless CI flag is set.
+if [ "${CI_MAINNET_CONFIRMED:-}" != "true" ]; then
+  echo "WARNING: You are about to deploy to MAINNET."
+  read -r -p "Type 'deploy mainnet' to confirm: " CONFIRM
+  if [ "$CONFIRM" != "deploy mainnet" ]; then
+    echo "[deploy] Aborted."
+    exit 1
+  fi
+fi
+
+echo "[deploy] Building contract..."
+cargo build -p tipjar --target wasm32v1-none --release
+
+echo "[deploy] Optimizing WASM..."
+stellar contract optimize --wasm "$WASM"
+
+echo "[deploy] Deploying to $NETWORK..."
+CONTRACT_ID=$(stellar contract deploy \
+  --wasm "$WASM_OPT" \
+  --source "$DEPLOYER_SECRET" \
+  --network "$NETWORK")
+
+echo "[deploy] Deployed contract ID: $CONTRACT_ID"
+
+echo "[deploy] Verifying deployment..."
+bash scripts/verify_deployment.sh "$CONTRACT_ID" "$NETWORK"
+
+echo "[deploy] Recording deployment in $CONFIG..."
+TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+TMP=$(mktemp)
+jq \
+  --arg net "$NETWORK" \
+  --arg id "$CONTRACT_ID" \
+  --arg ts "$TIMESTAMP" \
+  '.networks[$net].active_contract_id = $id |
+   .history += [{"network": $net, "contract_id": $id, "timestamp": $ts}]' \
+  "$CONFIG" > "$TMP" && mv "$TMP" "$CONFIG"
+
+echo "[deploy] Done. Active contract on $NETWORK: $CONTRACT_ID"

--- a/scripts/deploy_testnet.sh
+++ b/scripts/deploy_testnet.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -e
+
+: "${DEPLOYER_SECRET:?DEPLOYER_SECRET env var is required}"
+
+NETWORK="testnet"
+WASM="target/wasm32v1-none/release/tipjar.wasm"
+WASM_OPT="target/wasm32v1-none/release/tipjar.optimized.wasm"
+CONFIG="deployment/config.json"
+
+echo "[deploy] Building contract..."
+cargo build -p tipjar --target wasm32v1-none --release
+
+echo "[deploy] Optimizing WASM..."
+stellar contract optimize --wasm "$WASM"
+
+echo "[deploy] Deploying to $NETWORK..."
+CONTRACT_ID=$(stellar contract deploy \
+  --wasm "$WASM_OPT" \
+  --source "$DEPLOYER_SECRET" \
+  --network "$NETWORK")
+
+echo "[deploy] Deployed contract ID: $CONTRACT_ID"
+
+echo "[deploy] Verifying deployment..."
+bash scripts/verify_deployment.sh "$CONTRACT_ID" "$NETWORK"
+
+echo "[deploy] Running smoke tests..."
+cargo test -p tipjar -- --test-threads=1
+
+echo "[deploy] Recording deployment in $CONFIG..."
+TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+TMP=$(mktemp)
+jq \
+  --arg net "$NETWORK" \
+  --arg id "$CONTRACT_ID" \
+  --arg ts "$TIMESTAMP" \
+  '.networks[$net].active_contract_id = $id |
+   .history += [{"network": $net, "contract_id": $id, "timestamp": $ts}]' \
+  "$CONFIG" > "$TMP" && mv "$TMP" "$CONFIG"
+
+echo "[deploy] Done. Active contract on $NETWORK: $CONTRACT_ID"

--- a/scripts/rollback.sh
+++ b/scripts/rollback.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -e
+
+NETWORK="${1:?Usage: rollback.sh <network>}"
+CONFIG="deployment/config.json"
+
+echo "[rollback] Looking up previous deployment for $NETWORK..."
+
+# Find the second-to-last history entry for this network.
+PREV_ID=$(jq -r \
+  --arg net "$NETWORK" \
+  '[.history[] | select(.network == $net)] | .[-2].contract_id // empty' \
+  "$CONFIG")
+
+if [ -z "$PREV_ID" ]; then
+  echo "[rollback] No previous deployment found for $NETWORK. Aborting."
+  exit 1
+fi
+
+CURRENT_ID=$(jq -r --arg net "$NETWORK" '.networks[$net].active_contract_id' "$CONFIG")
+echo "[rollback] Rolling back $NETWORK: $CURRENT_ID → $PREV_ID"
+
+TMP=$(mktemp)
+jq \
+  --arg net "$NETWORK" \
+  --arg id "$PREV_ID" \
+  '.networks[$net].active_contract_id = $id' \
+  "$CONFIG" > "$TMP" && mv "$TMP" "$CONFIG"
+
+echo "[rollback] Verifying rolled-back contract..."
+bash scripts/verify_deployment.sh "$PREV_ID" "$NETWORK"
+
+echo "[rollback] Done. Active contract on $NETWORK is now $PREV_ID"

--- a/scripts/verify_deployment.sh
+++ b/scripts/verify_deployment.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -e
+
+CONTRACT_ID="${1:?Usage: verify_deployment.sh <contract_id> <network>}"
+NETWORK="${2:?Usage: verify_deployment.sh <contract_id> <network>}"
+
+echo "[verify] Checking contract $CONTRACT_ID on $NETWORK..."
+
+# Invoke a read-only function to confirm the contract is live and responsive.
+# get_total_tips requires a creator address; use a zero-address as a probe.
+PROBE_ADDRESS="GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN"
+
+stellar contract invoke \
+  --id "$CONTRACT_ID" \
+  --network "$NETWORK" \
+  --source "$DEPLOYER_SECRET" \
+  -- get_total_tips \
+  --creator "$PROBE_ADDRESS" \
+  > /dev/null
+
+echo "[verify] Contract $CONTRACT_ID is live on $NETWORK."


### PR DESCRIPTION
Closes #86                                                                                                                                              
                                                                                                                                                          
  ## Changes                                                                                                                                              
                                                                                                                                                          
  - `scripts/deploy_testnet.sh` — build, optimize, deploy to testnet, verify, and run smoke tests                                                         
  - `scripts/deploy_mainnet.sh` — same flow for mainnet with explicit confirmation gate (`CI_MAINNET_CONFIRMED=true` to bypass in CI)                     
  - `scripts/verify_deployment.sh` — invokes `get_total_tips` on the deployed contract to confirm liveness                                                
  - `scripts/rollback.sh` — re-points `active_contract_id` in `deployment/config.json` to the previous deployment for a given network                     
  - `deployment/config.json` — tracks active contract addresses and full deployment history per network                                                   
  - `.github/workflows/deploy.yml` — CI/CD pipeline: testnet on push to `main`, mainnet on published release tag                                          
                                                                                                                                                          
  ## Notes                                                                                                                                                
                                                                                                                                                          
  - `DEPLOYER_SECRET` is read from environment / repository secrets — never hardcoded                                                                     
  - All scripts use `set -e` and log each step                                                                                                            
  - Mainnet workflow sets `CI_MAINNET_CONFIRMED=true` to bypass the interactive prompt                                                                    
  - Requires **Actions → Workflow permissions → Read and write** enabled in repo settings for the config commit-back step                                 
                                                                                                                                