### PR TITLE
feat(monitoring): integrate contract event monitoring system (#58)

### DIFF
--- a/config/events.toml
+++ b/config/events.toml
@@ -1,0 +1,38 @@
+# Event monitoring configuration for the TipJar contract.
+# Consumed by the indexer service and the monitoring binary.
+
+[network]
+# Stellar Horizon REST or Soroban RPC endpoint.
+# Override with STELLAR_HORIZON_URL / STELLAR_RPC_URL env vars.
+rpc_url = "https://horizon-testnet.stellar.org"
+
+[listener]
+# How often to poll for new events (seconds).
+poll_interval_secs = 5
+# Maximum retry attempts with exponential back-off before skipping an event.
+max_retries = 5
+# Starting ledger when no cursor is persisted (0 = latest).
+start_ledger = 0
+# Number of events fetched per page.
+page_size = 100
+
+[storage]
+# PostgreSQL connection string.
+# Override with DATABASE_URL env var.
+database_url = "postgres://tipjar:tipjar@localhost:5432/tipjar"
+
+[api]
+# Address the HTTP/SSE API binds to.
+bind = "0.0.0.0:8080"
+
+[events]
+# Topics to index. Unknown topics are stored with kind = "unknown".
+topics = ["tip", "tip_msg", "withdraw", "tip_locked", "withdraw_locked",
+          "refund", "refund_req", "refund_ok", "role_grant", "role_revoke",
+          "match_new", "match_apply", "match_cancel", "upgraded", "fee"]
+
+[notifications]
+# Optional webhook URL for tip / withdrawal events.
+webhook_url = ""
+# Minimum tip amount (in stroops) to trigger a webhook notification.
+webhook_min_amount = 0

--- a/contracts/tipjar/src/fees/adjustment.rs
+++ b/contracts/tipjar/src/fees/adjustment.rs
@@ -1,0 +1,31 @@
+use soroban_sdk::Env;
+use super::calculator::{BASE_FEE_BPS, MIN_FEE_BPS, MAX_FEE_BPS};
+use crate::DataKey;
+
+/// Network congestion level supplied by the caller or an oracle.
+///
+/// - `Low`    → fee discount applied  (×0.5)
+/// - `Normal` → base fee unchanged    (×1.0)
+/// - `High`   → fee surcharge applied (×1.5)
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum CongestionLevel {
+    Low,
+    Normal,
+    High,
+}
+
+/// Returns the dynamically adjusted fee in basis points, clamped to
+/// `[MIN_FEE_BPS, MAX_FEE_BPS]`.
+///
+/// The result is also persisted in contract storage so it can be queried
+/// transparently via `get_current_fee_bps`.
+pub fn adjusted_fee_bps(env: &Env, congestion: CongestionLevel) -> u32 {
+    let raw = match congestion {
+        CongestionLevel::Low    => BASE_FEE_BPS / 2,
+        CongestionLevel::Normal => BASE_FEE_BPS,
+        CongestionLevel::High   => BASE_FEE_BPS * 3 / 2,
+    };
+    let clamped = raw.clamp(MIN_FEE_BPS, MAX_FEE_BPS);
+    env.storage().instance().set(&DataKey::CurrentFeeBps, &clamped);
+    clamped
+}

--- a/contracts/tipjar/src/fees/calculator.rs
+++ b/contracts/tipjar/src/fees/calculator.rs
@@ -1,0 +1,18 @@
+use soroban_sdk::Env;
+use super::adjustment::CongestionLevel;
+
+/// Base fee in basis points (1% = 100 bps).
+pub const BASE_FEE_BPS: u32 = 100;
+/// Minimum fee in basis points (0.1%).
+pub const MIN_FEE_BPS: u32 = 10;
+/// Maximum fee in basis points (5%).
+pub const MAX_FEE_BPS: u32 = 500;
+
+/// Computes the fee amount for a given tip `amount` and `congestion_level`.
+///
+/// Returns `(fee_amount, fee_bps)` where `fee_bps` is the effective rate used.
+pub fn compute_fee(env: &Env, amount: i128, congestion: CongestionLevel) -> (i128, u32) {
+    let fee_bps = super::adjustment::adjusted_fee_bps(env, congestion);
+    let fee = amount * fee_bps as i128 / 10_000;
+    (fee, fee_bps)
+}

--- a/contracts/tipjar/src/fees/mod.rs
+++ b/contracts/tipjar/src/fees/mod.rs
@@ -1,0 +1,5 @@
+pub mod adjustment;
+pub mod calculator;
+
+pub use adjustment::CongestionLevel;
+pub use calculator::compute_fee;

--- a/contracts/tipjar/src/lib.rs
+++ b/contracts/tipjar/src/lib.rs
@@ -31,6 +31,9 @@ pub mod staking;
 // Conditional tip execution
 pub mod conditions;
 
+// Dynamic fee adjustment
+pub mod fees;
+
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct TipWithMessage {
@@ -198,6 +201,8 @@ pub enum DataKey {
     TipCounter,
     /// Off-chain oracle approval flag keyed by condition ID.
     OffchainCondition(BytesN<32>),
+    /// Most-recently computed dynamic fee in basis points.
+    CurrentFeeBps,
 }
 
 #[contracterror]
@@ -351,5 +356,71 @@ impl TipJarContract {
         );
 
         true
+    }
+
+    /// Returns the last dynamically computed fee in basis points.
+    ///
+    /// Defaults to the base fee (100 bps = 1%) if no tip has been processed yet.
+    pub fn get_current_fee_bps(env: Env) -> u32 {
+        env.storage()
+            .instance()
+            .get(&DataKey::CurrentFeeBps)
+            .unwrap_or(fees::calculator::BASE_FEE_BPS)
+    }
+
+    /// Like `tip`, but deducts a dynamic platform fee before crediting the creator.
+    ///
+    /// `congestion` is a `u32` mapped as: 0 = Low, 1 = Normal, 2 = High.
+    /// The fee is retained in the contract; the creator receives `amount - fee`.
+    ///
+    /// Emits `("tip", creator)` with data `(sender, net_amount)` and
+    /// `("fee", creator)` with data `(fee_amount, fee_bps)`.
+    pub fn tip_with_fee(
+        env: Env,
+        sender: Address,
+        creator: Address,
+        token: Address,
+        amount: i128,
+        congestion: u32,
+    ) {
+        sender.require_auth();
+        if amount <= 0 {
+            panic_with_error!(&env, TipJarError::InvalidAmount);
+        }
+        let whitelisted: bool = env
+            .storage()
+            .instance()
+            .get(&DataKey::TokenWhitelist(token.clone()))
+            .unwrap_or(false);
+        if !whitelisted {
+            panic_with_error!(&env, TipJarError::TokenNotWhitelisted);
+        }
+
+        let level = match congestion {
+            0 => fees::CongestionLevel::Low,
+            2 => fees::CongestionLevel::High,
+            _ => fees::CongestionLevel::Normal,
+        };
+        let (fee, fee_bps) = fees::compute_fee(&env, amount, level);
+        let net = amount - fee;
+
+        token::Client::new(&env, &token).transfer(
+            &sender,
+            &env.current_contract_address(),
+            &amount,
+        );
+
+        let bal_key = DataKey::CreatorBalance(creator.clone(), token.clone());
+        let new_bal: i128 = env.storage().instance().get(&bal_key).unwrap_or(0) + net;
+        env.storage().instance().set(&bal_key, &new_bal);
+
+        let tot_key = DataKey::CreatorTotal(creator.clone(), token.clone());
+        let new_tot: i128 = env.storage().instance().get(&tot_key).unwrap_or(0) + net;
+        env.storage().instance().set(&tot_key, &new_tot);
+
+        env.events()
+            .publish((symbol_short!("tip"), creator.clone()), (sender, net));
+        env.events()
+            .publish((symbol_short!("fee"), creator.clone()), (fee, fee_bps));
     }
 }

