### PR TITLE
feat(contract): add tip message and metadata support

### DIFF
--- a/contracts/tipjar/Cargo.toml
+++ b/contracts/tipjar/Cargo.toml
@@ -31,3 +31,7 @@ path = "benches/gas_benchmarks.rs"
 [[test]]
 name = "quickcheck_properties"
 path = "tests/quickcheck_properties.rs"
+
+[[test]]
+name = "tip_message_tests"
+path = "tests/tip_message_tests.rs"

--- a/contracts/tipjar/src/lib.rs
+++ b/contracts/tipjar/src/lib.rs
@@ -77,6 +77,16 @@ pub struct LockedTip {
     pub unlock_timestamp: u64,
 }
 
+/// Metadata stored on-chain for each tip with an optional message.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TipMetadata {
+    pub sender: Address,
+    pub amount: i128,
+    pub message: Option<String>,
+    pub timestamp: u64,
+}
+
 /// Internal record of a tip for refund tracking.
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -245,6 +255,10 @@ pub enum DataKey {
     Subscription(Address, Address),
     /// Human-readable reason stored when the contract is paused.
     PauseReason,
+    /// TipMetadata keyed by (creator, tip_index).
+    TipHistory(Address, u64),
+    /// Total number of tips with metadata stored for a creator.
+    TipCount(Address),
 }
 
 #[contracterror]
@@ -850,6 +864,158 @@ impl TipJarContract {
         env.storage()
             .persistent()
             .get(&DataKey::Subscription(subscriber, creator))
+    }
+
+    /// Like `tip`, but stores an optional on-chain message and metadata.
+    ///
+    /// `message` is limited to 200 Unicode scalar values (character count, not
+    /// byte count) so that emoji and multi-byte characters are treated fairly.
+    /// Panics with `TipJarError::MessageTooLong` when the limit is exceeded.
+    ///
+    /// Metadata is stored in persistent storage under `TipHistory(creator, index)`
+    /// and the per-creator counter `TipCount(creator)` is incremented.
+    ///
+    /// Emits `("tip_msg", creator)` with data `(sender, amount, message)`.
+    pub fn tip_with_message(
+        env: Env,
+        sender: Address,
+        creator: Address,
+        token: Address,
+        amount: i128,
+        message: Option<String>,
+    ) -> u64 {
+        Self::require_not_paused(&env);
+        sender.require_auth();
+
+        // Validate message length by character count (not bytes) to support emoji.
+        if let Some(ref msg) = message {
+            // Soroban String stores raw bytes; convert to a &str slice for char counting.
+            let bytes = msg.to_string();
+            let char_count = bytes.chars().count();
+            if char_count > 200 {
+                panic_with_error!(&env, TipJarError::MessageTooLong);
+            }
+        }
+
+        if amount <= 0 {
+            panic_with_error!(&env, TipJarError::InvalidAmount);
+        }
+        let whitelisted: bool = env
+            .storage()
+            .instance()
+            .get(&DataKey::TokenWhitelist(token.clone()))
+            .unwrap_or(false);
+        if !whitelisted {
+            panic_with_error!(&env, TipJarError::TokenNotWhitelisted);
+        }
+
+        token::Client::new(&env, &token).transfer(
+            &sender,
+            &env.current_contract_address(),
+            &amount,
+        );
+
+        let fee_bp: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey::FeeBasisPoints)
+            .unwrap_or(0);
+        let fee: i128 = (amount * fee_bp as i128) / 10_000;
+        let creator_amount = amount - fee;
+
+        if fee > 0 {
+            let fee_key = DataKey::PlatformFeeBalance(token.clone());
+            let new_fee_bal: i128 =
+                env.storage().instance().get(&fee_key).unwrap_or(0) + fee;
+            env.storage().instance().set(&fee_key, &new_fee_bal);
+        }
+
+        let bal_key = DataKey::CreatorBalance(creator.clone(), token.clone());
+        let existing_bal: i128 = env
+            .storage()
+            .persistent()
+            .get(&bal_key)
+            .unwrap_or_else(|| env.storage().instance().get(&bal_key).unwrap_or(0));
+        env.storage()
+            .persistent()
+            .set(&bal_key, &(existing_bal + creator_amount));
+
+        let tot_key = DataKey::CreatorTotal(creator.clone(), token.clone());
+        let existing_tot: i128 = env
+            .storage()
+            .persistent()
+            .get(&tot_key)
+            .unwrap_or_else(|| env.storage().instance().get(&tot_key).unwrap_or(0));
+        env.storage()
+            .persistent()
+            .set(&tot_key, &(existing_tot + amount));
+
+        Self::update_leaderboard_stats(&env, &sender, &creator, amount);
+
+        // Store metadata and increment tip count.
+        let count_key = DataKey::TipCount(creator.clone());
+        let tip_index: u64 = env
+            .storage()
+            .persistent()
+            .get(&count_key)
+            .unwrap_or(0u64);
+
+        let timestamp = env.ledger().timestamp();
+        let metadata = TipMetadata {
+            sender: sender.clone(),
+            amount,
+            message: message.clone(),
+            timestamp,
+        };
+        env.storage()
+            .persistent()
+            .set(&DataKey::TipHistory(creator.clone(), tip_index), &metadata);
+        env.storage()
+            .persistent()
+            .set(&count_key, &(tip_index + 1));
+
+        env.events().publish(
+            (symbol_short!("tip_msg"), creator.clone()),
+            (sender, amount, message),
+        );
+
+        tip_index
+    }
+
+    /// Returns the most recent tips (with metadata) for `creator`, newest first.
+    ///
+    /// `limit` is capped at 100 to bound storage reads.
+    pub fn get_tip_history(env: Env, creator: Address, limit: u32) -> Vec<TipMetadata> {
+        let count_key = DataKey::TipCount(creator.clone());
+        let total: u64 = env
+            .storage()
+            .persistent()
+            .get(&count_key)
+            .unwrap_or(0u64);
+
+        let cap = if limit > 100 { 100 } else { limit } as u64;
+        let mut result = Vec::new(&env);
+
+        if total == 0 {
+            return result;
+        }
+
+        // Iterate from newest (total-1) down to oldest, up to `cap` entries.
+        let mut idx = total;
+        let mut fetched: u64 = 0;
+        while idx > 0 && fetched < cap {
+            idx -= 1;
+            if let Some(meta) = env
+                .storage()
+                .persistent()
+                .get::<_, TipMetadata>(&DataKey::TipHistory(creator.clone(), idx))
+            {
+                result.push_back(meta);
+                fetched += 1;
+            }
+        }
+
+        result
     }
 
     /// Splits a single tip among multiple recipients proportionally.

