### PR TITLE
feat(integration): integrate contract SDK for JavaScript/TypeScript

### DIFF
--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -18,5 +18,10 @@
     "jest": "^29.0.0",
     "ts-jest": "^29.0.0",
     "typescript": "^5.0.0"
+  },
+  "jest": {
+    "preset": "ts-jest",
+    "testEnvironment": "node",
+    "testMatch": ["**/__tests__/**/*.test.ts"]
   }
 }

--- a/sdk/typescript/src/__tests__/sdk.test.ts
+++ b/sdk/typescript/src/__tests__/sdk.test.ts
@@ -1,0 +1,161 @@
+import { TipJarContract } from '../src/TipJarContract';
+import { InvalidAmountError, TransactionFailedError, ContractNotInitializedError } from '../src/errors';
+import { parseTipEvent, parseWithdrawEvent } from '../src/events';
+import { NETWORK_CONFIG } from '../src/utils';
+import { TipJarSDK } from '../src/client';
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+jest.mock('@stellar/stellar-sdk', () => {
+  const mockSimulateOk = {
+    result: { retval: 'MOCK_RETVAL' },
+  };
+  const mockSendResult = { status: 'PENDING', hash: 'mock-hash' };
+  const mockGetTxResult = { status: 'SUCCESS' };
+
+  return {
+    Contract: jest.fn().mockImplementation(() => ({
+      call: jest.fn().mockReturnValue('mock-operation'),
+    })),
+    Keypair: {
+      fromSecret: jest.fn().mockReturnValue({
+        publicKey: () => 'GPUBLIC',
+        sign: jest.fn(),
+      }),
+    },
+    Networks: { TESTNET: 'Test SDF Network ; September 2015' },
+    SorobanRpc: {
+      Server: jest.fn().mockImplementation(() => ({
+        getAccount: jest.fn().mockResolvedValue({ id: 'GPUBLIC', sequence: '1' }),
+        simulateTransaction: jest.fn().mockResolvedValue(mockSimulateOk),
+        sendTransaction: jest.fn().mockResolvedValue(mockSendResult),
+        getTransaction: jest.fn().mockResolvedValue(mockGetTxResult),
+        getEvents: jest.fn().mockResolvedValue({ events: [] }),
+      })),
+      Api: {
+        isSimulationError: jest.fn().mockReturnValue(false),
+        GetTransactionStatus: { NOT_FOUND: 'NOT_FOUND', FAILED: 'FAILED', SUCCESS: 'SUCCESS' },
+      },
+      assembleTransaction: jest.fn().mockReturnValue({
+        build: jest.fn().mockReturnValue({ sign: jest.fn(), toXDR: jest.fn() }),
+      }),
+    },
+    TransactionBuilder: jest.fn().mockImplementation(() => ({
+      addOperation: jest.fn().mockReturnThis(),
+      setTimeout: jest.fn().mockReturnThis(),
+      build: jest.fn().mockReturnValue({ sign: jest.fn(), toXDR: jest.fn() }),
+    })),
+    nativeToScVal: jest.fn((v) => v),
+    scValToNative: jest.fn((v) => v),
+    xdr: {},
+  };
+});
+
+// ── Network config ────────────────────────────────────────────────────────────
+
+describe('NETWORK_CONFIG', () => {
+  it('has testnet and mainnet entries', () => {
+    expect(NETWORK_CONFIG.testnet.rpcUrl).toBe('https://soroban-testnet.stellar.org');
+    expect(NETWORK_CONFIG.mainnet.rpcUrl).toBe('https://soroban.stellar.org');
+  });
+
+  it('has correct network passphrases', () => {
+    expect(NETWORK_CONFIG.testnet.networkPassphrase).toContain('Test SDF');
+    expect(NETWORK_CONFIG.mainnet.networkPassphrase).toContain('Public Global');
+  });
+});
+
+// ── Error classes ─────────────────────────────────────────────────────────────
+
+describe('Error classes', () => {
+  it('InvalidAmountError has correct name', () => {
+    const e = new InvalidAmountError();
+    expect(e.name).toBe('InvalidAmountError');
+    expect(e).toBeInstanceOf(Error);
+  });
+
+  it('TransactionFailedError stores txHash', () => {
+    const e = new TransactionFailedError('failed', 'abc123');
+    expect(e.txHash).toBe('abc123');
+    expect(e.name).toBe('TransactionFailedError');
+  });
+
+  it('ContractNotInitializedError has correct name', () => {
+    const e = new ContractNotInitializedError();
+    expect(e.name).toBe('ContractNotInitializedError');
+  });
+});
+
+// ── Event parsing ─────────────────────────────────────────────────────────────
+
+describe('parseTipEvent', () => {
+  it('extracts sender and amount', () => {
+    const mockEvent = { value: ['GSENDER', '500'] } as any;
+    const result = parseTipEvent(mockEvent);
+    expect(result.sender).toBe('GSENDER');
+    expect(result.amount).toBe(500n);
+  });
+});
+
+describe('parseWithdrawEvent', () => {
+  it('extracts amount', () => {
+    const mockEvent = { value: ['250'] } as any;
+    const result = parseWithdrawEvent(mockEvent);
+    expect(result.amount).toBe(250n);
+  });
+});
+
+// ── TipJarContract ────────────────────────────────────────────────────────────
+
+describe('TipJarContract', () => {
+  const config = { contractId: 'CCONTRACT', network: 'testnet' as const };
+  const { Keypair } = jest.requireMock('@stellar/stellar-sdk');
+  const keypair = Keypair.fromSecret('SECRET');
+
+  it('throws InvalidAmountError for zero amount', async () => {
+    const sdk = new TipJarContract(config);
+    sdk.connect(keypair);
+    await expect(
+      sdk.sendTip({ tipper: 'GA', creator: 'GB', amount: 0n }),
+    ).rejects.toBeInstanceOf(InvalidAmountError);
+  });
+
+  it('throws InvalidAmountError for negative amount', async () => {
+    const sdk = new TipJarContract(config);
+    sdk.connect(keypair);
+    await expect(
+      sdk.sendTip({ tipper: 'GA', creator: 'GB', amount: -1n }),
+    ).rejects.toBeInstanceOf(InvalidAmountError);
+  });
+
+  it('sendTip returns txHash on success', async () => {
+    const sdk = new TipJarContract(config);
+    sdk.connect(keypair);
+    const result = await sdk.sendTip({ tipper: 'GA', creator: 'GB', amount: 100n });
+    expect(result.txHash).toBe('mock-hash');
+    expect(result.creator).toBe('GB');
+    expect(result.amount).toBe(100n);
+  });
+
+  it('getTipEvents returns empty array when no events', async () => {
+    const sdk = new TipJarContract(config);
+    sdk.connect(keypair);
+    const events = await sdk.getTipEvents('GB');
+    expect(events).toEqual([]);
+  });
+
+  it('throws TransactionFailedError without keypair', async () => {
+    const sdk = new TipJarContract(config);
+    await expect(
+      sdk.sendTip({ tipper: 'GA', creator: 'GB', amount: 100n }),
+    ).rejects.toBeInstanceOf(TransactionFailedError);
+  });
+});
+
+// ── TipJarSDK alias ───────────────────────────────────────────────────────────
+
+describe('TipJarSDK alias', () => {
+  it('is the same class as TipJarContract', () => {
+    expect(TipJarSDK).toBe(TipJarContract);
+  });
+});

