### PR TITLE
feat: memo support, property tests, gas optimization, and docs

### DIFF
--- a/contracts/tipjar/Cargo.toml
+++ b/contracts/tipjar/Cargo.toml
@@ -23,6 +23,7 @@ rand = "0.8"
 base64 = "0.22"
 quickcheck = "1.0"
 quickcheck_macros = "1.0"
+proptest = "1.4"
 
 [[test]]
 name = "gas_benchmarks"
@@ -31,3 +32,7 @@ path = "benches/gas_benchmarks.rs"
 [[test]]
 name = "quickcheck_properties"
 path = "tests/quickcheck_properties.rs"
+
+[[test]]
+name = "property_tests"
+path = "tests/property_tests.rs"

--- a/contracts/tipjar/src/lib.rs
+++ b/contracts/tipjar/src/lib.rs
@@ -36,6 +36,24 @@ pub mod conditions;
 // Dynamic fee adjustment
 pub mod fees;
 
+/// A tip record that includes an optional memo and timestamp.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TipWithMemo {
+    pub sender: Address,
+    pub amount: i128,
+    pub memo: Option<String>,
+    pub timestamp: u64,
+}
+
+/// Combined creator stats stored in a single persistent entry to reduce storage reads/writes.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CreatorStats {
+    pub balance: i128,
+    pub total: i128,
+}
+
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct TipWithMessage {
@@ -245,6 +263,12 @@ pub enum DataKey {
     Subscription(Address, Address),
     /// Human-readable reason stored when the contract is paused.
     PauseReason,
+    /// Number of memo-tips stored for a creator (u64).
+    TipCount(Address),
+    /// Individual memo-tip record keyed by (creator, tip_index).
+    TipData(Address, u64),
+    /// Combined balance+total for a creator per token (single storage entry).
+    CreatorStats(Address, Address),
 }
 
 #[contracterror]
@@ -291,6 +315,8 @@ pub enum TipJarError {
     InvalidPercentage = 30,
     /// Contract is paused; state-changing operations are blocked.
     ContractPaused = 31,
+    /// Memo exceeds the 200-character limit.
+    MemoTooLong = 32,
 }
 
 #[contract]
@@ -850,6 +876,121 @@ impl TipJarContract {
         env.storage()
             .persistent()
             .get(&DataKey::Subscription(subscriber, creator))
+    }
+
+    // ── CreatorStats helper (gas optimization) ───────────────────────────────
+
+    /// Reads combined balance+total for a creator/token in one storage call.
+    fn read_creator_stats(env: &Env, creator: &Address, token: &Address) -> CreatorStats {
+        env.storage()
+            .persistent()
+            .get(&DataKey::CreatorStats(creator.clone(), token.clone()))
+            .unwrap_or(CreatorStats { balance: 0, total: 0 })
+    }
+
+    /// Writes combined balance+total for a creator/token in one storage call.
+    fn write_creator_stats(env: &Env, creator: &Address, token: &Address, stats: &CreatorStats) {
+        env.storage()
+            .persistent()
+            .set(&DataKey::CreatorStats(creator.clone(), token.clone()), stats);
+    }
+
+    // ── memo tips ────────────────────────────────────────────────────────────
+
+    /// Sends a tip with an optional memo (max 200 UTF-8 characters).
+    ///
+    /// Stores the tip record on-chain and credits the creator's balance.
+    /// Emits `("tip_memo", creator)` with data `(sender, amount)`.
+    ///
+    /// # Panics
+    /// * `InvalidAmount` – if `amount <= 0`
+    /// * `MemoTooLong`   – if memo exceeds 200 characters
+    /// * `TokenNotWhitelisted` – if the token is not approved
+    pub fn tip_with_memo(
+        env: Env,
+        sender: Address,
+        creator: Address,
+        token: Address,
+        amount: i128,
+        memo: Option<String>,
+    ) {
+        Self::require_not_paused(&env);
+        if amount <= 0 {
+            panic_with_error!(&env, TipJarError::InvalidAmount);
+        }
+        if let Some(ref m) = memo {
+            if m.len() > 200 {
+                panic_with_error!(&env, TipJarError::MemoTooLong);
+            }
+        }
+        sender.require_auth();
+
+        let whitelisted: bool = env
+            .storage()
+            .instance()
+            .get(&DataKey::TokenWhitelist(token.clone()))
+            .unwrap_or(false);
+        if !whitelisted {
+            panic_with_error!(&env, TipJarError::TokenNotWhitelisted);
+        }
+
+        token::Client::new(&env, &token).transfer(
+            &sender,
+            &env.current_contract_address(),
+            &amount,
+        );
+
+        // Update creator stats with a single read/write (gas optimization).
+        let mut stats = Self::read_creator_stats(&env, &creator, &token);
+        stats.balance += amount;
+        stats.total += amount;
+        Self::write_creator_stats(&env, &creator, &token, &stats);
+
+        // Store the tip record.
+        let tip_count: u64 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::TipCount(creator.clone()))
+            .unwrap_or(0);
+        let tip_data = TipWithMemo {
+            sender: sender.clone(),
+            amount,
+            memo,
+            timestamp: env.ledger().timestamp(),
+        };
+        env.storage()
+            .persistent()
+            .set(&DataKey::TipData(creator.clone(), tip_count), &tip_data);
+        env.storage()
+            .persistent()
+            .set(&DataKey::TipCount(creator.clone()), &(tip_count + 1));
+
+        Self::update_leaderboard_stats(&env, &sender, &creator, amount);
+        env.events()
+            .publish((symbol_short!("tip_memo"), creator), (sender, amount));
+    }
+
+    /// Returns the most recent `limit` memo-tips for `creator` (up to 50).
+    pub fn get_tips_with_memos(env: Env, creator: Address, limit: u32) -> Vec<TipWithMemo> {
+        let tip_count: u64 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::TipCount(creator.clone()))
+            .unwrap_or(0);
+
+        let cap = if limit > 50 { 50 } else { limit } as u64;
+        let start = tip_count.saturating_sub(cap);
+        let mut tips = Vec::new(&env);
+        for i in start..tip_count {
+            if let Some(tip) = env
+                .storage()
+                .persistent()
+                .get(&DataKey::TipData(creator.clone(), i))
+            {
+                tips.push_back(tip);
+            }
+        }
+        tips
     }
 
     /// Splits a single tip among multiple recipients proportionally.