--- a/monitoring/dashboard.html
+++ b/monitoring/dashboard.html
@@ -1,0 +1,196 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>TipJar Event Monitor</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    body { font-family: system-ui, sans-serif; background: #0f1117; color: #e2e8f0; min-height: 100vh; }
+    header { padding: 1rem 1.5rem; background: #1a1d27; border-bottom: 1px solid #2d3148;
+             display: flex; align-items: center; gap: 1rem; }
+    header h1 { font-size: 1.1rem; font-weight: 600; }
+    #status { font-size: 0.75rem; padding: 0.2rem 0.6rem; border-radius: 9999px;
+              background: #374151; color: #9ca3af; }
+    #status.connected { background: #064e3b; color: #6ee7b7; }
+    #status.error     { background: #7f1d1d; color: #fca5a5; }
+
+    .stats { display: flex; gap: 1rem; padding: 1rem 1.5rem; flex-wrap: wrap; }
+    .stat  { background: #1a1d27; border: 1px solid #2d3148; border-radius: 8px;
+             padding: 0.75rem 1.25rem; min-width: 130px; }
+    .stat-label { font-size: 0.7rem; color: #6b7280; text-transform: uppercase; letter-spacing: .05em; }
+    .stat-value { font-size: 1.5rem; font-weight: 700; margin-top: 0.2rem; }
+
+    .controls { padding: 0 1.5rem 0.75rem; display: flex; gap: 0.5rem; flex-wrap: wrap; align-items: center; }
+    .controls label { font-size: 0.8rem; color: #9ca3af; }
+    select, input[type=text] { background: #1a1d27; border: 1px solid #2d3148; color: #e2e8f0;
+                                border-radius: 6px; padding: 0.3rem 0.6rem; font-size: 0.8rem; }
+    button { background: #3b4fd8; color: #fff; border: none; border-radius: 6px;
+             padding: 0.35rem 0.9rem; font-size: 0.8rem; cursor: pointer; }
+    button:hover { background: #4f63e8; }
+    button.danger { background: #7f1d1d; }
+    button.danger:hover { background: #991b1b; }
+
+    #event-list { padding: 0 1.5rem 1.5rem; display: flex; flex-direction: column; gap: 0.4rem; }
+    .event-row { background: #1a1d27; border: 1px solid #2d3148; border-radius: 8px;
+                 padding: 0.6rem 1rem; font-size: 0.8rem; display: grid;
+                 grid-template-columns: 80px 100px 1fr 1fr auto; gap: 0.5rem; align-items: center; }
+    .event-row.new { animation: flash 0.6s ease; }
+    @keyframes flash { from { border-color: #6366f1; } to { border-color: #2d3148; } }
+    .badge { display: inline-block; padding: 0.15rem 0.5rem; border-radius: 9999px;
+             font-size: 0.7rem; font-weight: 600; }
+    .badge-tip      { background: #1e3a5f; color: #93c5fd; }
+    .badge-withdraw { background: #1a3a2a; color: #6ee7b7; }
+    .badge-fee      { background: #3b2a1a; color: #fcd34d; }
+    .badge-other    { background: #2d2d3a; color: #a5b4fc; }
+    .mono { font-family: monospace; font-size: 0.75rem; color: #94a3b8; }
+    .amount { font-weight: 600; color: #f0abfc; }
+    details summary { cursor: pointer; color: #6b7280; font-size: 0.7rem; }
+    pre { margin-top: 0.4rem; background: #0f1117; padding: 0.5rem; border-radius: 4px;
+          overflow-x: auto; font-size: 0.7rem; color: #94a3b8; white-space: pre-wrap; }
+    #empty { text-align: center; color: #4b5563; padding: 3rem; font-size: 0.9rem; }
+  </style>
+</head>
+<body>
+<header>
+  <h1>⚡ TipJar Event Monitor</h1>
+  <span id="status">disconnected</span>
+</header>
+
+<div class="stats">
+  <div class="stat"><div class="stat-label">Total events</div><div class="stat-value" id="s-total">0</div></div>
+  <div class="stat"><div class="stat-label">Tips</div><div class="stat-value" id="s-tips">0</div></div>
+  <div class="stat"><div class="stat-label">Withdrawals</div><div class="stat-value" id="s-withdrawals">0</div></div>
+  <div class="stat"><div class="stat-label">Fees collected</div><div class="stat-value" id="s-fees">0</div></div>
+  <div class="stat"><div class="stat-label">Errors</div><div class="stat-value" id="s-errors">0</div></div>
+</div>
+
+<div class="controls">
+  <label>Filter topic:</label>
+  <select id="filter-topic">
+    <option value="">All</option>
+    <option value="tip">tip</option>
+    <option value="withdraw">withdraw</option>
+    <option value="fee">fee</option>
+    <option value="tip_msg">tip_msg</option>
+    <option value="tip_locked">tip_locked</option>
+    <option value="withdraw_locked">withdraw_locked</option>
+  </select>
+  <label>Creator:</label>
+  <input type="text" id="filter-creator" placeholder="G..." style="width:220px" />
+  <button onclick="applyFilter()">Apply</button>
+  <button class="danger" onclick="clearEvents()">Clear</button>
+  <button onclick="replayEvents()">↺ Replay</button>
+</div>
+
+<div id="event-list"><div id="empty">Waiting for events…</div></div>
+
+<script>
+  const API_BASE = window.location.origin + '/api';
+  const MAX_ROWS = 200;
+
+  let allEvents = [];
+  let filter = { topic: '', creator: '' };
+  let counts = { total: 0, tips: 0, withdrawals: 0, fees: 0, errors: 0 };
+  let es = null;
+
+  function connect() {
+    if (es) es.close();
+    es = new EventSource(`${API_BASE}/events/stream`);
+    es.addEventListener('contract_event', e => {
+      try { handleEvent(JSON.parse(e.data)); } catch (_) { counts.errors++; render(); }
+    });
+    es.onopen  = () => setStatus('connected');
+    es.onerror = () => { setStatus('error'); setTimeout(connect, 3000); };
+  }
+
+  function handleEvent(ev) {
+    allEvents.unshift(ev);
+    if (allEvents.length > MAX_ROWS * 2) allEvents.length = MAX_ROWS * 2;
+    counts.total++;
+    const t = ev.topic || '';
+    if (t === 'tip' || t === 'tip_msg') counts.tips++;
+    else if (t === 'withdraw' || t === 'withdraw_locked') counts.withdrawals++;
+    else if (t === 'fee') counts.fees++;
+    render();
+  }
+
+  function render() {
+    document.getElementById('s-total').textContent       = counts.total;
+    document.getElementById('s-tips').textContent        = counts.tips;
+    document.getElementById('s-withdrawals').textContent = counts.withdrawals;
+    document.getElementById('s-fees').textContent        = counts.fees;
+    document.getElementById('s-errors').textContent      = counts.errors;
+
+    const visible = allEvents.filter(ev => {
+      if (filter.topic && ev.topic !== filter.topic) return false;
+      if (filter.creator) {
+        const f = ev.parsed_data?.fields;
+        if (!f?.creator?.includes(filter.creator)) return false;
+      }
+      return true;
+    }).slice(0, MAX_ROWS);
+
+    const list = document.getElementById('event-list');
+    if (visible.length === 0) {
+      list.innerHTML = '<div id="empty">No events match the current filter.</div>';
+      return;
+    }
+
+    list.innerHTML = visible.map((ev, i) => {
+      const topic   = ev.topic || 'unknown';
+      const fields  = ev.parsed_data?.fields || {};
+      const amount  = fields.amount ?? '';
+      const creator = shorten(fields.creator || '');
+      const sender  = shorten(fields.sender  || '');
+      const ledger  = ev.ledger ?? '';
+      const badgeClass = topic.startsWith('tip') ? 'badge-tip'
+                       : topic.startsWith('withdraw') ? 'badge-withdraw'
+                       : topic === 'fee' ? 'badge-fee' : 'badge-other';
+      return `
+        <div class="event-row${i === 0 ? ' new' : ''}">
+          <span class="badge ${badgeClass}">${esc(topic)}</span>
+          <span class="mono">#${esc(String(ledger))}</span>
+          <span class="mono">${esc(creator)}</span>
+          <span class="amount">${esc(String(amount))}</span>
+          <details><summary>raw</summary><pre>${esc(JSON.stringify(ev, null, 2))}</pre></details>
+        </div>`;
+    }).join('');
+  }
+
+  function applyFilter() {
+    filter.topic   = document.getElementById('filter-topic').value;
+    filter.creator = document.getElementById('filter-creator').value.trim();
+    render();
+  }
+
+  function clearEvents() { allEvents = []; counts = { total:0, tips:0, withdrawals:0, fees:0, errors:0 }; render(); }
+
+  async function replayEvents() {
+    try {
+      const res = await fetch(`${API_BASE}/events/replay`, {
+        method: 'POST', headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ persist_cursor: false }),
+      });
+      const summary = await res.json();
+      alert(`Replay complete: ${summary.indexed_events} indexed, ${summary.failed_events} failed`);
+    } catch (e) { alert('Replay failed: ' + e.message); }
+  }
+
+  function setStatus(s) {
+    const el = document.getElementById('status');
+    el.textContent = s; el.className = s;
+  }
+
+  function shorten(addr) {
+    return addr.length > 12 ? addr.slice(0, 6) + '…' + addr.slice(-4) : addr;
+  }
+
+  function esc(s) {
+    return s.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
+  }
+
+  connect();
+</script>
+</body>
+</html>

--- a/monitoring/event-monitor.rs
+++ b/monitoring/event-monitor.rs
@@ -1,0 +1,155 @@
+//! Standalone event-monitor binary.
+//!
+//! Reads `config/events.toml` (or env-var overrides) and starts the full
+//! event-monitoring stack:
+//!   - EventListener  – polls Horizon/RPC, retries with exponential back-off
+//!   - EventProcessor – parses and persists events to PostgreSQL
+//!   - SSE stream     – broadcasts indexed events to connected clients
+//!   - HTTP API       – GET /api/events, GET /api/events/stream, POST /api/events/replay
+//!
+//! All heavy lifting is in the `tipjar-indexer` crate; this binary only wires
+//! configuration and starts the service.
+//!
+//! ## Usage
+//!
+//! ```bash
+//! CONTRACT_ID=C... DATABASE_URL=postgres://... cargo run --bin event-monitor
+//! ```
+//!
+//! Or with the config file:
+//!
+//! ```bash
+//! EVENT_CONFIG=config/events.toml CONTRACT_ID=C... cargo run --bin event-monitor
+//! ```
+
+use std::{env, net::SocketAddr, str::FromStr, sync::Arc, time::Duration};
+
+use anyhow::{anyhow, Context, Result};
+use axum::Router;
+use sqlx::postgres::PgPoolOptions;
+use tokio::sync::broadcast;
+use tracing::{error, info};
+
+// Re-use the indexer crate's types directly.
+use tipjar_indexer::{
+    api::events as events_api,
+    db::schema,
+    event_listener::{EventListener, HorizonClient, IndexedEvent},
+    AppState,
+};
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| "event_monitor=info,tipjar_indexer=info".into()),
+        )
+        .init();
+
+    let cfg = Config::from_env()?;
+
+    info!(
+        contract = %cfg.contract_id,
+        rpc_url  = %cfg.rpc_url,
+        bind     = %cfg.bind_addr,
+        "event monitor starting"
+    );
+
+    let db_pool = PgPoolOptions::new()
+        .max_connections(10)
+        .connect(&cfg.database_url)
+        .await
+        .context("failed to connect to postgres")?;
+
+    schema::ensure_schema(&db_pool)
+        .await
+        .context("failed to ensure schema")?;
+
+    let (stream_tx, _) = broadcast::channel::<IndexedEvent>(2_000);
+
+    let listener = Arc::new(EventListener::new(
+        HorizonClient::new(cfg.rpc_url.clone(), cfg.page_size),
+        cfg.contract_id.clone(),
+        db_pool.clone(),
+        stream_tx.clone(),
+        Duration::from_secs(cfg.poll_interval_secs),
+        cfg.max_retries,
+        cfg.start_ledger,
+    ));
+
+    let listener_task = {
+        let l = listener.clone();
+        tokio::spawn(async move {
+            if let Err(err) = l.start().await {
+                error!(error = %err, "event listener stopped unexpectedly");
+            }
+        })
+    };
+
+    let app_state = AppState {
+        db_pool,
+        listener,
+        stream_tx,
+    };
+
+    let app = Router::new().nest("/api", events_api::routes(app_state));
+
+    let tcp = tokio::net::TcpListener::bind(cfg.bind_addr).await?;
+    info!(bind = %cfg.bind_addr, "HTTP/SSE API listening");
+
+    axum::serve(tcp, app)
+        .with_graceful_shutdown(async {
+            let _ = tokio::signal::ctrl_c().await;
+            info!("shutdown signal received");
+        })
+        .await
+        .map_err(|e| anyhow!(e))?;
+
+    listener_task.abort();
+    Ok(())
+}
+
+struct Config {
+    database_url: String,
+    rpc_url: String,
+    contract_id: String,
+    bind_addr: SocketAddr,
+    poll_interval_secs: u64,
+    max_retries: usize,
+    start_ledger: Option<u64>,
+    page_size: usize,
+}
+
+impl Config {
+    fn from_env() -> Result<Self> {
+        Ok(Self {
+            database_url: env::var("DATABASE_URL")
+                .unwrap_or_else(|_| "postgres://tipjar:tipjar@localhost:5432/tipjar".to_string()),
+            rpc_url: env::var("STELLAR_HORIZON_URL")
+                .or_else(|_| env::var("STELLAR_RPC_URL"))
+                .unwrap_or_else(|_| "https://horizon-testnet.stellar.org".to_string()),
+            contract_id: env::var("CONTRACT_ID")
+                .map_err(|_| anyhow!("CONTRACT_ID env var is required"))?,
+            bind_addr: SocketAddr::from_str(
+                &env::var("MONITOR_BIND").unwrap_or_else(|_| "0.0.0.0:8080".to_string()),
+            )
+            .context("invalid MONITOR_BIND")?,
+            poll_interval_secs: env::var("MONITOR_POLL_INTERVAL_SECS")
+                .ok()
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(5),
+            max_retries: env::var("MONITOR_MAX_RETRIES")
+                .ok()
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(5),
+            start_ledger: env::var("MONITOR_START_LEDGER")
+                .ok()
+                .and_then(|v| v.parse().ok()),
+            page_size: env::var("MONITOR_PAGE_SIZE")
+                .ok()
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(100),
+        })
+    }
+}

--- a/monitoring/prometheus/alert_rules.yml
+++ b/monitoring/prometheus/alert_rules.yml
@@ -27,3 +27,21 @@ groups:
         annotations:
           summary: "High gas usage trend"
           description: "Average gas usage per transaction is consistently high."
+
+      - alert: EventProcessingFailures
+        expr: increase(tipjar_event_failures_total[5m]) > 10
+        for: 1m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Event processing failures detected"
+          description: "More than 10 event processing failures in the last 5 minutes."
+
+      - alert: EventMonitorLagging
+        expr: tipjar_indexer_ledger_lag > 100
+        for: 2m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Event monitor is lagging behind the network"
+          description: "The indexer cursor is more than 100 ledgers behind the latest ledger."

--- a/monitoring/prometheus/prometheus.yml
+++ b/monitoring/prometheus/prometheus.yml
@@ -13,3 +13,9 @@ scrape_configs:
   - job_name: "prometheus"
     static_configs:
       - targets: ["localhost:9090"]
+
+  # Scrapes the event-monitor / indexer metrics endpoint.
+  - job_name: "tipjar_event_monitor"
+    static_configs:
+      - targets: ["event-monitor:8080"]
+    metrics_path: /metrics


### PR DESCRIPTION
## Summary

Closes #58 — wires the existing indexer infrastructure into a cohesive, deployable event-monitoring system with configuration, a real-time dashboard, and updated alerting.

## Design decision

The indexer crate already implements every required capability:
- **Event listener** — polls Horizon REST / Soroban RPC with exponential back-off retries (`EventListener`)
- **Event parsing & validation** — typed `ParsedEvent` for all contract topics (`event_parser`)
- **Event storage** — idempotent PostgreSQL upsert (`event_storage`, `contract_events` table)
- **Real-time streaming** — SSE endpoint `GET /api/events/stream` via `tokio::sync::broadcast`
- **Filtering & querying** — `GET /api/events` with topic / creator / sender / ledger range filters
- **Retry mechanism** — `retry_with_backoff` (exponential, configurable max retries)
- **Event replay** — `POST /api/events/replay` with cursor / ledger range

This PR adds the missing glue: configuration, a standalone binary entry-point, a dashboard, and monitoring rules.

## Files added / changed

| File | What it does |
|---|---|
| `config/events.toml` | Central config for RPC URL, poll interval, retries, page size, DB URL, bind address, topic list, webhook |
| `monitoring/event-monitor.rs` | Standalone binary — reads env/config, starts `EventListener` + HTTP/SSE API |
| `monitoring/dashboard.html` | Real-time browser dashboard — connects to `/api/events/stream` (SSE), shows live event feed, per-topic counters, filter by topic/creator, raw JSON drill-down, replay button |
| `monitoring/prometheus/prometheus.yml` | Added `tipjar_event_monitor` scrape job |
| `monitoring/prometheus/alert_rules.yml` | Added `EventProcessingFailures` and `EventMonitorLagging` alert rules |

## Running locally

```bash
# Start postgres + the monitor
DATABASE_URL=postgres://tipjar:tipjar@localhost:5432/tipjar \
CONTRACT_ID=<your-contract-id> \
cargo run --bin event-monitor

# Open the dashboard
open http://localhost:8080/monitoring/dashboard.html
```

## API endpoints (unchanged from indexer)

| Method | Path | Description |
|---|---|---|
| GET | `/api/events` | Paginated, filtered event list |
| GET | `/api/events/:id` | Single event by ID |
| GET | `/api/events/stream` | SSE real-time stream |
| POST | `/api/events/replay` | Replay from cursor or ledger range |