### PR TITLE
feat(fees): add dynamic fee adjustment algorithm (#57)

### DIFF
--- a/contracts/tipjar/src/fees/adjustment.rs
+++ b/contracts/tipjar/src/fees/adjustment.rs
@@ -1,0 +1,31 @@
+use soroban_sdk::Env;
+use super::calculator::{BASE_FEE_BPS, MIN_FEE_BPS, MAX_FEE_BPS};
+use crate::DataKey;
+
+/// Network congestion level supplied by the caller or an oracle.
+///
+/// - `Low`    → fee discount applied  (×0.5)
+/// - `Normal` → base fee unchanged    (×1.0)
+/// - `High`   → fee surcharge applied (×1.5)
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum CongestionLevel {
+    Low,
+    Normal,
+    High,
+}
+
+/// Returns the dynamically adjusted fee in basis points, clamped to
+/// `[MIN_FEE_BPS, MAX_FEE_BPS]`.
+///
+/// The result is also persisted in contract storage so it can be queried
+/// transparently via `get_current_fee_bps`.
+pub fn adjusted_fee_bps(env: &Env, congestion: CongestionLevel) -> u32 {
+    let raw = match congestion {
+        CongestionLevel::Low    => BASE_FEE_BPS / 2,
+        CongestionLevel::Normal => BASE_FEE_BPS,
+        CongestionLevel::High   => BASE_FEE_BPS * 3 / 2,
+    };
+    let clamped = raw.clamp(MIN_FEE_BPS, MAX_FEE_BPS);
+    env.storage().instance().set(&DataKey::CurrentFeeBps, &clamped);
+    clamped
+}

--- a/contracts/tipjar/src/fees/calculator.rs
+++ b/contracts/tipjar/src/fees/calculator.rs
@@ -1,0 +1,18 @@
+use soroban_sdk::Env;
+use super::adjustment::CongestionLevel;
+
+/// Base fee in basis points (1% = 100 bps).
+pub const BASE_FEE_BPS: u32 = 100;
+/// Minimum fee in basis points (0.1%).
+pub const MIN_FEE_BPS: u32 = 10;
+/// Maximum fee in basis points (5%).
+pub const MAX_FEE_BPS: u32 = 500;
+
+/// Computes the fee amount for a given tip `amount` and `congestion_level`.
+///
+/// Returns `(fee_amount, fee_bps)` where `fee_bps` is the effective rate used.
+pub fn compute_fee(env: &Env, amount: i128, congestion: CongestionLevel) -> (i128, u32) {
+    let fee_bps = super::adjustment::adjusted_fee_bps(env, congestion);
+    let fee = amount * fee_bps as i128 / 10_000;
+    (fee, fee_bps)
+}

--- a/contracts/tipjar/src/fees/mod.rs
+++ b/contracts/tipjar/src/fees/mod.rs
@@ -1,0 +1,5 @@
+pub mod adjustment;
+pub mod calculator;
+
+pub use adjustment::CongestionLevel;
+pub use calculator::compute_fee;

--- a/contracts/tipjar/src/lib.rs
+++ b/contracts/tipjar/src/lib.rs
@@ -31,6 +31,9 @@ pub mod staking;
 // Conditional tip execution
 pub mod conditions;
 
+// Dynamic fee adjustment
+pub mod fees;
+
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct TipWithMessage {
@@ -198,6 +201,8 @@ pub enum DataKey {
     TipCounter,
     /// Off-chain oracle approval flag keyed by condition ID.
     OffchainCondition(BytesN<32>),
+    /// Most-recently computed dynamic fee in basis points.
+    CurrentFeeBps,
 }
 
 #[contracterror]
@@ -351,5 +356,71 @@ impl TipJarContract {
         );
 
         true
+    }
+
+    /// Returns the last dynamically computed fee in basis points.
+    ///
+    /// Defaults to the base fee (100 bps = 1%) if no tip has been processed yet.
+    pub fn get_current_fee_bps(env: Env) -> u32 {
+        env.storage()
+            .instance()
+            .get(&DataKey::CurrentFeeBps)
+            .unwrap_or(fees::calculator::BASE_FEE_BPS)
+    }
+
+    /// Like `tip`, but deducts a dynamic platform fee before crediting the creator.
+    ///
+    /// `congestion` is a `u32` mapped as: 0 = Low, 1 = Normal, 2 = High.
+    /// The fee is retained in the contract; the creator receives `amount - fee`.
+    ///
+    /// Emits `("tip", creator)` with data `(sender, net_amount)` and
+    /// `("fee", creator)` with data `(fee_amount, fee_bps)`.
+    pub fn tip_with_fee(
+        env: Env,
+        sender: Address,
+        creator: Address,
+        token: Address,
+        amount: i128,
+        congestion: u32,
+    ) {
+        sender.require_auth();
+        if amount <= 0 {
+            panic_with_error!(&env, TipJarError::InvalidAmount);
+        }
+        let whitelisted: bool = env
+            .storage()
+            .instance()
+            .get(&DataKey::TokenWhitelist(token.clone()))
+            .unwrap_or(false);
+        if !whitelisted {
+            panic_with_error!(&env, TipJarError::TokenNotWhitelisted);
+        }
+
+        let level = match congestion {
+            0 => fees::CongestionLevel::Low,
+            2 => fees::CongestionLevel::High,
+            _ => fees::CongestionLevel::Normal,
+        };
+        let (fee, fee_bps) = fees::compute_fee(&env, amount, level);
+        let net = amount - fee;
+
+        token::Client::new(&env, &token).transfer(
+            &sender,
+            &env.current_contract_address(),
+            &amount,
+        );
+
+        let bal_key = DataKey::CreatorBalance(creator.clone(), token.clone());
+        let new_bal: i128 = env.storage().instance().get(&bal_key).unwrap_or(0) + net;
+        env.storage().instance().set(&bal_key, &new_bal);
+
+        let tot_key = DataKey::CreatorTotal(creator.clone(), token.clone());
+        let new_tot: i128 = env.storage().instance().get(&tot_key).unwrap_or(0) + net;
+        env.storage().instance().set(&tot_key, &new_tot);
+
+        env.events()
+            .publish((symbol_short!("tip"), creator.clone()), (sender, net));
+        env.events()
+            .publish((symbol_short!("fee"), creator.clone()), (fee, fee_bps));
     }
 }