--- a/contracts/tipjar/tests/property_tests.rs
+++ b/contracts/tipjar/tests/property_tests.rs
@@ -1,0 +1,172 @@
+/// Property-based tests for the TipJar contract using proptest.
+///
+/// Each `proptest!` block states an invariant that must hold for all generated
+/// inputs.  The test runner shrinks failing cases automatically.
+use proptest::prelude::*;
+use soroban_sdk::{testutils::Address as _, token, Address, Env};
+use tipjar::{TipJarContract, TipJarContractClient};
+
+// ── test helpers ─────────────────────────────────────────────────────────────
+
+fn setup() -> (Env, TipJarContractClient<'static>, Address, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let token_admin = Address::generate(&env);
+    let token = env
+        .register_stellar_asset_contract_v2(token_admin.clone())
+        .address();
+
+    let admin = Address::generate(&env);
+    let contract_id = env.register(TipJarContract, ());
+    let client = TipJarContractClient::new(&env, &contract_id);
+
+    client.init(&admin);
+    client.add_token(&admin, &token);
+
+    (env, client, token, token_admin)
+}
+
+fn mint(env: &Env, token: &Address, to: &Address, amount: i128) {
+    token::StellarAssetClient::new(env, token).mint(to, &amount);
+}
+
+// ── properties ────────────────────────────────────────────────────────────────
+
+proptest! {
+    /// Property: after a single tip, the creator's withdrawable balance equals
+    /// the tipped amount.
+    #[test]
+    fn prop_tip_balance_invariant(amount in 1i128..1_000_000_000i128) {
+        let (env, client, token, _) = setup();
+        let sender = Address::generate(&env);
+        let creator = Address::generate(&env);
+
+        mint(&env, &token, &sender, amount);
+        client.tip(&sender, &creator, &token, &amount);
+
+        prop_assert_eq!(client.get_withdrawable_balance(&creator, &token), amount);
+        prop_assert_eq!(client.get_total_tips(&creator, &token), amount);
+    }
+
+    /// Property: multiple tips accumulate correctly — total equals the sum of
+    /// all individual amounts.
+    #[test]
+    fn prop_multiple_tips_accumulate(
+        amounts in prop::collection::vec(1i128..1_000_000i128, 1..10usize)
+    ) {
+        let (env, client, token, _) = setup();
+        let creator = Address::generate(&env);
+        let expected_total: i128 = amounts.iter().sum();
+
+        for amount in &amounts {
+            let sender = Address::generate(&env);
+            mint(&env, &token, &sender, *amount);
+            client.tip(&sender, &creator, &token, amount);
+        }
+
+        prop_assert_eq!(client.get_total_tips(&creator, &token), expected_total);
+        prop_assert_eq!(client.get_withdrawable_balance(&creator, &token), expected_total);
+    }
+
+    /// Property: after withdrawal the balance is zero but the historical total
+    /// is unchanged.
+    #[test]
+    fn prop_withdraw_clears_balance(amount in 1i128..1_000_000_000i128) {
+        let (env, client, token, _) = setup();
+        let sender = Address::generate(&env);
+        let creator = Address::generate(&env);
+
+        mint(&env, &token, &sender, amount);
+        client.tip(&sender, &creator, &token, &amount);
+        client.withdraw(&creator, &token);
+
+        prop_assert_eq!(client.get_withdrawable_balance(&creator, &token), 0);
+        prop_assert_eq!(client.get_total_tips(&creator, &token), amount);
+    }
+
+    /// Property: tipping with a non-positive amount must panic.
+    #[test]
+    fn prop_no_negative_or_zero_amounts(amount in i128::MIN..=0i128) {
+        let (env, client, token, _) = setup();
+        let sender = Address::generate(&env);
+        let creator = Address::generate(&env);
+
+        // Soroban panics are caught as Err by catch_unwind in std tests.
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            client.tip(&sender, &creator, &token, &amount);
+        }));
+        prop_assert!(result.is_err(), "expected panic for amount={}", amount);
+    }
+
+    /// Property: tip_with_memo stores exactly one record per call and the
+    /// returned list length equals the number of tips sent (up to the query
+    /// limit of 50).
+    #[test]
+    fn prop_memo_tip_count(
+        amounts in prop::collection::vec(1i128..100_000i128, 1..10usize)
+    ) {
+        let (env, client, token, _) = setup();
+        let creator = Address::generate(&env);
+        let n = amounts.len() as u32;
+
+        for amount in &amounts {
+            let sender = Address::generate(&env);
+            mint(&env, &token, &sender, *amount);
+            client.tip_with_memo(&sender, &creator, &token, amount, &None);
+        }
+
+        let tips = client.get_tips_with_memos(&creator, &n);
+        prop_assert_eq!(tips.len(), n);
+    }
+
+    /// Property: memo length exactly at the limit (200 chars) is accepted;
+    /// one character over must panic.
+    #[test]
+    fn prop_memo_length_boundary(extra in 0u32..=1u32) {
+        let (env, client, token, _) = setup();
+        let sender = Address::generate(&env);
+        let creator = Address::generate(&env);
+        mint(&env, &token, &sender, 1_000);
+
+        // Build a memo of length 200 + extra.
+        let memo_str: String = "a".repeat((200 + extra) as usize);
+        let memo = soroban_sdk::String::from_str(&env, &memo_str);
+
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            client.tip_with_memo(&sender, &creator, &token, &500, &Some(memo));
+        }));
+
+        if extra == 0 {
+            prop_assert!(result.is_ok(), "200-char memo should be accepted");
+        } else {
+            prop_assert!(result.is_err(), "201-char memo should be rejected");
+        }
+    }
+
+    /// Property: the sum of all per-creator balances across independent
+    /// creators equals the total amount transferred into the contract.
+    #[test]
+    fn prop_total_conservation(
+        amounts in prop::collection::vec(1i128..100_000i128, 2..6usize)
+    ) {
+        let (env, client, token, _) = setup();
+        let expected_total: i128 = amounts.iter().sum();
+
+        let mut creators = Vec::new();
+        for amount in &amounts {
+            let sender = Address::generate(&env);
+            let creator = Address::generate(&env);
+            mint(&env, &token, &sender, *amount);
+            client.tip(&sender, &creator, &token, amount);
+            creators.push((creator, *amount));
+        }
+
+        let actual_total: i128 = creators
+            .iter()
+            .map(|(c, _)| client.get_withdrawable_balance(c, &token))
+            .sum();
+
+        prop_assert_eq!(actual_total, expected_total);
+    }
+}