--- a/sdk/typescript/src/client.ts
+++ b/sdk/typescript/src/client.ts
@@ -1,0 +1,3 @@
+/** Re-export TipJarContract as TipJarSDK for issue #64 naming convention. */
+export { TipJarContract as TipJarSDK } from './TipJarContract';
+export type { SdkConfig as TipJarSDKConfig } from './types';

--- a/sdk/typescript/src/events.ts
+++ b/sdk/typescript/src/events.ts
@@ -1,0 +1,26 @@
+/** Event parsing utilities for TipJar on-chain events. */
+import { SorobanRpc, scValToNative } from '@stellar/stellar-sdk';
+import { TipEvent, WithdrawEvent } from './types';
+
+/**
+ * Parse a raw Soroban event into a typed TipEvent.
+ * Expects event value to be `(sender: Address, amount: i128)`.
+ */
+export function parseTipEvent(event: SorobanRpc.Api.EventResponse): TipEvent {
+  const [senderVal, amountVal] = event.value as unknown[];
+  return {
+    sender: scValToNative(senderVal as Parameters<typeof scValToNative>[0]) as string,
+    amount: BigInt(scValToNative(amountVal as Parameters<typeof scValToNative>[0]) as string),
+  };
+}
+
+/**
+ * Parse a raw Soroban event into a typed WithdrawEvent.
+ * Expects event value to be `(amount: i128)`.
+ */
+export function parseWithdrawEvent(event: SorobanRpc.Api.EventResponse): WithdrawEvent {
+  const [amountVal] = event.value as unknown[];
+  return {
+    amount: BigInt(scValToNative(amountVal as Parameters<typeof scValToNative>[0]) as string),
+  };
+}

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -1,4 +1,6 @@
 export * from './types';
 export * from './errors';
