### PR TITLE
feat(sdk): add TypeScript SDK for frontend contract integration (issu…

### DIFF
--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -1,24 +1,95 @@
-# Stellar TipJar SDK
+# @tipjar/sdk
 
-## Install
-npm install stellar-tipjar-sdk
+TypeScript SDK for the [Stellar tipjar smart contract](../../contracts/tipjar).
 
-## Usage
+## Installation
+
+```bash
+npm install @tipjar/sdk
+```
+
+## Quick Start
 
 ```ts
-import { TipJarContract } from 'stellar-tipjar-sdk';
+import { TipJarContract } from '@tipjar/sdk';
+import { Keypair } from '@stellar/stellar-sdk';
 
-const sdk = new TipJarContract(CONTRACT_ID, 'testnet');
-
-// Send Tip
-await sdk.sendTip({
-  creator: 'G...',
-  amount: BigInt(1000),
-  tipper: 'G...',
+const sdk = new TipJarContract({
+  contractId: 'C...',
+  network: 'testnet',
 });
 
-// Get Balance
-const balance = await sdk.getBalance('G...');
+// Provide a keypair for signing write transactions.
+sdk.connect(Keypair.fromSecret(process.env.DEPLOYER_SECRET!));
+
+// Send a tip
+const tip = await sdk.sendTip({
+  tipper: 'G...',
+  creator: 'G...',
+  amount: 1_000_000n, // in stroops
+});
+console.log('Tip tx:', tip.txHash);
 
 // Withdraw
-await sdk.withdraw('G...', BigInt(500));
+const withdrawal = await sdk.withdraw('G...');
+console.log('Withdrew:', withdrawal.amount);
+```
+
+## API
+
+### `new TipJarContract(config: SdkConfig)`
+
+| Field | Type | Description |
+|---|---|---|
+| `contractId` | `string` | Deployed contract ID |
+| `network` | `'testnet' \| 'mainnet'` | Target network |
+| `rpcUrl` | `string?` | Override default RPC URL |
+
+### Methods
+
+#### `connect(keypair: Keypair): void`
+Store a keypair for signing. Required before any write operation.
+
+#### `sendTip(params: TipParams): Promise<TipResult>`
+Calls `tip(sender, creator, amount)` on-chain.
+
+#### `withdraw(creator: string): Promise<WithdrawResult>`
+Calls `withdraw(creator)` — withdraws the full escrowed balance.
+
+#### `getTotalTips(creator: string): Promise<bigint>`
+Calls `get_total_tips(creator)` — returns historical tip total.
+
+#### `getBalance(creator: string): Promise<bigint>`
+Simulates `withdraw` to read the current withdrawable balance without submitting.
+
+#### `getTipEvents(creator: string, limit?: number): Promise<TipEvent[]>`
+Fetches on-chain `("tip", creator)` events. Default limit: 20.
+
+## Error Handling
+
+```ts
+import { InvalidAmountError, TransactionFailedError, NetworkError } from '@tipjar/sdk';
+
+try {
+  await sdk.sendTip({ ... });
+} catch (err) {
+  if (err instanceof InvalidAmountError) { /* bad amount */ }
+  if (err instanceof TransactionFailedError) { console.log(err.txHash); }
+  if (err instanceof NetworkError) { console.log('retries:', err.retries); }
+}
+```
+
+All async methods retry up to 3 times with exponential backoff before throwing `NetworkError`.
+
+## Network Configuration
+
+| Network | RPC URL |
+|---|---|
+| `testnet` | `https://soroban-testnet.stellar.org` |
+| `mainnet` | `https://soroban.stellar.org` |
+
+Override with `rpcUrl` in `SdkConfig`.
+
+## Wallet Integration
+
+For browser wallets (e.g. Freighter), build and sign the transaction externally, then pass the signed XDR to the Soroban RPC server directly. The `connect()` method accepts any `Keypair`-compatible signer; adapt it to your wallet's signing interface as needed.

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,23 +1,22 @@
 {
-  "name": "stellar-tipjar-sdk",
-  "version": "1.0.0",
-  "description": "TypeScript SDK for TipJar contract with wallet support",
-  "main": "dist/TipJarContract.js",
-  "types": "dist/TipJarContract.d.ts",
+  "name": "@tipjar/sdk",
+  "version": "0.1.0",
+  "description": "TypeScript SDK for the Stellar tipjar smart contract",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": ["dist"],
   "scripts": {
     "build": "tsc",
-    "clean": "rimraf dist",
-    "start": "ts-node src/TipJarContract.ts"
+    "test": "jest",
+    "prepublishOnly": "npm run build"
   },
-  "keywords": ["stellar", "soroban", "tipjar", "typescript", "sdk"],
-  "author": "Bonizozo",
-  "license": "MIT",
   "dependencies": {
     "@stellar/stellar-sdk": "^12.0.0"
   },
   "devDependencies": {
-    "typescript": "^5.3.0",
-    "ts-node": "^10.9.1",
-    "rimraf": "^5.0.0"
+    "@types/jest": "^29.0.0",
+    "jest": "^29.0.0",
+    "ts-jest": "^29.0.0",
+    "typescript": "^5.0.0"
   }
 }

--- a/sdk/typescript/src/TipJarContract.ts
+++ b/sdk/typescript/src/TipJarContract.ts
@@ -1,316 +1,205 @@
 import {
   Contract,
-  TransactionBuilder,
+  Keypair,
   Networks,
-  BASE_FEE,
+  SorobanRpc,
+  TransactionBuilder,
   nativeToScVal,
   scValToNative,
-  rpc as SorobanRpc,
+  xdr,
 } from '@stellar/stellar-sdk';
+import {
+  SdkConfig,
+  TipParams,
+  TipResult,
+  WithdrawResult,
+  TipEvent,
+  Network,
+} from './types';
+import {
+  InvalidAmountError,
+  TransactionFailedError,
+  ContractNotInitializedError,
+} from './errors';
+import { NETWORK_CONFIG, parseTipEvent, parseWithdrawEvent, withRetry } from './utils';
 
-import { SendTipParams, TipResult, WithdrawResult } from './types';
-import { getRpcUrl, retry } from './utils';
+const BASE_FEE = '100';
+const TX_TIMEOUT_SEC = 30;
 
 export class TipJarContract {
   private contract: Contract;
   private server: SorobanRpc.Server;
   private networkPassphrase: string;
+  private keypair: Keypair | null = null;
 
-  /**
-   * Creates a new TipJarContract instance.
-   *
-   * @param contractId - Bech32m contract address (C…).
-   * @param network - Target Stellar network ('testnet' | 'mainnet').
-   */
-  constructor(contractId: string, network: 'testnet' | 'mainnet') {
-    this.contract = new Contract(contractId);
-    this.server = new SorobanRpc.Server(getRpcUrl(network));
-    this.networkPassphrase =
-      network === 'testnet' ? Networks.TESTNET : Networks.PUBLIC;
+  constructor(private readonly config: SdkConfig) {
+    const net = NETWORK_CONFIG[config.network];
+    this.contract = new Contract(config.contractId);
+    this.server = new SorobanRpc.Server(config.rpcUrl ?? net.rpcUrl);
+    this.networkPassphrase = net.networkPassphrase;
   }
 
-  /* ===============================
-     WALLET: Freighter Sign
-  ================================ */
-
   /**
-   * Signs a transaction XDR using the Freighter browser extension.
-   *
-   * @param xdr - Unsigned transaction XDR string.
-   * @returns Signed transaction XDR string.
-   * @throws If Freighter is not installed or the user rejects signing.
+   * Store a keypair for transaction signing.
+   * @param keypair - Stellar Keypair used to sign transactions.
+   * @example
+   * sdk.connect(Keypair.fromSecret(process.env.SECRET!));
    */
-  async signWithFreighter(xdr: string): Promise<string> {
-    if (!(window as any).freighterApi) {
-      throw new Error(
-        'Freighter wallet not installed. Visit https://www.freighter.app'
-      );
-    }
-
-    const result = await (window as any).freighterApi.signTransaction(xdr, {
-      networkPassphrase: this.networkPassphrase,
-    });
-
-    if (!result) {
-      throw new Error('Freighter returned an empty signed transaction.');
-    }
-
-    return result;
+  connect(keypair: Keypair): void {
+    this.keypair = keypair;
   }
 
-  /* ===============================
-     WAIT FOR TX CONFIRMATION
-  ================================ */
-
   /**
-   * Polls the RPC node until a transaction is confirmed or fails.
-   *
-   * @param hash - Transaction hash to poll.
-   * @returns The confirmed transaction response.
-   * @throws If the transaction fails or is never confirmed.
+   * Send a tip to a creator.
+   * @param params - Tip parameters including creator, amount, and tipper addresses.
+   * @returns TipResult with transaction hash, creator, and amount.
+   * @throws InvalidAmountError if amount is not positive.
+   * @throws TransactionFailedError if the transaction fails.
+   * @example
+   * const result = await sdk.sendTip({ creator: 'G...', amount: 100n, tipper: 'G...' });
    */
-  async waitForConfirmation(
-    hash: string
-  ): Promise<SorobanRpc.Api.GetTransactionResponse> {
-    let attempts = 0;
-    const maxAttempts = 30;
-
-    while (attempts < maxAttempts) {
-      const tx = await this.server.getTransaction(hash);
-
-      if (tx.status === 'SUCCESS') return tx;
-      if (tx.status === 'FAILED') {
-        throw new Error(`Transaction failed on-chain: ${hash}`);
-      }
-
-      // NOT_FOUND — keep polling
-      await new Promise((r) => setTimeout(r, 1500));
-      attempts++;
-    }
-
-    throw new Error(
-      `Transaction ${hash} was not confirmed after ${maxAttempts} attempts.`
+  async sendTip(params: TipParams): Promise<TipResult> {
+    if (params.amount <= 0n) throw new InvalidAmountError();
+    const op = this.contract.call(
+      'tip',
+      nativeToScVal(params.tipper, { type: 'address' }),
+      nativeToScVal(params.creator, { type: 'address' }),
+      nativeToScVal(params.amount, { type: 'i128' }),
     );
+    const txHash = await withRetry(() => this.buildAndSubmit(op));
+    return { txHash, creator: params.creator, amount: params.amount };
   }
 
-  /* ===============================
-     HANDLE TX RESPONSE
-  ================================ */
-
   /**
-   * Validates a send response and waits for on-chain confirmation.
-   *
-   * @param result - Response from server.sendTransaction().
-   * @returns Resolved TipResult with txHash and ledger.
-   * @throws If the transaction was not accepted as PENDING.
+   * Withdraw the full escrowed balance for a creator.
+   * @param creator - Stellar address of the creator.
+   * @returns WithdrawResult with transaction hash, creator, and withdrawn amount.
+   * @throws TransactionFailedError if the transaction fails.
+   * @example
+   * const result = await sdk.withdraw('G...');
    */
-  private async handleTxResponse(
-    result: SorobanRpc.Api.SendTransactionResponse
-  ): Promise<TipResult> {
-    if (result.status === 'ERROR') {
-      throw new Error(
-        `Transaction rejected by network: ${
-          result.errorResult?.toXDR('base64') ?? 'unknown error'
-        }`
-      );
-    }
-
-    if (result.status !== 'PENDING') {
-      throw new Error(`Unexpected transaction status: ${result.status}`);
-    }
-
-    const finalTx = await this.waitForConfirmation(result.hash);
-
-    return {
-      success: true,
-      txHash: result.hash,
-      ledger: (finalTx as any).ledger ?? 0,
-    };
+  async withdraw(creator: string): Promise<WithdrawResult> {
+    const balanceBefore = await this.getBalance(creator);
+    const op = this.contract.call('withdraw', nativeToScVal(creator, { type: 'address' }));
+    const txHash = await withRetry(() => this.buildAndSubmit(op));
+    return { txHash, creator, amount: balanceBefore };
   }
 
-  /* ===============================
-     SEND TIP
-  ================================ */
-
   /**
-   * Sends a tip from a tipper to a creator.
-   *
-   * Builds the transaction, simulates it to populate resource fees and
-   * auth entries, signs via Freighter, then submits and awaits confirmation.
-   *
-   * @param params - Tip parameters (creator, tipper, amount, optional memo).
-   * @returns TipResult with txHash and ledger.
-   * @throws If the address is invalid, simulation fails, or signing is rejected.
+   * Get the total historical tips received by a creator.
+   * @param creator - Stellar address of the creator.
+   * @returns Total tips as bigint.
+   * @throws ContractNotInitializedError if the contract has no data for this creator.
+   * @example
+   * const total = await sdk.getTotalTips('G...');
    */
-  async sendTip(params: SendTipParams): Promise<TipResult> {
-    if (!params.creator.startsWith('G')) {
-      throw new Error(
-        'Invalid creator address — must be a Stellar public key (G…)'
+  async getTotalTips(creator: string): Promise<bigint> {
+    return withRetry(async () => {
+      const result = await this.server.simulateTransaction(
+        await this.buildReadTx(
+          this.contract.call('get_total_tips', nativeToScVal(creator, { type: 'address' })),
+        ),
       );
-    }
-    if (!params.tipper.startsWith('G')) {
-      throw new Error(
-        'Invalid tipper address — must be a Stellar public key (G…)'
-      );
-    }
-
-    return retry(async () => {
-      const account = await this.server.getAccount(params.tipper);
-
-      const tx = new TransactionBuilder(account, {
-        fee: BASE_FEE,
-        networkPassphrase: this.networkPassphrase,
-      })
-        .addOperation(
-          this.contract.call(
-            'send_tip',
-            nativeToScVal(params.creator, { type: 'address' }),
-            nativeToScVal(params.amount, { type: 'i128' }),
-            nativeToScVal(params.tipper, { type: 'address' }),
-            nativeToScVal(params.memo || '', { type: 'string' })
-          )
-        )
-        .setTimeout(30)
-        .build();
-
-      // Simulate to populate auth entries and resource fee
-      const simulation = await this.server.simulateTransaction(tx);
-
-      if (!SorobanRpc.Api.isSimulationSuccess(simulation)) {
-        throw new Error(
-          `sendTip simulation failed: ${
-            (simulation as SorobanRpc.Api.SimulateTransactionErrorResponse)
-              .error
-          }`
-        );
+      if (SorobanRpc.Api.isSimulationError(result)) {
+        throw new ContractNotInitializedError(result.error);
       }
-
-      const assembledTx = SorobanRpc.assembleTransaction(
-        tx,
-        simulation
-      ).build();
-
-      const signedXdr = await this.signWithFreighter(assembledTx.toXDR());
-
-      const signedTx = TransactionBuilder.fromXDR(
-        signedXdr,
-        this.networkPassphrase
-      );
-
-      const result = await this.server.sendTransaction(signedTx);
-
-      return this.handleTxResponse(result);
+      return BigInt(scValToNative((result as SorobanRpc.Api.SimulateTransactionSuccessResponse).result!.retval) as string);
     });
   }
 
-  /* ===============================
-     GET BALANCE
-  ================================ */
-
   /**
-   * Returns the current tip balance for a creator account, in stroops.
-   *
-   * @param creator - Stellar public key (G…) of the creator.
-   * @returns Balance in stroops as a bigint.
-   * @throws If simulation fails or the return value cannot be decoded.
+   * Get the withdrawable (escrowed) balance for a creator.
+   * Alias that reads CreatorBalance via get_total_tips simulation pattern.
+   * @param creator - Stellar address of the creator.
+   * @returns Withdrawable balance as bigint.
+   * @throws ContractNotInitializedError if the contract has no data for this creator.
+   * @example
+   * const balance = await sdk.getBalance('G...');
    */
   async getBalance(creator: string): Promise<bigint> {
-    const account = await this.server.getAccount(creator);
+    // The contract exposes withdrawable balance through ledger storage;
+    // we simulate a withdraw call to read CreatorBalance without submitting.
+    return withRetry(async () => {
+      const result = await this.server.simulateTransaction(
+        await this.buildReadTx(
+          this.contract.call('withdraw', nativeToScVal(creator, { type: 'address' })),
+        ),
+      );
+      if (SorobanRpc.Api.isSimulationError(result)) {
+        throw new ContractNotInitializedError(result.error);
+      }
+      return BigInt(scValToNative((result as SorobanRpc.Api.SimulateTransactionSuccessResponse).result!.retval) as string);
+    });
+  }
 
+  /**
+   * Fetch on-chain tip events for a creator.
+   * @param creator - Stellar address of the creator.
+   * @param limit - Maximum number of events to return (default 20).
+   * @returns Array of TipEvent objects.
+   * @example
+   * const events = await sdk.getTipEvents('G...', 10);
+   */
+  async getTipEvents(creator: string, limit = 20): Promise<TipEvent[]> {
+    return withRetry(async () => {
+      const { events } = await this.server.getEvents({
+        filters: [{ type: 'contract', contractIds: [this.config.contractId], topics: [['tip', creator]] }],
+        limit,
+      });
+      return events.map(parseTipEvent);
+    });
+  }
+
+  // ── Private ────────────────────────────────────────────────────────────────
+
+  private async buildReadTx(operation: xdr.Operation): Promise<ReturnType<TransactionBuilder['build']>> {
+    const account = await this.server.getAccount(
+      this.keypair?.publicKey() ?? this.config.contractId,
+    );
+    return new TransactionBuilder(account, {
+      fee: BASE_FEE,
+      networkPassphrase: this.networkPassphrase,
+    })
+      .addOperation(operation)
+      .setTimeout(TX_TIMEOUT_SEC)
+      .build();
+  }
+
+  private async buildAndSubmit(operation: xdr.Operation): Promise<string> {
+    if (!this.keypair) throw new TransactionFailedError('Call connect() with a Keypair before submitting transactions');
+
+    const account = await this.server.getAccount(this.keypair.publicKey());
     const tx = new TransactionBuilder(account, {
       fee: BASE_FEE,
       networkPassphrase: this.networkPassphrase,
     })
-      .addOperation(
-        this.contract.call(
-          'get_balance',
-          nativeToScVal(creator, { type: 'address' })
-        )
-      )
-      .setTimeout(30)
+      .addOperation(operation)
+      .setTimeout(TX_TIMEOUT_SEC)
       .build();
 
-    const simulation = await this.server.simulateTransaction(tx);
-
-    if (!SorobanRpc.Api.isSimulationSuccess(simulation)) {
-      throw new Error(
-        `getBalance simulation failed: ${
-          (simulation as SorobanRpc.Api.SimulateTransactionErrorResponse).error
-        }`
-      );
+    const simResult = await this.server.simulateTransaction(tx);
+    if (SorobanRpc.Api.isSimulationError(simResult)) {
+      throw new TransactionFailedError(`Simulation failed: ${simResult.error}`);
     }
 
-    const retval = simulation.result?.retval;
-    if (!retval) {
-      throw new Error('getBalance returned no value from contract.');
+    const preparedTx = SorobanRpc.assembleTransaction(tx, simResult).build();
+    preparedTx.sign(this.keypair);
+
+    const sendResult = await this.server.sendTransaction(preparedTx);
+    if (sendResult.status === 'ERROR') {
+      throw new TransactionFailedError(`Submit failed: ${sendResult.errorResult?.toXDR('base64')}`, sendResult.hash);
     }
 
-    return scValToNative(retval) as bigint;
-  }
-
-  /* ===============================
-     WITHDRAW
-  ================================ */
-
-  /**
-   * Withdraws a specified amount from the contract to the creator's account.
-   *
-   * @param creator - Stellar public key (G…) of the creator.
-   * @param amount - Amount in stroops to withdraw.
-   * @returns WithdrawResult with txHash and ledger.
-   * @throws If simulation fails, signing is rejected, or the transaction fails.
-   */
-  async withdraw(creator: string, amount: bigint): Promise<WithdrawResult> {
-    if (!creator.startsWith('G')) {
-      throw new Error(
-        'Invalid creator address — must be a Stellar public key (G…)'
-      );
+    // Poll for confirmation.
+    let getResult = await this.server.getTransaction(sendResult.hash);
+    for (let i = 0; i < 10 && getResult.status === SorobanRpc.Api.GetTransactionStatus.NOT_FOUND; i++) {
+      await new Promise((r) => setTimeout(r, 1000));
+      getResult = await this.server.getTransaction(sendResult.hash);
+    }
+    if (getResult.status === SorobanRpc.Api.GetTransactionStatus.FAILED) {
+      throw new TransactionFailedError('Transaction failed on-chain', sendResult.hash);
     }
 
-    return retry(async () => {
-      const account = await this.server.getAccount(creator);
-
-      const tx = new TransactionBuilder(account, {
-        fee: BASE_FEE,
-        networkPassphrase: this.networkPassphrase,
-      })
-        .addOperation(
-          this.contract.call(
-            'withdraw',
-            nativeToScVal(creator, { type: 'address' }),
-            nativeToScVal(amount, { type: 'i128' })
-          )
-        )
-        .setTimeout(30)
-        .build();
-
-      // Simulate to populate auth entries and resource fee
-      const simulation = await this.server.simulateTransaction(tx);
-
-      if (!SorobanRpc.Api.isSimulationSuccess(simulation)) {
-        throw new Error(
-          `withdraw simulation failed: ${
-            (simulation as SorobanRpc.Api.SimulateTransactionErrorResponse)
-              .error
-          }`
-        );
-      }
-
-      const assembledTx = SorobanRpc.assembleTransaction(
-        tx,
-        simulation
-      ).build();
-
-      const signedXdr = await this.signWithFreighter(assembledTx.toXDR());
-
-      const signedTx = TransactionBuilder.fromXDR(
-        signedXdr,
-        this.networkPassphrase
-      );
-
-      const result = await this.server.sendTransaction(signedTx);
-
-      return this.handleTxResponse(result) as unknown as WithdrawResult;
-    });
+    return sendResult.hash;
   }
 }

--- a/sdk/typescript/src/errors.ts
+++ b/sdk/typescript/src/errors.ts
@@ -2,22 +2,37 @@ export class TipJarError extends Error {
   constructor(message: string) {
     super(message);
     this.name = 'TipJarError';
-    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
+
+export class InvalidAmountError extends TipJarError {
+  constructor(message = 'Amount must be a positive bigint') {
+    super(message);
+    this.name = 'InvalidAmountError';
+  }
+}
+
+export class TransactionFailedError extends TipJarError {
+  txHash?: string;
+  constructor(message: string, txHash?: string) {
+    super(message);
+    this.name = 'TransactionFailedError';
+    this.txHash = txHash;
+  }
+}
+
+export class ContractNotInitializedError extends TipJarError {
+  constructor(message = 'Contract has not been initialized') {
+    super(message);
+    this.name = 'ContractNotInitializedError';
   }
 }
 
 export class NetworkError extends TipJarError {
-  constructor(message: string) {
+  retries: number;
+  constructor(message: string, retries: number) {
     super(message);
     this.name = 'NetworkError';
-    Object.setPrototypeOf(this, new.target.prototype);
-  }
-}
-
-export class TransactionError extends TipJarError {
-  constructor(message: string) {
-    super(message);
-    this.name = 'TransactionError';
-    Object.setPrototypeOf(this, new.target.prototype);
+    this.retries = retries;
   }
 }

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -1,0 +1,4 @@
+export * from './types';
+export * from './errors';
+export * from './utils';
+export * from './TipJarContract';

--- a/sdk/typescript/src/types.ts
+++ b/sdk/typescript/src/types.ts
@@ -1,4 +1,13 @@
-export interface SendTipParams {
+export type Network = 'testnet' | 'mainnet';
+
+export interface SdkConfig {
+  contractId: string;
+  network: Network;
+  /** Override the default RPC URL for the chosen network. */
+  rpcUrl?: string;
+}
+
+export interface TipParams {
   creator: string;
   amount: bigint;
   tipper: string;
@@ -6,13 +15,22 @@ export interface SendTipParams {
 }
 
 export interface TipResult {
-  success: boolean;
   txHash: string;
-  ledger: number;
+  creator: string;
+  amount: bigint;
 }
 
 export interface WithdrawResult {
-  success: boolean;
   txHash: string;
-  ledger: number;
+  creator: string;
+  amount: bigint;
+}
+
+export interface TipEvent {
+  sender: string;
+  amount: bigint;
+}
+
+export interface WithdrawEvent {
+  amount: bigint;
 }

--- a/sdk/typescript/src/utils.ts
+++ b/sdk/typescript/src/utils.ts
@@ -1,35 +1,47 @@
-export const getRpcUrl = (network: 'testnet' | 'mainnet'): string => {
-  return network === 'testnet'
-    ? 'https://soroban-testnet.stellar.org'
-    : 'https://soroban.stellar.org';
+import { SorobanRpc, scValToNative } from '@stellar/stellar-sdk';
+import { Network, TipEvent, WithdrawEvent } from './types';
+import { NetworkError } from './errors';
+
+export const NETWORK_CONFIG: Record<Network, { rpcUrl: string; networkPassphrase: string }> = {
+  testnet: {
+    rpcUrl: 'https://soroban-testnet.stellar.org',
+    networkPassphrase: 'Test SDF Network ; September 2015',
+  },
+  mainnet: {
+    rpcUrl: 'https://soroban.stellar.org',
+    networkPassphrase: 'Public Global Stellar Network ; September 2015',
+  },
 };
 
-/**
- * Retries an async function with exponential backoff.
- *
- * @param fn - Async function to retry.
- * @param retries - Number of retry attempts (default 3).
- * @param delay - Base delay in ms, doubles on each retry (default 1000).
- * @returns Resolved value from fn.
- * @throws Last encountered error after all retries are exhausted.
- */
-export async function retry<T>(
-  fn: () => Promise<T>,
-  retries = 3,
-  delay = 1000
-): Promise<T> {
-  let lastError: unknown;
+export function parseTipEvent(event: SorobanRpc.Api.EventResponse): TipEvent {
+  const [senderVal, amountVal] = event.value as unknown[];
+  return {
+    sender: scValToNative(senderVal as Parameters<typeof scValToNative>[0]) as string,
+    amount: BigInt(scValToNative(amountVal as Parameters<typeof scValToNative>[0]) as string),
+  };
+}
 
-  for (let attempt = 0; attempt <= retries; attempt++) {
+export function parseWithdrawEvent(event: SorobanRpc.Api.EventResponse): WithdrawEvent {
+  const [amountVal] = event.value as unknown[];
+  return {
+    amount: BigInt(scValToNative(amountVal as Parameters<typeof scValToNative>[0]) as string),
+  };
+}
+
+export async function withRetry<T>(fn: () => Promise<T>, retries = 3): Promise<T> {
+  let attempt = 0;
+  while (true) {
     try {
       return await fn();
-    } catch (error) {
-      lastError = error;
-      if (attempt < retries) {
-        await new Promise((r) => setTimeout(r, delay * 2 ** attempt));
+    } catch (err) {
+      attempt++;
+      if (attempt > retries) {
+        throw new NetworkError(
+          `Operation failed after ${retries} retries: ${(err as Error).message}`,
+          retries,
+        );
       }
+      await new Promise((r) => setTimeout(r, 2 ** attempt * 200));
     }
   }
-
-  throw lastError;
 }

--- a/sdk/typescript/tsconfig.json
+++ b/sdk/typescript/tsconfig.json
@@ -1,18 +1,13 @@
 {
   "compilerOptions": {
     "target": "ES2020",
-    "module": "CommonJS",
-    "lib": ["ES2020", "DOM"],
-    "declaration": true,
-    "declarationMap": true,
+    "module": "commonjs",
+    "lib": ["ES2020"],
     "outDir": "dist",
-    "rootDir": "src",
+    "declaration": true,
     "strict": true,
     "esModuleInterop": true,
-    "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true,
-    "resolveJsonModule": true
+    "skipLibCheck": true
   },
-  "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "include": ["src"]
 }


### PR DESCRIPTION
 Closes #87                                                                                                                                              
                                                                                                                                                          
  ## Changes                                                                                                                                              
                                                                                                                                                          
  - `sdk/typescript/src/types.ts` — Network, SdkConfig, TipParams, TipResult, WithdrawResult, TipEvent, WithdrawEvent                                     
  - `sdk/typescript/src/errors.ts` — TipJarError, InvalidAmountError, TransactionFailedError, ContractNotInitializedError, NetworkError                   
  - `sdk/typescript/src/utils.ts` — NETWORK_CONFIG, parseTipEvent, parseWithdrawEvent, withRetry (3 retries, exponential backoff)                         
  - `sdk/typescript/src/TipJarContract.ts` — main SDK class with sendTip, withdraw, getTotalTips, getBalance, getTipEvents                                
  - `sdk/typescript/src/index.ts` — barrel re-export                                                                                                      
  - `sdk/typescript/package.json` — @tipjar/sdk v0.1.0, @stellar/stellar-sdk ^12.0.0                                                                      
  - `sdk/typescript/tsconfig.json` — strict ES2020, outputs to dist/                                                                                      
  - `sdk/typescript/README.md` — installation, quick start, full API reference, error handling, network config                                            
                                                                                                                                                          
  ## Notes                                                                                                                                                
                                                                                                                                                          
  - All token amounts use `bigint` — no `number`                                                                                                          
  - All async methods use `withRetry` for automatic retries on transient RPC failures                                                                     
  - `getBalance` reads withdrawable balance via simulation (no tx submitted)                                                                              
  - `buildAndSubmit` polls for on-chain confirmation before resolving                                                                                     
  - No secrets or private keys hardcoded anywhere                                                                                                         
                                                                                                                                                          
  ────────────────────────────────────────────