--- a/docs/CONTRACT_SPEC.md
+++ b/docs/CONTRACT_SPEC.md
@@ -1,0 +1,180 @@
+# TipJar Contract Specification
+
+## Overview
+
+The TipJar contract lets supporters tip creators using whitelisted Stellar tokens. Tips are held in escrow and can be withdrawn by the creator at any time. The contract supports optional memos, recurring subscriptions, split tips, conditional execution, and a leaderboard.
+
+## Public Functions
+
+### Initialization
+
+#### `init(admin: Address, fee_basis_points: u32, refund_window_seconds: u64)`
+One-time setup. Stores the admin address, platform fee, and refund window.
+
+- Panics: `AlreadyInitialized` if called more than once.
+- Panics: `FeeExceedsMaximum` if `fee_basis_points > 500` (5%).
+
+#### `add_token(admin: Address, token: Address)`
+Whitelists a token for use in tips. Admin only.
+
+- Panics: `Unauthorized` if caller is not the stored admin.
+
+### Tipping
+
+#### `tip(sender: Address, creator: Address, token: Address, amount: i128) -> u64`
+Transfers `amount` of `token` from `sender` into escrow for `creator`. Returns the tip ID.
+
+- Requires auth from `sender`.
+- Panics: `InvalidAmount` if `amount <= 0`.
+- Panics: `TokenNotWhitelisted` if the token is not approved.
+- Emits: `("tip", creator)` → `(sender, amount)`.
+
+#### `tip_with_memo(sender, creator, token, amount, memo: Option<String>)`
+Like `tip` but stores an optional memo (max 200 UTF-8 characters) on-chain alongside a timestamp. Uses the `CreatorStats` optimization (single storage read/write per call).
+
+- Panics: `MemoTooLong` if memo exceeds 200 characters.
+- Emits: `("tip_memo", creator)` → `(sender, amount)`.
+
+#### `tip_with_fee(sender, creator, token, amount, congestion: u32)`
+Deducts a dynamic platform fee before crediting the creator. `congestion`: 0=Low, 1=Normal, 2=High.
+
+- Emits: `("tip", creator)` → `(sender, net_amount)` and `("fee", creator)` → `(fee_amount, fee_bps)`.
+
+#### `tip_split(sender, token, recipients: Vec<TipRecipient>, amount)`
+Splits a tip among 2–10 recipients. Each recipient's `percentage` is in basis points; all must sum to 10 000.
+
+- Panics: `InvalidRecipientCount`, `InvalidPercentage`, `InvalidPercentageSum`.
+- Emits: `("tip_splt", creator)` → `(sender, share, percentage)` per recipient.
+
+#### `execute_conditional_tip(sender, creator, token, amount, conditions) -> bool`
+Executes a tip only if all conditions evaluate to true. Returns `false` (no transfer) when conditions fail.
+
+### Querying
+
+#### `get_withdrawable_balance(creator: Address, token: Address) -> i128`
+Returns the creator's current escrowed balance.
+
+#### `get_total_tips(creator: Address, token: Address) -> i128`
+Returns the historical total tips received by the creator.
+
+#### `get_tips_with_memos(creator: Address, limit: u32) -> Vec<TipWithMemo>`
+Returns the most recent `limit` memo-tips (capped at 50) for the creator, oldest first.
+
+#### `get_leaderboard(period: TimePeriod, kind: ParticipantKind, limit: u32) -> Vec<LeaderboardEntry>`
+Returns the top `limit` (max 100) tippers or creators sorted by total amount descending.
+
+### Withdrawal
+
+#### `withdraw(creator: Address, token: Address)`
+Transfers the full escrowed balance to the creator.
+
+- Requires auth from `creator`.
+- Panics: `NothingToWithdraw` if balance is zero.
+- Emits: `("withdraw", creator)` → `amount`.
+
+### Subscriptions
+
+#### `create_subscription(subscriber, creator, token, amount, interval_seconds)`
+Creates a recurring tip. Minimum interval: 86 400 s (1 day).
+
+#### `execute_subscription_payment(subscriber, creator)`
+Executes a due payment. Anyone may call this.
+
+#### `pause_subscription / resume_subscription / cancel_subscription`
+Subscriber-only lifecycle management.
+
+#### `get_subscription(subscriber, creator) -> Option<Subscription>`
+
+### Administration
+
+#### `pause(admin, reason: String)` / `unpause(admin)`
+Halts / resumes all state-changing operations.
+
+#### `is_paused() -> bool`
+
+#### `upgrade(new_wasm_hash: BytesN<32>)`
+Upgrades the contract WASM. Admin only. Increments the on-chain version.
+
+#### `get_version() -> u32`
+
+## Storage Layout
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `Admin` | `Address` | Contract administrator |
+| `TokenWhitelist(token)` | `bool` | Whether a token is approved |
+| `CreatorBalance(creator, token)` | `i128` | Withdrawable escrow balance |
+| `CreatorTotal(creator, token)` | `i128` | Historical total tips |
+| `CreatorStats(creator, token)` | `CreatorStats` | Combined balance+total (optimized) |
+| `TipCount(creator)` | `u64` | Number of memo-tips stored |
+| `TipData(creator, index)` | `TipWithMemo` | Individual memo-tip record |
+| `Subscription(subscriber, creator)` | `Subscription` | Recurring tip state |
+| `Paused` | `bool` | Emergency pause flag |
+| `PauseReason` | `String` | Human-readable pause reason |
+| `ContractVersion` | `u32` | Incremented on each upgrade |
+
+## Error Codes
+
+| Code | Name | Description |
+|------|------|-------------|
+| 1 | `AlreadyInitialized` | `init` called more than once |
+| 2 | `TokenNotWhitelisted` | Token not approved for tips |
+| 3 | `InvalidAmount` | Amount must be positive |
+| 4 | `NothingToWithdraw` | Creator balance is zero |
+| 5 | `MessageTooLong` | Tip message exceeds limit |
+| 9 | `Unauthorized` | Caller is not the admin |
+| 24 | `SubscriptionNotFound` | No subscription exists |
+| 25 | `SubscriptionNotActive` | Subscription is paused or cancelled |
+| 26 | `PaymentNotDue` | Interval has not elapsed |
+| 27 | `InvalidInterval` | Interval below 1-day minimum |
+| 28 | `InvalidRecipientCount` | Must have 2–10 recipients |
+| 29 | `InvalidPercentageSum` | Shares must sum to 10 000 bps |
+| 30 | `InvalidPercentage` | Individual share is zero |
+| 31 | `ContractPaused` | Contract is paused |
+| 32 | `MemoTooLong` | Memo exceeds 200 characters |
+
+## Data Structures
+
+```rust
+pub struct TipWithMemo {
+    pub sender: Address,
+    pub amount: i128,
+    pub memo: Option<String>,  // max 200 UTF-8 chars
+    pub timestamp: u64,        // ledger timestamp
+}
+
+pub struct CreatorStats {
+    pub balance: i128,  // withdrawable
+    pub total: i128,    // historical
+}
+
+pub struct Subscription {
+    pub subscriber: Address,
+    pub creator: Address,
+    pub token: Address,
+    pub amount: i128,
+    pub interval_seconds: u64,
+    pub last_payment: u64,
+    pub next_payment: u64,
+    pub status: SubscriptionStatus,  // Active | Paused | Cancelled
+}
+
+pub struct TipRecipient {
+    pub creator: Address,
+    pub percentage: u32,  // basis points, must be > 0
+}
+```
+
+## Events
+
+| Topic | Data | Emitted by |
+|-------|------|-----------|
+| `("tip", creator)` | `(sender, amount)` | `tip` |
+| `("tip_memo", creator)` | `(sender, amount)` | `tip_with_memo` |
+| `("tip_splt", creator)` | `(sender, share, pct)` | `tip_split` |
+| `("withdraw", creator)` | `amount` | `withdraw` |
+| `("sub_new", creator)` | `(subscriber, amount, interval)` | `create_subscription` |
+| `("sub_pay", creator)` | `(subscriber, amount)` | `execute_subscription_payment` |
+| `("paused",)` | `(admin, reason)` | `pause` |
+| `("unpaused",)` | `admin` | `unpause` |
+| `("upgraded",)` | `version` | `upgrade` |

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,0 +1,164 @@
+# TipJar Deployment Guide
+
+## Prerequisites
+
+```bash
+# Install Stellar CLI
+cargo install --locked stellar-cli --features opt
+
+# Add WASM target
+rustup target add wasm32v1-none
+
+# Verify
+stellar --version
+```
+
+## Build
+
+```bash
+cargo build -p tipjar --target wasm32v1-none --release
+```
+
+The compiled WASM is at `target/wasm32v1-none/release/tipjar.wasm`.
+
+## Testnet Deployment
+
+```bash
+# 1. Generate and fund a deployer account
+stellar keys generate deployer --network testnet
+stellar keys fund deployer --network testnet
+
+# 2. Deploy the contract
+CONTRACT_ID=$(stellar contract deploy \
+  --wasm target/wasm32v1-none/release/tipjar.wasm \
+  --source deployer \
+  --network testnet)
+echo "Contract ID: $CONTRACT_ID"
+
+# 3. Initialize (fee = 1%, refund window = 7 days)
+stellar contract invoke \
+  --id $CONTRACT_ID \
+  --source deployer \
+  --network testnet \
+  -- init \
+  --admin $(stellar keys address deployer) \
+  --fee_basis_points 100 \
+  --refund_window_seconds 604800
+
+# 4. Whitelist a token (e.g. native XLM)
+XLM_TOKEN=$(stellar contract id asset \
+  --asset native \
+  --network testnet)
+
+stellar contract invoke \
+  --id $CONTRACT_ID \
+  --source deployer \
+  --network testnet \
+  -- add_token \
+  --admin $(stellar keys address deployer) \
+  --token $XLM_TOKEN
+```
+
+Or use the helper script:
+
+```bash
+bash scripts/deploy_testnet.sh
+```
+
+## Mainnet Deployment
+
+```bash
+bash scripts/deploy_mainnet.sh
+```
+
+Review `scripts/deploy_mainnet.sh` before running — it requires a funded mainnet account and prompts for confirmation.
+
+## Verify Deployment
+
+```bash
+# Check contract is initialized
+stellar contract invoke \
+  --id $CONTRACT_ID \
+  --network testnet \
+  -- is_paused
+
+# Check version
+stellar contract invoke \
+  --id $CONTRACT_ID \
+  --network testnet \
+  -- get_version
+```
+
+## Upgrading
+
+```bash
+# Build new WASM
+cargo build -p tipjar --target wasm32v1-none --release
+
+# Upload new WASM and get its hash
+NEW_HASH=$(stellar contract upload \
+  --wasm target/wasm32v1-none/release/tipjar.wasm \
+  --source deployer \
+  --network testnet)
+
+# Upgrade (admin only)
+stellar contract invoke \
+  --id $CONTRACT_ID \
+  --source deployer \
+  --network testnet \
+  -- upgrade \
+  --new_wasm_hash $NEW_HASH
+```
+
+The contract version is incremented automatically. All storage is preserved.
+
+## Emergency Pause
+
+```bash
+stellar contract invoke \
+  --id $CONTRACT_ID \
+  --source deployer \
+  --network testnet \
+  -- pause \
+  --admin $(stellar keys address deployer) \
+  --reason '"Emergency maintenance"'
+
+# Resume
+stellar contract invoke \
+  --id $CONTRACT_ID \
+  --source deployer \
+  --network testnet \
+  -- unpause \
+  --admin $(stellar keys address deployer)
+```
+
+## Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `CONTRACT_ID` | Deployed contract address |
+| `ADMIN_SECRET` | Admin account secret key |
+| `TOKEN_ADDR` | Whitelisted token contract address |
+| `STELLAR_NETWORK` | `testnet` or `mainnet` |
+| `STELLAR_RPC_URL` | Soroban RPC endpoint |
+
+## Network RPC Endpoints
+
+| Network | RPC URL |
+|---------|---------|
+| Testnet | `https://soroban-testnet.stellar.org` |
+| Mainnet | `https://mainnet.stellar.validationcloud.io/v1/<key>` |
+| Futurenet | `https://rpc-futurenet.stellar.org` |
+
+## Running Tests
+
+```bash
+# Unit + integration tests
+cargo test -p tipjar
+
+# Property tests
+cargo test --test property_tests -p tipjar
+
+# QuickCheck tests
+cargo test --test quickcheck_properties -p tipjar
+```

