### PR TITLE
feat(integration): integrate contract gas optimization tools

### DIFF
--- a/.github/workflows/gas-check.yml
+++ b/.github/workflows/gas-check.yml
@@ -1,0 +1,47 @@
+name: Gas Regression Check
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  gas-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+
+      # Run benchmarks on the current branch and save the report
+      - name: Profile gas (current)
+        run: bash scripts/profile-gas.sh
+
+      - name: Upload gas report
+        uses: actions/upload-artifact@v4
+        with:
+          name: gas-report-${{ github.sha }}
+          path: gas-report.json
+
+      # On PRs, fetch the baseline from main and compare
+      - name: Download baseline report (main)
+        if: github.event_name == 'pull_request'
+        uses: dawidd6/action-download-artifact@v3
+        with:
+          workflow: gas-check.yml
+          branch: main
+          name: gas-report-${{ github.event.pull_request.base.sha }}
+          path: baseline/
+        continue-on-error: true   # no baseline on first run
+
+      - name: Compare against baseline
+        if: github.event_name == 'pull_request' && hashFiles('baseline/gas-report.json') != ''
+        run: |
+          bash scripts/profile-gas.sh --baseline baseline/gas-report.json

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["contracts/tipjar", "indexer", "sdk", "tests/integration"]
+members = ["contracts/tipjar", "indexer", "sdk", "tests/integration", "tools/gas"]
 resolver = "2"
 
 [workspace.package]

--- a/scripts/profile-gas.sh
+++ b/scripts/profile-gas.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# profile-gas.sh — Run gas profiling and optionally compare against a baseline.
+#
+# Usage:
+#   bash scripts/profile-gas.sh                        # profile only
+#   bash scripts/profile-gas.sh --baseline gas-report.json  # profile + compare
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+REPORT="$REPO_ROOT/gas-report.json"
+BASELINE=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --baseline) BASELINE="$2"; shift 2 ;;
+    *) echo "Unknown argument: $1"; exit 1 ;;
+  esac
+done
+
+echo "=== TipJar Gas Profiler ==="
+echo ""
+
+# 1. Run profiler (produces gas-report.json)
+PROFILER_ARGS=(--output "$REPORT")
+[[ -n "$BASELINE" ]] && PROFILER_ARGS+=(--baseline "$BASELINE")
+
+cargo run --manifest-path "$REPO_ROOT/Cargo.toml" \
+  -p tipjar-gas-tools --bin gas-profiler -- "${PROFILER_ARGS[@]}"
+
+echo ""
+
+# 2. Run analyzer (prints recommendations)
+cargo run --manifest-path "$REPO_ROOT/Cargo.toml" \
+  -p tipjar-gas-tools --bin gas-analyzer -- --report "$REPORT"

--- a/tools/gas/Cargo.toml
+++ b/tools/gas/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "tipjar-gas-tools"
+version = "0.1.0"
+edition = "2021"
+description = "Gas profiling and optimization tools for TipJar"
+
+[[bin]]
+name = "gas-profiler"
+path = "gas_profiler.rs"
+
+[[bin]]
+name = "gas-analyzer"
+path = "gas_analyzer.rs"
+
+[dependencies]
+anyhow = "1"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+chrono = { version = "0.4", features = ["serde"] }
+clap = { version = "4", features = ["derive"] }