### PR DESCRIPTION
## Summary

Closes #57 — implements a dynamic fee adjustment algorithm that automatically adjusts platform fees based on network congestion.

## Changes

### New files
- `contracts/tipjar/src/fees/mod.rs` — module root, re-exports `CongestionLevel` and `compute_fee`
- `contracts/tipjar/src/fees/calculator.rs` — fee constants (`BASE_FEE_BPS=100`, `MIN_FEE_BPS=10`, `MAX_FEE_BPS=500`) and `compute_fee(env, amount, congestion) -> (fee_amount, fee_bps)`
- `contracts/tipjar/src/fees/adjustment.rs` — `CongestionLevel` enum (Low / Normal / High) and `adjusted_fee_bps` which clamps the result and persists it in storage for transparency

### Modified
- `contracts/tipjar/src/lib.rs`
  - Added `DataKey::CurrentFeeBps` storage key
  - Wired in `pub mod fees`
  - Added `get_current_fee_bps()` — returns last computed fee bps (defaults to base 100 bps)
  - Added `tip_with_fee(sender, creator, token, amount, congestion)` — deducts dynamic fee before crediting creator, emits both `("tip", creator)` and `("fee", creator)` events

## Fee Schedule

| Congestion | Multiplier | Effective fee |
|------------|-----------|---------------|
| Low        | ×0.5      | 0.5% (50 bps) |
| Normal     | ×1.0      | 1.0% (100 bps)|
| High       | ×1.5      | 1.5% (150 bps)|

All values are clamped to `[MIN_FEE_BPS=10, MAX_FEE_BPS=500]`.

## Transparency
The last computed fee is stored under `DataKey::CurrentFeeBps` and readable on-chain via `get_current_fee_bps()`. Both fee amount and rate are emitted as events on every `tip_with_fee` call.