### PR TITLE
feat: deployment docs, withdrawal limits, and matching campaigns

### DIFF
--- a/contracts/tipjar/src/lib.rs
+++ b/contracts/tipjar/src/lib.rs
@@ -154,6 +154,40 @@ pub struct MatchingProgram {
     pub active: bool,
 }
 
+/// A time-boxed sponsor matching campaign with a budget and expiry.
+///
+/// `match_ratio` is in basis points: 100 = 1:1, 200 = 2:1.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct MatchingCampaign {
+    pub sponsor: Address,
+    pub creator: Address,
+    pub token: Address,
+    /// Match ratio in basis points (100 = 1:1, 200 = 2:1).
+    pub match_ratio: u32,
+    pub total_budget: i128,
+    pub remaining_budget: i128,
+    pub start_time: u64,
+    pub end_time: u64,
+    pub active: bool,
+}
+
+/// Per-creator withdrawal rate-limit state.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct WithdrawalLimits {
+    /// Maximum amount withdrawable within a 24-hour window (0 = unlimited).
+    pub daily_limit: i128,
+    /// Minimum seconds that must elapse between withdrawals (0 = no cooldown).
+    pub cooldown_seconds: u64,
+    /// Ledger timestamp of the last successful withdrawal.
+    pub last_withdrawal: u64,
+    /// Amount already withdrawn in the current 24-hour window.
+    pub withdrawn_today: i128,
+    /// Ledger timestamp when the current 24-hour window started.
+    pub day_start: u64,
+}
+
 /// A single recipient in a split tip, with share in basis points (10 000 = 100%).
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -245,6 +279,16 @@ pub enum DataKey {
     Subscription(Address, Address),
     /// Human-readable reason stored when the contract is paused.
     PauseReason,
+    /// Per-creator withdrawal limit state (token-agnostic).
+    WithdrawalLimits(Address),
+    /// Default withdrawal limits applied when no per-creator limits are set.
+    DefaultWithdrawalLimits,
+    /// Matching campaign by campaign ID.
+    MatchingCampaign(u64),
+    /// Global matching campaign counter.
+    CampaignCounter,
+    /// Campaign IDs indexed under a creator.
+    CreatorCampaigns(Address),
 }
 
 #[contracterror]
@@ -291,6 +335,14 @@ pub enum TipJarError {
     InvalidPercentage = 30,
     /// Contract is paused; state-changing operations are blocked.
     ContractPaused = 31,
+    /// Withdrawal would exceed the creator's daily limit.
+    DailyLimitExceeded = 32,
+    /// Cooldown period since the last withdrawal has not elapsed.
+    CooldownActive = 33,
+    /// No matching campaign exists for the given campaign ID.
+    CampaignNotFound = 34,
+    /// Campaign is still active; sponsor cannot withdraw unused funds yet.
+    CampaignStillActive = 35,
 }
 
 #[contract]
@@ -479,11 +531,13 @@ impl TipJarContract {
         env.storage().persistent().set(&tot_key, &new_tot);
         Self::update_leaderboard_stats(&env, &sender, &creator, amount);
         env.events().publish((symbol_short!("tip"), creator.clone()), (sender, amount));
+        Self::apply_matching_campaigns(&env, &creator, &token, amount);
         tip_id
     }
 
     /// Withdraws the full escrowed balance for `creator` in `token`.
     ///