--- a/tools/gas/gas_analyzer.rs
+++ b/tools/gas/gas_analyzer.rs
@@ -1,0 +1,126 @@
+//! gas-analyzer — reads a gas-report.json produced by gas-profiler and prints
+//! optimization recommendations based on CPU instruction counts.
+//!
+//! Usage:
+//!   cargo run --bin gas-analyzer -- --report gas-report.json
+
+use anyhow::{Context, Result};
+use clap::Parser;
+use serde::{Deserialize, Serialize};
+
+#[derive(Parser)]
+struct Cli {
+    /// Path to the gas report JSON (produced by gas-profiler)
+    #[arg(long, default_value = "gas-report.json")]
+    report: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct BenchResult {
+    function: String,
+    cpu_instructions: u64,
+    memory_bytes: u64,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct GasReport {
+    timestamp: String,
+    results: Vec<BenchResult>,
+}
+
+/// Thresholds (CPU instructions) above which we emit recommendations.
+const WARN_CPU: u64 = 500_000;
+const CRITICAL_CPU: u64 = 2_000_000;
+
+fn main() -> Result<()> {
+    let cli = Cli::parse();
+    let json = std::fs::read_to_string(&cli.report)
+        .with_context(|| format!("cannot read {}", cli.report))?;
+    let report: GasReport = serde_json::from_str(&json)?;
+
+    println!("=== TipJar Gas Analysis Report ===");
+    println!("Generated: {}\n", report.timestamp);
+    println!("{:<45} {:>18} {:>14}", "Function", "CPU Instructions", "Memory Bytes");
+    println!("{}", "-".repeat(80));
+
+    let mut any_recommendation = false;
+    for r in &report.results {
+        let marker = if r.cpu_instructions >= CRITICAL_CPU {
+            "🔴"
+        } else if r.cpu_instructions >= WARN_CPU {
+            "🟡"
+        } else {
+            "🟢"
+        };
+        println!(
+            "{} {:<43} {:>18} {:>14}",
+            marker, r.function, r.cpu_instructions, r.memory_bytes
+        );
+    }
+
+    println!("\n=== Optimization Recommendations ===\n");
+    for r in &report.results {
+        let recs = recommendations(&r.function, r.cpu_instructions, r.memory_bytes);
+        if !recs.is_empty() {
+            any_recommendation = true;
+            println!("▶ {}:", r.function);
+            for rec in recs {
+                println!("  • {rec}");
+            }
+        }
+    }
+
+    if !any_recommendation {
+        println!("✅ All functions are within acceptable gas limits. No recommendations.");
+    }
+
+    Ok(())
+}
+
+fn recommendations(function: &str, cpu: u64, mem: u64) -> Vec<String> {
+    let mut recs = Vec::new();
+
+    if cpu >= CRITICAL_CPU {
+        recs.push(format!(
+            "CPU usage ({cpu}) is critically high. Consider splitting this operation \
+             or caching intermediate results in persistent storage."
+        ));
+    } else if cpu >= WARN_CPU {
+        recs.push(format!(
+            "CPU usage ({cpu}) exceeds the warning threshold ({WARN_CPU}). \
+             Profile hot loops and reduce redundant storage reads."
+        ));
+    }
+
+    if mem >= 50_000 {
+        recs.push(format!(
+            "Memory usage ({mem} bytes) is high. Avoid allocating large Vecs/Maps \
+             inside the contract; prefer streaming or pagination."
+        ));
+    }
+
+    // Function-specific hints
+    if function.contains("batch") && cpu >= WARN_CPU {
+        recs.push(
+            "Batch operations: ensure per-item storage writes are minimised. \
+             Consider accumulating deltas and writing once per creator."
+                .to_string(),
+        );
+    }
+    if function.contains("leaderboard") || function.contains("top_tippers") {
+        recs.push(
+            "Leaderboard queries iterate over all participants. \
+             Maintain a pre-sorted index in storage to avoid O(n) scans."
+                .to_string(),
+        );
+    }
+    if function.contains("locked") && cpu >= WARN_CPU {
+        recs.push(
+            "Locked tip operations: use a counter-keyed map instead of scanning \
+             all locked tips to find eligible withdrawals."
+                .to_string(),
+        );
+    }
+
+    recs
+}

--- a/tools/gas/gas_profiler.rs
+++ b/tools/gas/gas_profiler.rs
@@ -1,0 +1,123 @@
+//! gas-profiler — runs `cargo test -- bench --nocapture` and captures the
+//! `[BENCH]` lines emitted by `tests/gas/benchmarks.rs`, then writes a
+//! structured JSON report to `gas-report.json` (or a path given via --output).
+//!
+//! Usage:
+//!   cargo run --bin gas-profiler -- [--output path/to/report.json]
+
+use anyhow::{bail, Context, Result};
+use chrono::Utc;
+use clap::Parser;
+use serde::{Deserialize, Serialize};
+use std::process::Command;
+
+#[derive(Parser)]
+struct Cli {
+    /// Where to write the JSON report (default: gas-report.json)
+    #[arg(long, default_value = "gas-report.json")]
+    output: String,
+
+    /// Optional baseline report to compare against
+    #[arg(long)]
+    baseline: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct BenchResult {
+    pub function: String,
+    pub cpu_instructions: u64,
+    pub memory_bytes: u64,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct GasReport {
+    pub timestamp: String,
+    pub results: Vec<BenchResult>,
+}
+
+fn main() -> Result<()> {
+    let cli = Cli::parse();
+
+    eprintln!("Running gas benchmarks...");
+    let output = Command::new("cargo")
+        .args(["test", "-p", "tipjar", "--", "bench", "--nocapture"])
+        .output()
+        .context("failed to run cargo test")?;
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let combined = format!("{stdout}{stderr}");
+
+    let results = parse_bench_output(&combined);
+    if results.is_empty() {
+        bail!("No [BENCH] lines found in test output. Make sure the benchmarks compile and run.");
+    }
+
+    let report = GasReport {
+        timestamp: Utc::now().to_rfc3339(),
+        results,
+    };
+
+    let json = serde_json::to_string_pretty(&report)?;
+    std::fs::write(&cli.output, &json).context("failed to write report")?;
+    eprintln!("Report written to {}", cli.output);
+
+    // Optional baseline comparison
+    if let Some(baseline_path) = cli.baseline {
+        let baseline_json = std::fs::read_to_string(&baseline_path)
+            .context("failed to read baseline report")?;
+        let baseline: GasReport = serde_json::from_str(&baseline_json)?;
+        compare(&baseline, &report);
+    }
+
+    Ok(())
+}
+
+/// Parse lines like: `[BENCH] tip (cold storage): cpu=12345 instructions, mem=6789 bytes`
+fn parse_bench_output(output: &str) -> Vec<BenchResult> {
+    let mut results = Vec::new();
+    for line in output.lines() {
+        let Some(rest) = line.strip_prefix("[BENCH] ") else { continue };
+        // Split on ": cpu="
+        let Some((func, metrics)) = rest.split_once(": cpu=") else { continue };
+        // metrics = "12345 instructions, mem=6789 bytes"
+        let Some((cpu_part, mem_part)) = metrics.split_once(" instructions, mem=") else { continue };
+        let Some((mem_val, _)) = mem_part.split_once(" bytes") else { continue };
+        let Ok(cpu) = cpu_part.trim().parse::<u64>() else { continue };
+        let Ok(mem) = mem_val.trim().parse::<u64>() else { continue };
+        results.push(BenchResult {
+            function: func.trim().to_string(),
+            cpu_instructions: cpu,
+            memory_bytes: mem,
+        });
+    }
+    results
+}
+
+fn compare(baseline: &GasReport, current: &GasReport) {
+    println!("\n=== Gas Regression Report ===");
+    println!("{:<40} {:>15} {:>15} {:>10}", "Function", "Baseline CPU", "Current CPU", "Delta %");
+    println!("{}", "-".repeat(85));
+
+    let mut regression = false;
+    for cur in &current.results {
+        if let Some(base) = baseline.results.iter().find(|b| b.function == cur.function) {
+            let delta_pct = (cur.cpu_instructions as f64 - base.cpu_instructions as f64)
+                / base.cpu_instructions as f64
+                * 100.0;
+            let flag = if delta_pct > 10.0 { " ⚠ REGRESSION" } else { "" };
+            if delta_pct > 10.0 { regression = true; }
+            println!(
+                "{:<40} {:>15} {:>15} {:>9.1}%{}",
+                cur.function, base.cpu_instructions, cur.cpu_instructions, delta_pct, flag
+            );
+        }
+    }
+
+    if regression {
+        eprintln!("\n❌ Gas regression detected (>10% increase). Failing.");
+        std::process::exit(1);
+    } else {
+        println!("\n✅ No gas regressions detected.");
+    }
+}


### PR DESCRIPTION
## Summary

Adds gas profiling, analysis, and CI regression detection for the TipJar contract (issue #65).

The existing benchmark suite in `tests/gas/benchmarks.rs` already emits `[BENCH]` lines with CPU instruction and memory byte counts. This PR builds the tooling layer on top of it.

## New files

| File | Purpose |
|------|---------|
| `tools/gas/gas_profiler.rs` | Binary: runs `cargo test -- bench --nocapture`, parses `[BENCH]` output, writes `gas-report.json`. Accepts `--baseline` to diff and fail on >10% CPU regression |
| `tools/gas/gas_analyzer.rs` | Binary: reads `gas-report.json`, prints colour-coded table + per-function optimization recommendations |
| `tools/gas/Cargo.toml` | `tipjar-gas-tools` crate with two `[[bin]]` targets |
| `scripts/profile-gas.sh` | Runs profiler then analyzer in one command; `--baseline` flag for regression comparison |
| `.github/workflows/gas-check.yml` | CI: profiles on every PR/push, uploads report as artifact, compares against main baseline on PRs |

## How it works

```
scripts/profile-gas.sh
  └─ gas-profiler  →  cargo test -- bench --nocapture
                   →  parse [BENCH] lines
                   →  write gas-report.json
                   →  (optional) diff vs baseline, exit 1 if >10% regression
  └─ gas-analyzer  →  read gas-report.json
                   →  print table (🟢/🟡/🔴 by threshold)
                   →  print optimization recommendations
```

## CI regression detection

On every PR the workflow:
1. Profiles the current branch → uploads `gas-report-{sha}.json`
2. Downloads the baseline artifact from the last main-branch run
3. Runs `gas-profiler --baseline` — exits non-zero if any function's CPU count increased by more than 10%

First run (no baseline yet) passes gracefully via `continue-on-error: true`.

## Optimization recommendations emitted by gas-analyzer

- CPU > 500k instructions → warning with storage-read reduction advice
- CPU > 2M instructions → critical with operation-splitting advice  
- Memory > 50k bytes → pagination/streaming advice
- Batch functions → per-item write minimisation hint
- Leaderboard queries → pre-sorted index hint
- Locked tip operations → counter-keyed map hint

Closes #65