--- a/contracts/tipjar/tests/tip_message_tests.rs
+++ b/contracts/tipjar/tests/tip_message_tests.rs
@@ -1,0 +1,191 @@
+#![cfg(test)]
+
+extern crate std;
+
+use soroban_sdk::{
+    testutils::{Address as _, Ledger},
+    Address, Env, String,
+};
+use tipjar::{DataKey, TipJarContract, TipJarContractClient, TipJarError, TipMetadata};
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+fn setup() -> (Env, TipJarContractClient<'static>, Address, Address, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, TipJarContract);
+    let client = TipJarContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+
+    // Deploy a mock token.
+    let token_id = env.register_stellar_asset_contract(token_admin.clone());
+
+    client.init(&admin, &0u32, &0u64);
+    client.add_token(&admin, &token_id);
+
+    // Fund sender with tokens via the asset contract.
+    let sender = Address::generate(&env);
+    let token_client = soroban_sdk::token::StellarAssetClient::new(&env, &token_id);
+    token_client.mint(&sender, &1_000_000i128);
+
+    (env, client, sender, Address::generate(&env), token_id)
+}
+
+// ── tests ─────────────────────────────────────────────────────────────────────
+
+#[test]
+fn test_tip_with_message_stores_metadata() {
+    let (env, client, sender, creator, token) = setup();
+
+    let msg = String::from_str(&env, "Great content, keep it up!");
+    let tip_index = client.tip_with_message(&sender, &creator, &token, &500i128, &Some(msg.clone()));
+
+    assert_eq!(tip_index, 0);
+
+    let history = client.get_tip_history(&creator, &10u32);
+    assert_eq!(history.len(), 1);
+
+    let meta: TipMetadata = history.get(0).unwrap();
+    assert_eq!(meta.sender, sender);
+    assert_eq!(meta.amount, 500i128);
+    assert_eq!(meta.message, Some(msg));
+}
+
+#[test]
+fn test_tip_without_message_stores_none() {
+    let (env, client, sender, creator, token) = setup();
+
+    client.tip_with_message(&sender, &creator, &token, &100i128, &None);
+
+    let history = client.get_tip_history(&creator, &10u32);
+    assert_eq!(history.len(), 1);
+    assert_eq!(history.get(0).unwrap().message, None);
+}
+
+#[test]
+fn test_message_exactly_200_chars_accepted() {
+    let (env, client, sender, creator, token) = setup();
+
+    // Build a 200-character ASCII string.
+    let s: std::string::String = "a".repeat(200);
+    let msg = String::from_str(&env, &s);
+
+    // Should not panic.
+    client.tip_with_message(&sender, &creator, &token, &100i128, &Some(msg));
+    assert_eq!(client.get_tip_history(&creator, &1u32).len(), 1);
+}
+
+#[test]
+#[should_panic]
+fn test_message_exceeding_200_chars_rejected() {
+    let (env, client, sender, creator, token) = setup();
+
+    let s: std::string::String = "a".repeat(201);
+    let msg = String::from_str(&env, &s);
+
+    client.tip_with_message(&sender, &creator, &token, &100i128, &Some(msg));
+}
+
+#[test]
+fn test_tip_history_returned_newest_first() {
+    let (env, client, sender, creator, token) = setup();
+
+    // Mint more tokens for multiple tips.
+    let token_client = soroban_sdk::token::StellarAssetClient::new(&env, &token);
+    token_client.mint(&sender, &10_000i128);
+
+    for i in 0u32..5 {
+        let msg_str = std::format!("tip {}", i);
+        let msg = String::from_str(&env, &msg_str);
+        // Advance ledger time so timestamps differ.
+        env.ledger().with_mut(|l| l.timestamp += 1);
+        client.tip_with_message(&sender, &creator, &token, &100i128, &Some(msg));
+    }
+
+    let history = client.get_tip_history(&creator, &5u32);
+    assert_eq!(history.len(), 5);
+
+    // Newest first: tip 4 should be at index 0.
+    let first_msg = history.get(0).unwrap().message.unwrap();
+    assert_eq!(first_msg, String::from_str(&env, "tip 4"));
+    let last_msg = history.get(4).unwrap().message.unwrap();
+    assert_eq!(last_msg, String::from_str(&env, "tip 0"));
+}
+
+#[test]
+fn test_tip_history_limit_respected() {
+    let (env, client, sender, creator, token) = setup();
+
+    let token_client = soroban_sdk::token::StellarAssetClient::new(&env, &token);
+    token_client.mint(&sender, &10_000i128);
+
+    for _ in 0..10 {
+        client.tip_with_message(&sender, &creator, &token, &50i128, &None);
+    }
+
+    let history = client.get_tip_history(&creator, &3u32);
+    assert_eq!(history.len(), 3);
+}
+
+#[test]
+fn test_utf8_emoji_message_accepted() {
+    let (env, client, sender, creator, token) = setup();
+
+    // 5 emoji = 5 chars but many bytes each — must pass the 200-char limit.
+    let msg = String::from_str(&env, "🎉🚀💎🌟🔥");
+    client.tip_with_message(&sender, &creator, &token, &100i128, &Some(msg.clone()));
+
+    let history = client.get_tip_history(&creator, &1u32);
+    assert_eq!(history.get(0).unwrap().message.unwrap(), msg);
+}
+
+#[test]
+#[should_panic]
+fn test_emoji_message_exceeding_200_chars_rejected() {
+    let (env, client, sender, creator, token) = setup();
+
+    // 201 emoji = 201 chars (but many more bytes).
+    let s: std::string::String = "🎉".repeat(201);
+    let msg = String::from_str(&env, &s);
+
+    client.tip_with_message(&sender, &creator, &token, &100i128, &Some(msg));
+}
+
+#[test]
+fn test_storage_efficiency_tip_count_increments() {
+    let (env, client, sender, creator, token) = setup();
+
+    let token_client = soroban_sdk::token::StellarAssetClient::new(&env, &token);
+    token_client.mint(&sender, &10_000i128);
+
+    for i in 0u64..3 {
+        client.tip_with_message(&sender, &creator, &token, &100i128, &None);
+        // Verify the count key matches expected value.
+        let count: u64 = env
+            .as_contract(&client.address, || {
+                env.storage()
+                    .persistent()
+                    .get::<DataKey, u64>(&DataKey::TipCount(creator.clone()))
+                    .unwrap_or(0)
+            });
+        assert_eq!(count, i + 1);
+    }
+}
+
+#[test]
+fn test_existing_tip_behavior_unaffected() {
+    let (env, client, sender, creator, token) = setup();
+
+    // The original `tip` function should still work independently.
+    client.tip(&sender, &creator, &token, &200i128);
+
+    // tip_with_message history should be empty (tip() doesn't write TipHistory).
+    let history = client.get_tip_history(&creator, &10u32);
+    assert_eq!(history.len(), 0);
+
+    // But balance should be credited.
+    assert_eq!(client.get_withdrawable_balance(&creator, &token), 200i128);
+}


### PR DESCRIPTION


## Summary
Extends the tipjar contract to support optional messages and metadata 
on-chain, allowing senders to attach a note to their tip for context 
or appreciation.

## Changes
- Added `TipMetadata` struct (sender, amount, message, timestamp)
- Added `TipHistory` and `TipCount` keys to `DataKey` enum
- Implemented `tip_with_message` with optional message parameter
- Message length capped at 200 characters (UTF-8 / emoji safe)
- Implemented `get_tip_history` query function
- Enhanced events emitted with message data
- Added `MessageTooLong` error variant

## Files Changed
- `contracts/tipjar/src/lib.rs`

## Testing
- [ ] Tip with message saves and retrieves correctly
- [ ] Tip without message works as before
- [ ] Message exceeding 200 chars rejected
- [ ] Tip history returns most recent first
- [ ] UTF-8 and emoji characters supported
- [ ] `cargo check` passes for touched workspace members






close #103 