+    /// Enforces per-creator (or default) daily limits and cooldown periods.
     /// Emits `("withdraw", creator)` with data `amount`.
     pub fn withdraw(env: Env, creator: Address, token: Address) {
         Self::require_not_paused(&env);
@@ -494,6 +548,7 @@ impl TipJarContract {
         if amount == 0 {
             panic_with_error!(&env, TipJarError::NothingToWithdraw);
         }
+        Self::check_and_update_withdrawal_limits(&env, &creator, amount);
         env.storage().persistent().set(&bal_key, &0i128);
         token::Client::new(&env, &token).transfer(&env.current_contract_address(), &creator, &amount);
         env.events().publish((symbol_short!("withdraw"), creator.clone()), amount);
@@ -926,5 +981,308 @@ impl TipJarContract {
                 (sender.clone(), share, r.percentage),
             );
         }
+    }
+
+    // ── withdrawal limits ────────────────────────────────────────────────────
+
+    /// Checks and updates withdrawal limits for `creator`. Panics if exceeded.
+    fn check_and_update_withdrawal_limits(env: &Env, creator: &Address, amount: i128) {
+        let mut limits: WithdrawalLimits = env
+            .storage()
+            .persistent()
+            .get(&DataKey::WithdrawalLimits(creator.clone()))
+            .or_else(|| env.storage().instance().get(&DataKey::DefaultWithdrawalLimits))
+            .unwrap_or(WithdrawalLimits {
+                daily_limit: 0,
+                cooldown_seconds: 0,
+                last_withdrawal: 0,
+                withdrawn_today: 0,
+                day_start: 0,
+            });
+
+        // 0 means unlimited / no cooldown.
+        if limits.daily_limit == 0 && limits.cooldown_seconds == 0 {
+            return;
+        }
+
+        let now = env.ledger().timestamp();
+
+        if limits.cooldown_seconds > 0 && limits.last_withdrawal > 0 {
+            if now - limits.last_withdrawal < limits.cooldown_seconds {
+                panic_with_error!(env, TipJarError::CooldownActive);
+            }
+        }
+
+        if limits.daily_limit > 0 {
+            const DAY: u64 = 86_400;
+            if now - limits.day_start >= DAY {
+                limits.withdrawn_today = 0;
+                limits.day_start = now;
+            }
+            if limits.withdrawn_today + amount > limits.daily_limit {
+                panic_with_error!(env, TipJarError::DailyLimitExceeded);
+            }
+            limits.withdrawn_today += amount;
+        }
+
+        limits.last_withdrawal = now;
+        env.storage()
+            .persistent()
+            .set(&DataKey::WithdrawalLimits(creator.clone()), &limits);
+    }
+
+    /// Sets the default withdrawal limits applied to all creators without custom limits.
+    ///
+    /// Pass `daily_limit = 0` for unlimited and `cooldown_seconds = 0` for no cooldown.
+    /// Admin only.
+    pub fn set_default_withdrawal_limits(
+        env: Env,
+        admin: Address,
+        daily_limit: i128,
+        cooldown_seconds: u64,
+    ) {
+        admin.require_auth();
+        let stored_admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+        if admin != stored_admin {
+            panic_with_error!(&env, TipJarError::Unauthorized);
+        }
+        let limits = WithdrawalLimits {
+            daily_limit,
+            cooldown_seconds,
+            last_withdrawal: 0,
+            withdrawn_today: 0,
+            day_start: 0,
+        };
+        env.storage()
+            .instance()
+            .set(&DataKey::DefaultWithdrawalLimits, &limits);
+    }
+
+    /// Sets custom withdrawal limits for a specific creator. Admin only.
+    pub fn set_creator_withdrawal_limits(
+        env: Env,
+        admin: Address,
+        creator: Address,
+        daily_limit: i128,
+        cooldown_seconds: u64,
+    ) {
+        admin.require_auth();
+        let stored_admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+        if admin != stored_admin {
+            panic_with_error!(&env, TipJarError::Unauthorized);
+        }
+        let limits = WithdrawalLimits {
+            daily_limit,
+            cooldown_seconds,
+            last_withdrawal: 0,
+            withdrawn_today: 0,
+            day_start: 0,
+        };
+        env.storage()
+            .persistent()
+            .set(&DataKey::WithdrawalLimits(creator), &limits);
+    }
+
+    /// Emergency withdrawal bypassing limits. Admin only.
+    ///
+    /// Emits `("emg_wdraw", creator)` with data `amount`.
+    pub fn emergency_withdraw(env: Env, admin: Address, creator: Address, token: Address) {
+        admin.require_auth();
+        let stored_admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+        if admin != stored_admin {
+            panic_with_error!(&env, TipJarError::Unauthorized);
+        }
+        let bal_key = DataKey::CreatorBalance(creator.clone(), token.clone());
+        let amount: i128 = env.storage().persistent().get(&bal_key).unwrap_or(0);
+        if amount == 0 {
+            panic_with_error!(&env, TipJarError::NothingToWithdraw);
+        }
+        env.storage().persistent().set(&bal_key, &0i128);
+        token::Client::new(&env, &token)
+            .transfer(&env.current_contract_address(), &creator, &amount);
+        env.events()
+            .publish((symbol_short!("emg_wdraw"), creator), amount);
+    }
+
+    // ── matching campaigns ───────────────────────────────────────────────────
+
+    /// Creates a time-boxed matching campaign funded by `sponsor`.
+    ///
+    /// `match_ratio` is in basis points (100 = 1:1, 200 = 2:1).
+    /// `duration_days` sets how long the campaign runs from now.
+    ///
+    /// Transfers `budget` from sponsor into contract escrow.
+    /// Emits `("campaign", sponsor)` with data `(creator, campaign_id, budget)`.
+    /// Returns the new campaign ID.
+    pub fn create_matching_campaign(
+        env: Env,
+        sponsor: Address,
+        creator: Address,
+        token: Address,
+        match_ratio: u32,
+        budget: i128,
+        duration_days: u32,
+    ) -> u64 {
+        Self::require_not_paused(&env);
+        sponsor.require_auth();
+        if budget <= 0 {
+            panic_with_error!(&env, TipJarError::InvalidAmount);
+        }
+        if match_ratio == 0 {
+            panic_with_error!(&env, TipJarError::InvalidMatchRatio);
+        }
+
+        token::Client::new(&env, &token)
+            .transfer(&sponsor, &env.current_contract_address(), &budget);
+
+        let campaign_id: u64 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::CampaignCounter)
+            .unwrap_or(0u64);
+
+        let now = env.ledger().timestamp();
+        let campaign = MatchingCampaign {
+            sponsor: sponsor.clone(),
+            creator: creator.clone(),
+            token,
+            match_ratio,
+            total_budget: budget,
+            remaining_budget: budget,
+            start_time: now,
+            end_time: now + (duration_days as u64 * 86_400),
+            active: true,
+        };
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::MatchingCampaign(campaign_id), &campaign);
+        env.storage()
+            .persistent()
+            .set(&DataKey::CampaignCounter, &(campaign_id + 1));
+
+        let mut ids: Vec<u64> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::CreatorCampaigns(creator.clone()))
+            .unwrap_or_else(|| Vec::new(&env));
+        ids.push_back(campaign_id);
+        env.storage()
+            .persistent()
+            .set(&DataKey::CreatorCampaigns(creator.clone()), &ids);
+
+        env.events().publish(
+            (symbol_short!("campaign"), sponsor),
+            (creator, campaign_id, budget),
+        );
+
+        campaign_id
+    }
+
+    /// Applies active matching campaigns when a tip is made to `creator`.
+    ///
+    /// Called internally by `tip`. Adds matched amounts to the creator's balance.
+    fn apply_matching_campaigns(env: &Env, creator: &Address, token: &Address, tip_amount: i128) {
+        let ids: Vec<u64> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::CreatorCampaigns(creator.clone()))
+            .unwrap_or_else(|| Vec::new(env));
+
+        let now = env.ledger().timestamp();
+
+        for campaign_id in ids.iter() {
+            let key = DataKey::MatchingCampaign(campaign_id);
+            let mut campaign: MatchingCampaign = match env.storage().persistent().get(&key) {
+                Some(c) => c,
+                None => continue,
+            };
+
+            if !campaign.active
+                || now < campaign.start_time
+                || now > campaign.end_time
+                || campaign.remaining_budget <= 0
+                || &campaign.token != token
+            {
+                continue;
+            }
+
+            let match_amount = (tip_amount * campaign.match_ratio as i128) / 100;
+            let actual_match = match_amount.min(campaign.remaining_budget);
+            if actual_match <= 0 {
+                continue;
+            }
+
+            campaign.remaining_budget -= actual_match;
+            env.storage().persistent().set(&key, &campaign);
+
+            let bal_key = DataKey::CreatorBalance(creator.clone(), token.clone());
+            let bal: i128 = env.storage().persistent().get(&bal_key).unwrap_or(0);
+            env.storage().persistent().set(&bal_key, &(bal + actual_match));
+
+            env.events().publish(
+                (symbol_short!("match"), creator.clone()),
+                (campaign_id, actual_match),
+            );
+        }
+    }
+
+    /// Allows a sponsor to withdraw unused funds from an expired campaign.
+    ///
+    /// Emits `("camp_wdraw", sponsor)` with data `(campaign_id, amount)`.
+    pub fn withdraw_campaign_funds(env: Env, sponsor: Address, campaign_id: u64) {
+        sponsor.require_auth();
+        let key = DataKey::MatchingCampaign(campaign_id);
+        let mut campaign: MatchingCampaign = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .unwrap_or_else(|| panic_with_error!(&env, TipJarError::CampaignNotFound));
+
+        if campaign.sponsor != sponsor {
+            panic_with_error!(&env, TipJarError::Unauthorized);
+        }
+        if env.ledger().timestamp() <= campaign.end_time {
+            panic_with_error!(&env, TipJarError::CampaignStillActive);
+        }
+
+        let refund = campaign.remaining_budget;
+        if refund > 0 {
+            token::Client::new(&env, &campaign.token)
+                .transfer(&env.current_contract_address(), &sponsor, &refund);
+            campaign.remaining_budget = 0;
+        }
+        campaign.active = false;
+        env.storage().persistent().set(&key, &campaign);
+
+        env.events().publish(
+            (symbol_short!("camp_wdraw"), sponsor),
+            (campaign_id, refund),
+        );
+    }
+
+    /// Returns all active campaigns for `creator`.
+    pub fn get_active_campaigns(env: Env, creator: Address) -> Vec<MatchingCampaign> {
+        let ids: Vec<u64> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::CreatorCampaigns(creator))
+            .unwrap_or_else(|| Vec::new(&env));
+
+        let now = env.ledger().timestamp();
+        let mut result = Vec::new(&env);
+
+        for campaign_id in ids.iter() {
+            if let Some(c) = env
+                .storage()
+                .persistent()
+                .get::<_, MatchingCampaign>(&DataKey::MatchingCampaign(campaign_id))
+            {
+                if c.active && now <= c.end_time {
+                    result.push_back(c);
+                }
+            }
+        }
+        result
     }
 }

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,0 +1,259 @@
+# Deployment Guide
+
+End-to-end guide for building, testing, and deploying the TipJar contract to testnet and mainnet.
+
+---
+
+## Prerequisites
+
+| Requirement | Notes |
+|---|---|
+| Rust toolchain (stable) | `rustup update stable` |
+| `wasm32v1-none` target | `rustup target add wasm32v1-none` |
+| Stellar CLI | [Install guide](https://developers.stellar.org/docs/tools/developer-tools/cli/install-cli) |
+| `jq` | Used by deploy scripts for config updates |
+| Funded Stellar account | Testnet: use Friendbot; Mainnet: fund via exchange |
+
+---
+
+## Build
+
+```bash
+# Build optimized WASM
+cargo build -p tipjar --target wasm32v1-none --release
+
+# Optimize WASM size (reduces deployment cost)
+stellar contract optimize --wasm target/wasm32v1-none/release/tipjar.wasm
+# Output: target/wasm32v1-none/release/tipjar.optimized.wasm
+```
+
+---
+
+## Test Before Deploying
+
+```bash
+# Unit tests
+cargo test -p tipjar
+
+# Full integration test suite
+cargo test --workspace
+```
+
+All tests must pass before proceeding to deployment.
+
+---
+
+## Testnet Deployment
+
+### 1. Set environment variables
+
+```bash
+export DEPLOYER_SECRET=<your-testnet-secret-key>
+```
+
+### 2. Run the deploy script
+
+```bash
+bash scripts/deploy_testnet.sh
+```
+
+This script:
+1. Builds and optimizes the WASM
+2. Deploys to testnet via `stellar contract deploy`
+3. Verifies the contract is live
+4. Runs smoke tests
+5. Records the contract ID in `deployment/config.json`
+
+### 3. Initialize the contract
+
+```bash
+stellar contract invoke \
+  --id $CONTRACT_ID \
+  --source $DEPLOYER_SECRET \
+  --network testnet \
+  -- init \
+  --admin ADMIN_ADDRESS \
+  --token TOKEN_ADDRESS
+```
+
+### 4. Whitelist additional tokens (if needed)
+
+```bash
+stellar contract invoke \
+  --id $CONTRACT_ID \
+  --source $DEPLOYER_SECRET \
+  --network testnet \
+  -- add_token \
+  --admin ADMIN_ADDRESS \
+  --token ADDITIONAL_TOKEN_ADDRESS
+```
+
+### 5. Verify deployment
+
+```bash
+bash scripts/verify_deployment.sh $CONTRACT_ID testnet
+```
+
+---
+
+## Mainnet Deployment
+
+> Complete the [Mainnet Readiness Checklist](MAINNET_CHECKLIST.md) before proceeding.
+
+### 1. Set environment variables
+
+```bash
+export DEPLOYER_SECRET=<your-mainnet-secret-key>
+```
+
+### 2. Run the mainnet deploy script
+
+```bash
+bash scripts/deploy-mainnet.sh
+# or equivalently:
+bash scripts/deploy_mainnet.sh
+```
+
+The script requires interactive confirmation (`deploy mainnet`) unless `CI_MAINNET_CONFIRMED=true` is set.
+
+### 3. Initialize the contract
+
+```bash
+stellar contract invoke \
+  --id $CONTRACT_ID \
+  --source $DEPLOYER_SECRET \
+  --network mainnet \
+  -- init \
+  --admin ADMIN_ADDRESS \
+  --token TOKEN_ADDRESS
+```
+
+### 4. Post-deployment validation
+
+```bash
+# Verify contract is live
+bash scripts/verify_deployment.sh $CONTRACT_ID mainnet
+
+# Check contract version
+stellar contract invoke \
+  --id $CONTRACT_ID \
+  --network mainnet \
+  -- get_contract_version
+
+# Test a read-only query
+stellar contract invoke \
+  --id $CONTRACT_ID \
+  --network mainnet \
+  -- get_total_tips \
+  --creator ADMIN_ADDRESS \
+  --token TOKEN_ADDRESS
+```
+
+---
+
+## Configuration
+
+Contract IDs and deployment history are stored in `deployment/config.json`:
+
+```json
+{
+  "networks": {
+    "testnet": { "active_contract_id": "C..." },
+    "mainnet": { "active_contract_id": "C..." }
+  },
+  "history": [...]
+}
+```
+
+---
+
+## Rollback Procedure
+
+If a critical issue is found after deployment:
+
+1. **Pause the contract immediately** to stop fund movement:
+   ```bash
+   stellar contract invoke \
+     --id $CONTRACT_ID \
+     --source $DEPLOYER_SECRET \
+     --network mainnet \
+     -- pause \
+     --caller ADMIN_ADDRESS \
+     --reason "Critical issue detected - investigating"
+   ```
+
+2. **Investigate** the issue. Check events via the indexer or Stellar Explorer.
+
+3. **Roll back** the active contract ID to the previous deployment:
+   ```bash
+   bash scripts/rollback.sh mainnet
+   ```
+   This updates `deployment/config.json` to point to the previous contract ID. Direct users to the previous contract while the fix is prepared.
+
+4. **Deploy a fix** using the standard deployment flow once the issue is resolved.
+
+5. **Unpause** (if the new contract was paused, not the rolled-back one):
+   ```bash
+   stellar contract invoke \
+     --id $NEW_CONTRACT_ID \
+     --source $DEPLOYER_SECRET \
+     --network mainnet \
+     -- unpause \
+     --caller ADMIN_ADDRESS
+   ```
+
+---
+
+## Monitoring Setup
+
+### Prometheus + Grafana
+
+```bash
+# Start monitoring stack
+docker-compose -f monitoring/docker-compose.yml up -d
+```
+
+- Prometheus config: `monitoring/prometheus/prometheus.yml`
+- Alert rules: `monitoring/prometheus/alert_rules.yml`
+- Grafana dashboard: `monitoring/grafana/contract_health.json`
+
+### Event Monitor
+
+```bash
+bash scripts/start_indexer.sh
+```
+
+Key alerts configured:
+- High transaction volume (>100 tx/5min)
+- Error rate >5%
+- Excessive gas usage
+- Indexer lag >100 ledgers
+
+---
+
+## Troubleshooting
+
+See [TROUBLESHOOTING.md](TROUBLESHOOTING.md) for common errors and fixes.
+
+### Build fails: `can't find crate for 'std'`
+
+```bash
+rustup target add wasm32v1-none
+```
+
+### Deploy fails: `DEPLOYER_SECRET not set`
+
+```bash
+export DEPLOYER_SECRET=<your-secret-key>
+```
+
+### Contract not found after deploy
+
+Confirm the `--network` flag matches where you deployed. Check `deployment/config.json` for the recorded contract ID.
+
+### Stale test snapshots
+
+```bash
+rm -rf contracts/tipjar/test_snapshots
+cargo test -p tipjar
+```

--- a/docs/MAINNET_CHECKLIST.md
+++ b/docs/MAINNET_CHECKLIST.md
@@ -1,0 +1,89 @@
+# Mainnet Readiness Checklist
+
+Complete every item before deploying to mainnet. Check off each item as it is verified.
+
+---
+
+## Security
+
+- [ ] Security audit completed by an independent Soroban specialist
+- [ ] All audit findings resolved or formally accepted with documented rationale
+- [ ] Admin key stored in HSM or secrets manager — never in source control
+- [ ] Admin key is a multisig account (recommended for high-value deployments)
+- [ ] `DEPLOYER_SECRET` is separate from the admin key
+- [ ] No secret keys committed to git (`git log --all -S 'S...' --oneline` returns nothing)
+- [ ] Token whitelist reviewed — only legitimate SAC or trusted token contracts included
+- [ ] Threat model reviewed: [docs/THREAT_MODEL.md](THREAT_MODEL.md)
+- [ ] Emergency pause runbook documented and shared with on-call team
+
+## Code Quality
+
+- [ ] All unit tests pass: `cargo test -p tipjar`
+- [ ] Full test suite passes: `cargo test --workspace`
+- [ ] No compiler warnings: `cargo build -p tipjar --target wasm32v1-none --release 2>&1 | grep -c warning` returns 0
+- [ ] WASM size is within acceptable limits (check with `wc -c target/wasm32v1-none/release/tipjar.optimized.wasm`)
+- [ ] Contract version is set correctly in storage
+
+## Testnet Validation
+
+- [ ] Contract deployed and initialized on testnet
+- [ ] `tip` flow tested end-to-end on testnet with real token
+- [ ] `withdraw` flow tested on testnet
+- [ ] `tip_batch` tested on testnet
+- [ ] `tip_locked` and `withdraw_locked` tested on testnet
+- [ ] Role management (`grant_role`, `revoke_role`) tested on testnet
+- [ ] `pause` / `unpause` tested on testnet
+- [ ] Matching campaign creation and matching tested on testnet
+- [ ] Withdrawal limits and cooldown tested on testnet
+- [ ] Integration tests run against testnet deployment
+- [ ] Testnet contract ID recorded in `deployment/config.json`
+
+## Configuration
+
+- [ ] `deployment/config.json` has correct mainnet RPC URL and network passphrase
+- [ ] Mainnet token address(es) confirmed and verified
+- [ ] Admin address confirmed and funded (minimum 10 XLM recommended)
+- [ ] Deployer account funded (minimum 10 XLM for deployment fees)
+- [ ] Frontend / SDK updated with testnet contract ID for final pre-launch testing
+
+## Monitoring
+
+- [ ] Prometheus + Grafana stack deployed and accessible
+- [ ] Alert rules configured: `monitoring/prometheus/alert_rules.yml`
+- [ ] Event indexer running and synced to testnet
+- [ ] On-call rotation established with alert notification channels (PagerDuty / Slack)
+- [ ] Dashboard bookmarked: `monitoring/dashboard.html`
+- [ ] Runbook for each alert documented
+
+## Documentation
+
+- [ ] [DEPLOYMENT.md](DEPLOYMENT.md) reviewed and up to date
+- [ ] [API.md](API.md) reflects current contract interface
+- [ ] [SECURITY.md](SECURITY.md) reviewed
+- [ ] Rollback procedure tested on testnet: `bash scripts/rollback.sh testnet`
+- [ ] Post-deployment announcement drafted (blog post / social / Discord)
+
+## Go / No-Go Sign-Off
+
+| Role | Name | Date | Approved |
+|---|---|---|---|
+| Lead Engineer | | | ☐ |
+| Security Reviewer | | | ☐ |
+| Product Owner | | | ☐ |
+
+---
+
+## Post-Deployment Checklist
+
+Complete these steps immediately after mainnet deployment.
+
+- [ ] Contract ID recorded in `deployment/config.json`
+- [ ] `verify_deployment.sh` passes: `bash scripts/verify_deployment.sh $CONTRACT_ID mainnet`
+- [ ] Contract initialized with correct admin and token addresses
+- [ ] First tip transaction submitted and confirmed on-chain
+- [ ] First withdrawal confirmed on-chain
+- [ ] Monitoring alerts firing correctly (trigger a test alert)
+- [ ] Event indexer synced to mainnet and processing events
+- [ ] Frontend updated with mainnet contract ID
+- [ ] Deployment announced to users
+- [ ] Deployment recorded in team changelog / release notes

--- a/scripts/deploy-mainnet.sh
+++ b/scripts/deploy-mainnet.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# deploy-mainnet.sh — alias wrapper for deploy_mainnet.sh
+# Allows both `bash scripts/deploy-mainnet.sh` and `bash scripts/deploy_mainnet.sh`.
+set -e
+exec "$(dirname "$0")/deploy_mainnet.sh" "$@"

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -3,8 +3,9 @@ use soroban_sdk::{
     token, Address, Env, String as SorobanString, Map, Vec as SorobanVec,
 };
 use tipjar::{
-    TipJarContract, TipJarContractClient, TipJarError, BatchTip, LockedTip, 
-    MatchingProgram, Role, TimePeriod, TipWithMessage, LeaderboardEntry, TipHistoryQuery
+    TipJarContract, TipJarContractClient, TipJarError, BatchTip, LockedTip,
+    MatchingProgram, Role, TimePeriod, TipWithMessage, LeaderboardEntry, TipHistoryQuery,
+    MatchingCampaign,
 };
 
 mod common;
@@ -22,47 +23,153 @@ mod cross_contract;
 mod integration_tests {
     use super::*;
 
-    /// Comprehensive integration test suite entry point
+    /// Comprehensive integration test suite entry point (unit-test environment).
     #[test]
     fn run_comprehensive_integration_tests() {
-        // Core functionality tests
         core_functionality::test_complete_tip_workflows();
         core_functionality::test_role_based_operations();
         core_functionality::test_token_management_workflows();
         core_functionality::test_pause_unpause_workflows();
         core_functionality::test_upgrade_workflows();
 
-        // Advanced features tests
         advanced_features::test_batch_operations();
         advanced_features::test_locked_tips_workflows();
         advanced_features::test_matching_programs();
         advanced_features::test_leaderboard_functionality();
         advanced_features::test_cross_contract_integrations();
 
-        // Edge cases tests
         edge_cases::test_boundary_conditions();
         edge_cases::test_concurrent_operations();
         edge_cases::test_malformed_inputs();
 
-        // Failure scenarios tests
         failure_scenarios::test_insufficient_balance_scenarios();
         failure_scenarios::test_unauthorized_access();
         failure_scenarios::test_invalid_token_operations();
         failure_scenarios::test_time_based_failures();
 
-        // Gas analysis tests
         gas_analysis::test_basic_operation_costs();
         gas_analysis::test_batch_operation_efficiency();
         gas_analysis::test_complex_operation_costs();
 
-        // Property-based tests
         property_tests::test_balance_conservation_properties();
         property_tests::test_authorization_properties();
         property_tests::test_leaderboard_consistency_properties();
 
-        // Cross-contract integration tests
         cross_contract::test_dex_integration();
         cross_contract::test_nft_integration();
         cross_contract::test_external_contract_failures();
+    }
+}
+
+/// Testnet integration tests.
+///
+/// These tests require a live testnet deployment and funded accounts.
+/// Run with: `cargo test -- --ignored`
+///
+/// Required environment variables:
+///   CONTRACT_ID   — deployed contract address on testnet
+///   ADMIN_SECRET  — admin account secret key
+///   TOKEN_ADDRESS — whitelisted token address
+#[cfg(test)]
+mod testnet_integration {
+    /// Verifies the full tip → withdraw flow on testnet.
+    #[test]
+    #[ignore]
+    fn test_tip_and_withdraw() {
+        // 1. sender tips creator 100 stroops
+        // 2. assert get_withdrawable_balance == 100
+        // 3. creator withdraws
+        // 4. assert get_withdrawable_balance == 0
+        todo!("implement against live testnet via stellar CLI or SDK")
+    }
+
+    /// Verifies that daily withdrawal limits are enforced on testnet.
+    #[test]
+    #[ignore]
+    fn test_withdrawal_daily_limit_enforced() {
+        // 1. Admin sets daily_limit = 50 for creator
+        // 2. Creator has balance of 100
+        // 3. Creator attempts to withdraw 100 → expect DailyLimitExceeded (32)
+        todo!("implement against live testnet")
+    }
+
+    /// Verifies cooldown period between withdrawals on testnet.
+    #[test]
+    #[ignore]
+    fn test_withdrawal_cooldown() {
+        // 1. Admin sets cooldown_seconds = 3600 for creator
+        // 2. Creator withdraws successfully
+        // 3. Creator immediately attempts second withdrawal → expect CooldownActive (33)
+        todo!("implement against live testnet")
+    }
+
+    /// Verifies matching campaign creation and automatic matching on testnet.
+    #[test]
+    #[ignore]
+    fn test_matching_campaign_flow() {
+        // 1. Sponsor creates campaign: match_ratio=100 (1:1), budget=500, duration=7 days
+        // 2. Sender tips creator 100
+        // 3. Assert creator balance == 200 (100 tip + 100 match)
+        // 4. Assert campaign remaining_budget == 400
+        todo!("implement against live testnet")
+    }
+
+    /// Verifies sponsor can reclaim unused campaign funds after expiry.
+    #[test]
+    #[ignore]
+    fn test_campaign_fund_withdrawal_after_expiry() {
+        // 1. Sponsor creates campaign with duration=0 days (expires immediately)
+        // 2. Sponsor calls withdraw_campaign_funds
+        // 3. Assert sponsor balance restored
+        todo!("implement against live testnet")
+    }
+
+    /// Verifies that withdraw_campaign_funds fails while campaign is still active.
+    #[test]
+    #[ignore]
+    fn test_campaign_withdrawal_blocked_while_active() {
+        // 1. Sponsor creates campaign with duration=30 days
+        // 2. Sponsor immediately calls withdraw_campaign_funds → expect CampaignStillActive (35)
+        todo!("implement against live testnet")
+    }
+
+    /// Verifies multi-user concurrent tip scenario on testnet.
+    #[test]
+    #[ignore]
+    fn test_concurrent_tips_from_multiple_senders() {
+        // 1. Three senders each tip the same creator 100 stroops
+        // 2. Assert creator balance == 300
+        todo!("implement against live testnet")
+    }
+
+    /// Verifies network error recovery: re-submit after timeout.
+    #[test]
+    #[ignore]
+    fn test_network_failure_recovery() {
+        // 1. Submit a tip transaction
+        // 2. Simulate timeout by not waiting for confirmation
+        // 3. Re-query transaction status and confirm eventual consistency
+        todo!("implement against live testnet")
+    }
+
+    /// Verifies the pause / unpause flow on testnet.
+    #[test]
+    #[ignore]
+    fn test_pause_blocks_tips() {
+        // 1. Admin pauses contract
+        // 2. Sender attempts tip → expect ContractPaused (31)
+        // 3. Admin unpauses
+        // 4. Sender tips successfully
+        todo!("implement against live testnet")
+    }
+
+    /// Verifies emergency_withdraw bypasses limits on testnet.
+    #[test]
+    #[ignore]
+    fn test_emergency_withdraw_bypasses_limits() {
+        // 1. Admin sets daily_limit = 1 for creator
+        // 2. Creator has balance of 1000
+        // 3. Admin calls emergency_withdraw → succeeds despite limit
+        todo!("implement against live testnet")
     }
 }


### PR DESCRIPTION
closes #142  
closes #140 
closes #139 
closes #134 


## Deployment Documentation

- docs/DEPLOYMENT.md: end-to-end deployment guide covering build, testnet and mainnet deployment steps, configuration, rollback procedure, monitoring setup, and troubleshooting
- docs/MAINNET_CHECKLIST.md: gated pre-launch checklist with sections for security audit, code quality, testnet validation, configuration, monitoring, documentation sign-off, go/no-go approval, and post-deployment verification
- scripts/deploy-mainnet.sh: thin exec wrapper around deploy_mainnet.sh so both naming conventions (hyphen and underscore) work

## Withdrawal Limits & Cooldown (contracts/tipjar/src/lib.rs)

New types:
- WithdrawalLimits struct: daily_limit, cooldown_seconds, last_withdrawal, withdrawn_today, day_start

New DataKey variants:
- WithdrawalLimits(Address): per-creator limit state
- DefaultWithdrawalLimits: fallback limits for all creators

New error codes:
- DailyLimitExceeded = 32
- CooldownActive = 33

New public functions:
- set_default_withdrawal_limits(admin, daily_limit, cooldown_seconds)
- set_creator_withdrawal_limits(admin, creator, daily_limit, cooldown_seconds)
- emergency_withdraw(admin, creator, token): bypasses limits, admin only

Modified:
- withdraw: now calls check_and_update_withdrawal_limits before transferring; limits of 0 mean unlimited / no cooldown

## Matching Campaigns (contracts/tipjar/src/lib.rs)

New types:
- MatchingCampaign struct: sponsor, creator, token, match_ratio (basis points), total_budget, remaining_budget, start_time, end_time, active

New DataKey variants:
- MatchingCampaign(u64), CampaignCounter, CreatorCampaigns(Address)

New error codes:
- CampaignNotFound = 34
- CampaignStillActive = 35

New public functions:
- create_matching_campaign(sponsor, creator, token, match_ratio, budget, duration_days): transfers budget into escrow, returns campaign_id
- withdraw_campaign_funds(sponsor, campaign_id): sponsor reclaims unused budget after campaign expiry
- get_active_campaigns(creator): returns all non-expired campaigns

Modified:
- tip: calls apply_matching_campaigns after crediting creator; matched amounts are added to creator balance and emitted as ("match", creator) events

## Integration Tests (tests/integration_tests.rs)

- Added MatchingCampaign to imports
- Added testnet_integration module with 9 #[ignore] test stubs: test_tip_and_withdraw, test_withdrawal_daily_limit_enforced, test_withdrawal_cooldown, test_matching_campaign_flow, test_campaign_fund_withdrawal_after_expiry, test_campaign_withdrawal_blocked_while_active, test_concurrent_tips_from_multiple_senders, test_network_failure_recovery, test_pause_blocks_tips, test_emergency_withdraw_bypasses_limits
- Run ignored tests with: cargo test -- --ignored