--- a/docs/INTEGRATION.md
+++ b/docs/INTEGRATION.md
@@ -1,0 +1,180 @@
+# TipJar Integration Guide
+
+## Prerequisites
+
+- Stellar CLI (`stellar`) ≥ 21.0
+- A funded Stellar account on the target network
+- The deployed contract ID (see `docs/DEPLOYMENT.md`)
+
+## TypeScript / JavaScript
+
+The SDK in `sdk/typescript/` wraps the contract calls.
+
+```typescript
+import { TipJarContract } from './sdk/typescript/src/TipJarContract';
+
+const client = new TipJarContract({
+  contractId: 'CABC...',
+  networkPassphrase: Networks.TESTNET,
+  rpcUrl: 'https://soroban-testnet.stellar.org',
+});
+
+// Send a tip
+await client.tip({
+  sender: keypair.publicKey(),
+  creator: 'GCREATOR...',
+  token: 'CTOKEN...',
+  amount: BigInt(10_000_000), // 1 XLM in stroops
+});
+
+// Send a tip with memo
+await client.tipWithMemo({
+  sender: keypair.publicKey(),
+  creator: 'GCREATOR...',
+  token: 'CTOKEN...',
+  amount: BigInt(5_000_000),
+  memo: 'Great video! 🎉',
+});
+
+// Query recent memo-tips
+const tips = await client.getTipsWithMemos({
+  creator: 'GCREATOR...',
+  limit: 10,
+});
+
+// Withdraw as creator
+await client.withdraw({
+  creator: keypair.publicKey(),
+  token: 'CTOKEN...',
+});
+```
+
+## Stellar CLI
+
+```bash
+# Tip a creator
+stellar contract invoke \
+  --id $CONTRACT_ID \
+  --source $SENDER_SECRET \
+  --network testnet \
+  -- tip \
+  --sender $SENDER_ADDR \
+  --creator $CREATOR_ADDR \
+  --token $TOKEN_ADDR \
+  --amount 10000000
+
+# Tip with memo
+stellar contract invoke \
+  --id $CONTRACT_ID \
+  --source $SENDER_SECRET \
+  --network testnet \
+  -- tip_with_memo \
+  --sender $SENDER_ADDR \
+  --creator $CREATOR_ADDR \
+  --token $TOKEN_ADDR \
+  --amount 5000000 \
+  --memo '"Great content! 🎉"'
+
+# Query memo-tips
+stellar contract invoke \
+  --id $CONTRACT_ID \
+  --network testnet \
+  -- get_tips_with_memos \
+  --creator $CREATOR_ADDR \
+  --limit 10
+
+# Withdraw
+stellar contract invoke \
+  --id $CONTRACT_ID \
+  --source $CREATOR_SECRET \
+  --network testnet \
+  -- withdraw \
+  --creator $CREATOR_ADDR \
+  --token $TOKEN_ADDR
+```
+
+## Subscribing to Events
+
+Listen for on-chain events using the Stellar RPC `getEvents` endpoint:
+
+```typescript
+const events = await server.getEvents({
+  startLedger: fromLedger,
+  filters: [{
+    type: 'contract',
+    contractIds: [CONTRACT_ID],
+    topics: [['tip', '*']],   // all tip events
+  }],
+});
+
+for (const event of events.events) {
+  const [creator] = event.topic;
+  const [sender, amount] = event.value;
+  console.log(`${sender} tipped ${creator} ${amount} stroops`);
+}
+```
+
+## Recurring Subscriptions
+
+```typescript
+// Create a weekly subscription of 1 XLM
+await client.createSubscription({
+  subscriber: keypair.publicKey(),
+  creator: 'GCREATOR...',
+  token: 'CTOKEN...',
+  amount: BigInt(10_000_000),
+  intervalSeconds: BigInt(604_800), // 7 days
+});
+
+// Execute a due payment (anyone can call)
+await client.executeSubscriptionPayment({
+  subscriber: 'GSUB...',
+  creator: 'GCREATOR...',
+});
+```
+
+## Split Tips
+
+```typescript
+// Split 10 XLM: 70% to creator A, 30% to creator B
+await client.tipSplit({
+  sender: keypair.publicKey(),
+  token: 'CTOKEN...',
+  amount: BigInt(100_000_000),
+  recipients: [
+    { creator: 'GCREATOR_A...', percentage: 7000 },
+    { creator: 'GCREATOR_B...', percentage: 3000 },
+  ],
+});
+```
+
+## Error Handling
+
+All contract errors are returned as `u32` codes. Map them to `TipJarError` variants:
+
+```typescript
+try {
+  await client.tip({ ... });
+} catch (e) {
+  if (e.code === 3) console.error('Invalid amount');
+  if (e.code === 2) console.error('Token not whitelisted');
+  if (e.code === 32) console.error('Memo too long (max 200 chars)');
+}
+```
+
+See `docs/CONTRACT_SPEC.md` for the full error code table.
+
+## Amount Units
+
+All amounts are in **stroops** (the smallest Stellar unit). 1 XLM = 10 000 000 stroops.
+
+```typescript
+const ONE_XLM = BigInt(10_000_000);
+```
+
+## Security Notes
+
+- Always call `is_paused()` before building a transaction in production UIs.
+- Validate memo length client-side (≤ 200 chars) before submitting to avoid wasted fees.
+- Token addresses must be whitelisted by the admin before use.
+- The contract holds funds in escrow; creators must call `withdraw` to receive them.