+export * from './events';
 export * from './utils';
 export * from './TipJarContract';
+export * from './client';

--- a/sdk/typescript/src/utils.ts
+++ b/sdk/typescript/src/utils.ts
@@ -1,6 +1,7 @@
-import { SorobanRpc, scValToNative } from '@stellar/stellar-sdk';
-import { Network, TipEvent, WithdrawEvent } from './types';
+import { Network } from './types';
 import { NetworkError } from './errors';
+
+export { parseTipEvent, parseWithdrawEvent } from './events';
 
 export const NETWORK_CONFIG: Record<Network, { rpcUrl: string; networkPassphrase: string }> = {
   testnet: {
@@ -12,21 +13,6 @@ export const NETWORK_CONFIG: Record<Network, { rpcUrl: string; networkPassphrase
     networkPassphrase: 'Public Global Stellar Network ; September 2015',
   },
 };
-
-export function parseTipEvent(event: SorobanRpc.Api.EventResponse): TipEvent {
-  const [senderVal, amountVal] = event.value as unknown[];
-  return {
-    sender: scValToNative(senderVal as Parameters<typeof scValToNative>[0]) as string,
-    amount: BigInt(scValToNative(amountVal as Parameters<typeof scValToNative>[0]) as string),
-  };
-}
-
-export function parseWithdrawEvent(event: SorobanRpc.Api.EventResponse): WithdrawEvent {
-  const [amountVal] = event.value as unknown[];
-  return {
-    amount: BigInt(scValToNative(amountVal as Parameters<typeof scValToNative>[0]) as string),
-  };
-}
 
 export async function withRetry<T>(fn: () => Promise<T>, retries = 3): Promise<T> {
   let attempt = 0;


### PR DESCRIPTION
## Summary

Completes the TypeScript SDK for frontend contract interaction (issue #64).

The core SDK (`TipJarContract`) already existed. This PR adds the missing pieces required by the issue spec and wires everything together cleanly.

## Changes

| File | What changed |
|------|-------------|
| `src/client.ts` | New — exports `TipJarSDK` as an alias for `TipJarContract` |
| `src/events.ts` | New — dedicated event parsing module (`parseTipEvent`, `parseWithdrawEvent`) |
| `src/utils.ts` | Refactored — re-exports from `events.ts` instead of duplicating the parsers |
| `src/index.ts` | Updated — exports `client` and `events` modules |
| `src/__tests__/sdk.test.ts` | New — Jest tests (see below) |
| `package.json` | Added `jest` config block |

## Tests

- Network config has correct RPC URLs and passphrases for testnet/mainnet
- `InvalidAmountError`, `TransactionFailedError`, `ContractNotInitializedError` have correct names and fields
- `parseTipEvent` extracts sender and amount
- `parseWithdrawEvent` extracts amount
- `sendTip` throws `InvalidAmountError` for zero/negative amounts
- `sendTip` returns `txHash` on success
- `getTipEvents` returns empty array when no events
- `sendTip` throws `TransactionFailedError` when no keypair connected
- `TipJarSDK` is the same class as `TipJarContract`

Closes #64