### PR DESCRIPTION
closes #136 
closes #129 
closes #127 
closes #126 


Memo support (contracts/tipjar/src/lib.rs)
- Add TipWithMemo struct (sender, amount, memo: Option<String>, timestamp)
- Add MemoTooLong error variant (code 32, limit: 200 UTF-8 chars)
- Add DataKey::TipCount(Address) and DataKey::TipData(Address, u64)
- Add tip_with_memo(): validates amount/memo, transfers tokens, stores record on-chain, updates leaderboard, emits ("tip_memo", creator)
- Add get_tips_with_memos(): returns most recent N tips (capped at 50)

Gas optimization (contracts/tipjar/src/lib.rs)
- Add CreatorStats { balance, total } struct to combine both fields in a single persistent storage entry
- Add DataKey::CreatorStats(Address, Address)
- Add read_creator_stats() / write_creator_stats() helpers: one read + one write per tip instead of two reads + two writes
- tip_with_memo uses this optimization

Property tests (contracts/tipjar/tests/property_tests.rs)
- Add proptest = "1.4" to dev-dependencies in Cargo.toml
- Add [[test]] entry for property_tests in Cargo.toml
- prop_tip_balance_invariant: balance equals tipped amount
- prop_multiple_tips_accumulate: total equals sum of all tips
- prop_withdraw_clears_balance: balance is 0 after withdrawal, total unchanged
- prop_no_negative_or_zero_amounts: non-positive amounts must panic
- prop_memo_tip_count: stored record count matches number of tips sent
- prop_memo_length_boundary: 200-char memo accepted, 201-char rejected

Documentation
- docs/CONTRACT_SPEC.md: all public functions, storage layout, error codes, data structures, and events table
- docs/INTEGRATION.md: TypeScript SDK examples, CLI commands, event subscription, subscriptions, split tips, error handling, security notes
- docs/DEPLOYMENT.md: build, testnet/mainnet deploy, upgrade, emergency pause, env vars, network endpoints, and test commands