### PR TITLE
feat(integration): build contract state migration tools

### DIFF
--- a/scripts/migrate/Cargo.toml
+++ b/scripts/migrate/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "migrate"
+version = "0.1.0"
+edition = "2021"
+description = "TipJar contract state migration toolkit — export, transform, import, verify, rollback"
+license = "MIT"
+
+[[bin]]
+name = "migrate"
+path = "main.rs"
+
+[[test]]
+name = "migration_tests"
+path = "tests/migration_tests.rs"
+
+[dependencies]
+serde       = { version = "1",    features = ["derive"] }
+serde_json  = "1"
+toml        = "0.8"
+sha2        = "0.10"
+hex         = "0.4"
+chrono      = { version = "0.4",  features = ["serde"] }
+
+[dev-dependencies]
+tempfile = "3"
+toml     = "0.8"

--- a/scripts/migrate/config.toml
+++ b/scripts/migrate/config.toml
@@ -1,0 +1,81 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# TipJar Contract State Migration Configuration
+# ─────────────────────────────────────────────────────────────────────────────
+# Copy this file to config.local.toml and fill in real values.
+# Never commit config.local.toml — it contains sensitive contract IDs.
+
+[migration]
+# Human-readable label for this migration run (used in history log).
+label = "v1-to-v2"
+
+# Source contract to export state from.
+source_contract_id = "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4"
+
+# Target contract to import state into.
+target_contract_id = "CBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBSC4"
+
+# Stellar network to operate on: "testnet" | "mainnet" | "futurenet" | "local"
+network = "testnet"
+
+# RPC endpoint for the chosen network.
+# Testnet:  https://soroban-testnet.stellar.org
+# Mainnet:  https://soroban-mainnet.stellar.org
+rpc_url = "https://soroban-testnet.stellar.org"
+
+# Network passphrase (must match `network`).
+# Testnet:  "Test SDF Network ; September 2015"
+# Mainnet:  "Public Global Stellar Network ; September 2015"
+network_passphrase = "Test SDF Network ; September 2015"
+
+# Admin secret key (Stellar keypair) that has upgrade/migrate authority.
+# Prefer loading from the environment variable MIGRATION_ADMIN_SECRET instead.
+# admin_secret = "S..."
+
+# ── Safety flags ──────────────────────────────────────────────────────────────
+
+# When true, the export and transform phases run normally but import is skipped.
+# No on-chain writes are performed.  Use this to validate the snapshot first.
+dry_run = true
+
+# Maximum number of RPC retry attempts per call before aborting.
+max_retries = 3
+
+# Delay in milliseconds between retry attempts.
+retry_delay_ms = 1000
+
+# ── Snapshot / backup ─────────────────────────────────────────────────────────
+
+# Directory where snapshot JSON files are written.
+snapshot_dir = "./migration-snapshots"
+
+# Filename for the pre-migration backup snapshot (relative to snapshot_dir).
+backup_filename = "pre-migration-backup.json"
+
+# Filename for the exported source snapshot (relative to snapshot_dir).
+export_filename = "source-snapshot.json"
+
+# Filename for the transformed snapshot ready for import (relative to snapshot_dir).
+transformed_filename = "transformed-snapshot.json"
+
+# ── History log ───────────────────────────────────────────────────────────────
+
+# Local file that accumulates migration run history.
+history_file = "./migration-history.json"
+
+# ── Schema version ────────────────────────────────────────────────────────────
+
+# Source schema version (matches ContractVersion stored on-chain).
+source_version = 1
+
+# Target schema version the transformed snapshot must conform to.
+target_version = 2
+
+# ── Batch / progress ──────────────────────────────────────────────────────────
+
+# Number of records to process per progress report line.
+progress_batch_size = 50
+
+# ── Verification ──────────────────────────────────────────────────────────────
+
+# Abort the import if verification detects any mismatch.
+abort_on_verify_failure = true

--- a/scripts/migrate/export_state.rs
+++ b/scripts/migrate/export_state.rs
@@ -1,0 +1,646 @@
+//! # State Export — `StateMigrator::export_state()`
+//!
+//! Reads all persistent and instance storage from the **source** TipJar
+//! contract and serialises it into a [`StateSnapshot`].
+//!
+//! ## Dry-run mode
+//! When `dry_run = true` in the config the export still runs in full (it is
+//! read-only by nature) but the snapshot is **not** written to disk.  This
+//! lets operators validate what would be exported without touching the
+//! filesystem.
+//!
+//! ## Progress reporting
+//! Progress is printed to stdout after every `config.progress_batch_size`
+//! records so long-running exports remain observable.
+//!
+//! ## Usage
+//! ```bash
+//! # Export with dry-run (no file written)
+//! cargo run --manifest-path scripts/migrate/Cargo.toml \
+//!     --bin export -- --config scripts/migrate/config.toml --dry-run
+//!
+//! # Full export (writes snapshot to disk)
+//! cargo run --manifest-path scripts/migrate/Cargo.toml \
+//!     --bin export -- --config scripts/migrate/config.toml
+//! ```
+
+use std::collections::HashMap;
+use std::fs;
+use std::path::Path;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use sha2::{Digest, Sha256};
+
+use crate::rpc_client::RpcClient;
+use crate::types::{
+    LeaderboardEntry, LockedTip, Milestone, MatchingProgram, MigrationConfig, StateSnapshot,
+    Subscription, SubscriptionStatus, TipMetadata, TipRecord, TimeLock,
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// StateMigrator
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Orchestrates the export, import, verify, and rollback phases.
+pub struct StateMigrator {
+    pub config: MigrationConfig,
+    pub rpc: RpcClient,
+}
+
+impl StateMigrator {
+    /// Creates a new migrator from a parsed config.
+    pub fn new(config: MigrationConfig) -> Self {
+        let rpc = RpcClient::new(
+            config.migration.rpc_url.clone(),
+            config.migration.max_retries,
+            config.migration.retry_delay_ms,
+        );
+        Self { config, rpc }
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // export_state
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /// Exports the complete on-chain state of the source contract into a
+    /// [`StateSnapshot`].
+    ///
+    /// # Dry-run behaviour
+    /// When `config.migration.dry_run` is `true` the snapshot is returned but
+    /// **not** written to disk.
+    ///
+    /// # Errors
+    /// Returns an error string if any RPC call fails after all retries.
+    pub fn export_state(&self) -> Result<StateSnapshot, String> {
+        let cfg = &self.config.migration;
+        let contract_id = &cfg.source_contract_id;
+
+        println!("╔══════════════════════════════════════════════════════════╗");
+        println!("║           TipJar State Export — v{:<26}║", cfg.source_version);
+        println!("╚══════════════════════════════════════════════════════════╝");
+        println!("  Contract : {}", contract_id);
+        println!("  Network  : {}", cfg.network);
+        println!("  Dry-run  : {}", cfg.dry_run);
+        println!();
+
+        // ── instance storage ─────────────────────────────────────────────────
+        println!("[1/9] Reading instance storage …");
+
+        let admin = self
+            .rpc
+            .get_instance_string(contract_id, "Admin")?;
+        let fee_basis_points = self
+            .rpc
+            .get_instance_u32(contract_id, "FeeBasisPoints")
+            .unwrap_or(0);
+        let refund_window_seconds = self
+            .rpc
+            .get_instance_u64(contract_id, "RefundWindow")
+            .unwrap_or(0);
+        let paused = self
+            .rpc
+            .get_instance_bool(contract_id, "Paused")
+            .unwrap_or(false);
+        let pause_reason = self
+            .rpc
+            .get_instance_string_opt(contract_id, "PauseReason");
+        let tip_counter = self
+            .rpc
+            .get_instance_u64(contract_id, "TipCounter")
+            .unwrap_or(0);
+        let matching_counter = self
+            .rpc
+            .get_instance_u64(contract_id, "MatchingCounter")
+            .unwrap_or(0);
+        let current_fee_bps = self
+            .rpc
+            .get_instance_u32(contract_id, "CurrentFeeBps")
+            .unwrap_or(100);
+        let schema_version = self
+            .rpc
+            .get_instance_u32(contract_id, "ContractVersion")
+            .unwrap_or(0);
+        let whitelisted_tokens = self
+            .rpc
+            .get_whitelisted_tokens(contract_id)?;
+
+        println!(
+            "    admin={}, fee_bps={}, paused={}, tip_counter={}, version={}",
+            admin, fee_basis_points, paused, tip_counter, schema_version
+        );
+
+        // ── creator balances & totals ─────────────────────────────────────────
+        println!("[2/9] Reading creator balances and totals …");
+        let (creator_balances, creator_totals) =
+            self.export_creator_financials(contract_id)?;
+        println!(
+            "    {} balance entries, {} total entries",
+            creator_balances.len(),
+            creator_totals.len()
+        );
+
+        // ── tip history ───────────────────────────────────────────────────────
+        println!("[3/9] Reading tip history …");
+        let tip_history = self.export_tip_history(contract_id, &creator_balances)?;
+        let total_tips: usize = tip_history.values().map(|v| v.len()).sum();
+        println!(
+            "    {} creators with {} total tip records",
+            tip_history.len(),
+            total_tips
+        );
+
+        // ── leaderboard aggregates ────────────────────────────────────────────
+        println!("[4/9] Reading leaderboard aggregates …");
+        let (tipper_aggregates, creator_aggregates) =
+            self.export_leaderboard_aggregates(contract_id)?;
+        println!(
+            "    {} tipper entries, {} creator entries",
+            tipper_aggregates.len(),
+            creator_aggregates.len()
+        );
+
+        // ── subscriptions ─────────────────────────────────────────────────────
+        println!("[5/9] Reading subscriptions …");
+        let subscriptions = self.export_subscriptions(contract_id)?;
+        println!("    {} subscriptions", subscriptions.len());
+
+        // ── time locks ────────────────────────────────────────────────────────
+        println!("[6/9] Reading time-locked tips …");
+        let time_locks = self.export_time_locks(contract_id)?;
+        println!("    {} time locks", time_locks.len());
+
+        // ── milestones ────────────────────────────────────────────────────────
+        println!("[7/9] Reading milestones …");
+        let milestones = self.export_milestones(contract_id, &creator_balances)?;
+        println!("    {} milestones", milestones.len());
+
+        // ── matching programs ─────────────────────────────────────────────────
+        println!("[8/9] Reading matching programs …");
+        let matching_programs = self.export_matching_programs(contract_id, matching_counter)?;
+        println!("    {} matching programs", matching_programs.len());
+
+        // ── tip records & locked tips ─────────────────────────────────────────
+        println!("[9/9] Reading tip records and locked tips …");
+        let tip_records = self.export_tip_records(contract_id, tip_counter)?;
+        let locked_tips = self.export_locked_tips(contract_id, &creator_balances)?;
+        let user_roles = self.export_user_roles(contract_id)?;
+        println!(
+            "    {} tip records, {} locked tips, {} role assignments",
+            tip_records.len(),
+            locked_tips.len(),
+            user_roles.len()
+        );
+
+        // ── ledger metadata ───────────────────────────────────────────────────
+        let ledger_sequence = self.rpc.get_latest_ledger_sequence()?;
+        let exported_at = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+
+        // ── assemble snapshot ─────────────────────────────────────────────────
+        let mut snapshot = StateSnapshot {
+            contract_id: contract_id.clone(),
+            schema_version,
+            exported_at,
+            ledger_sequence,
+            checksum: String::new(), // filled below
+            admin,
+            fee_basis_points,
+            refund_window_seconds,
+            paused,
+            pause_reason,
+            tip_counter,
+            matching_counter,
+            current_fee_bps,
+            whitelisted_tokens,
+            creator_balances,
+            creator_totals,
+            tip_history,
+            tipper_aggregates,
+            creator_aggregates,
+            subscriptions,
+            time_locks,
+            milestones,
+            matching_programs,
+            tip_records,
+            locked_tips,
+            user_roles,
+        };
+
+        // Seal with checksum.
+        snapshot.checksum = compute_checksum(&snapshot)?;
+
+        let total = snapshot.total_records();
+        println!();
+        println!("✓ Export complete — {} total records", total);
+        println!("  Checksum : {}", snapshot.checksum);
+
+        // ── persist to disk (skipped in dry-run) ──────────────────────────────
+        if cfg.dry_run {
+            println!("  [dry-run] Snapshot NOT written to disk.");
+        } else {
+            let dir = Path::new(&cfg.snapshot_dir);
+            fs::create_dir_all(dir)
+                .map_err(|e| format!("Failed to create snapshot dir: {}", e))?;
+            let path = dir.join(&cfg.export_filename);
+            let json = serde_json::to_string_pretty(&snapshot)
+                .map_err(|e| format!("Serialisation error: {}", e))?;
+            fs::write(&path, json)
+                .map_err(|e| format!("Failed to write snapshot: {}", e))?;
+            println!("  Snapshot written → {}", path.display());
+        }
+
+        Ok(snapshot)
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Private helpers
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /// Reads all `CreatorBalance` and `CreatorTotal` persistent entries.
+    fn export_creator_financials(
+        &self,
+        contract_id: &str,
+    ) -> Result<(HashMap<String, i128>, HashMap<String, i128>), String> {
+        let batch = self.config.migration.progress_batch_size;
+        let raw = self.rpc.scan_persistent_prefix(contract_id, "CreatorBalance")?;
+        let mut balances: HashMap<String, i128> = HashMap::new();
+        let mut totals: HashMap<String, i128> = HashMap::new();
+
+        for (i, (key, value)) in raw.iter().enumerate() {
+            // key format: "CreatorBalance:GCREATOR:GTOKEN"
+            let parts: Vec<&str> = key.splitn(3, ':').collect();
+            if parts.len() == 3 {
+                let composite = format!("{}:{}", parts[1], parts[2]);
+                let amount: i128 = value.parse().unwrap_or(0);
+                balances.insert(composite, amount);
+            }
+            if (i + 1) % batch == 0 {
+                println!("    … {} balance entries read", i + 1);
+            }
+        }
+
+        let raw_totals = self.rpc.scan_persistent_prefix(contract_id, "CreatorTotal")?;
+        for (i, (key, value)) in raw_totals.iter().enumerate() {
+            let parts: Vec<&str> = key.splitn(3, ':').collect();
+            if parts.len() == 3 {
+                let composite = format!("{}:{}", parts[1], parts[2]);
+                let amount: i128 = value.parse().unwrap_or(0);
+                totals.insert(composite, amount);
+            }
+            if (i + 1) % batch == 0 {
+                println!("    … {} total entries read", i + 1);
+            }
+        }
+
+        Ok((balances, totals))
+    }
+
+    /// Reads all `TipHistory` and `TipCount` entries for every known creator.
+    fn export_tip_history(
+        &self,
+        contract_id: &str,
+        creator_balances: &HashMap<String, i128>,
+    ) -> Result<HashMap<String, Vec<TipMetadata>>, String> {
+        let batch = self.config.migration.progress_batch_size;
+        // Derive the set of known creators from the balance map keys.
+        let creators: std::collections::HashSet<String> = creator_balances
+            .keys()
+            .filter_map(|k| k.split(':').next().map(|s| s.to_string()))
+            .collect();
+
+        let mut history: HashMap<String, Vec<TipMetadata>> = HashMap::new();
+        let mut total_read = 0usize;
+
+        for creator in &creators {
+            let count_key = format!("TipCount:{}", creator);
+            let count: u64 = self
+                .rpc
+                .get_persistent_u64(contract_id, &count_key)
+                .unwrap_or(0);
+
+            let mut tips: Vec<TipMetadata> = Vec::with_capacity(count as usize);
+            for idx in 0..count {
+                let tip_key = format!("TipHistory:{}:{}", creator, idx);
+                if let Some(meta) = self.rpc.get_persistent_tip_metadata(contract_id, &tip_key)? {
+                    tips.push(meta);
+                }
+                total_read += 1;
+                if total_read % batch == 0 {
+                    println!("    … {} tip history records read", total_read);
+                }
+            }
+            if !tips.is_empty() {
+                history.insert(creator.clone(), tips);
+            }
+        }
+
+        Ok(history)
+    }
+
+    /// Reads all `TipperAggregate`, `CreatorAggregate`, `TipperParticipants`,
+    /// and `CreatorParticipants` entries for bucket 0 (AllTime).
+    fn export_leaderboard_aggregates(
+        &self,
+        contract_id: &str,
+    ) -> Result<(HashMap<String, LeaderboardEntry>, HashMap<String, LeaderboardEntry>), String> {
+        let batch = self.config.migration.progress_batch_size;
+        const BUCKET_ALL_TIME: u32 = 0;
+
+        let tipper_part_key = format!("TipperParticipants:{}", BUCKET_ALL_TIME);
+        let tipper_addrs = self
+            .rpc
+            .get_persistent_address_vec(contract_id, &tipper_part_key)
+            .unwrap_or_default();
+
+        let creator_part_key = format!("CreatorParticipants:{}", BUCKET_ALL_TIME);
+        let creator_addrs = self
+            .rpc
+            .get_persistent_address_vec(contract_id, &creator_part_key)
+            .unwrap_or_default();
+
+        let mut tipper_agg: HashMap<String, LeaderboardEntry> = HashMap::new();
+        for (i, addr) in tipper_addrs.iter().enumerate() {
+            let agg_key = format!("TipperAggregate:{}:{}", addr, BUCKET_ALL_TIME);
+            if let Some(entry) = self
+                .rpc
+                .get_persistent_leaderboard_entry(contract_id, &agg_key)?
+            {
+                tipper_agg.insert(format!("{}:{}", addr, BUCKET_ALL_TIME), entry);
+            }
+            if (i + 1) % batch == 0 {
+                println!("    … {} tipper aggregates read", i + 1);
+            }
+        }
+
+        let mut creator_agg: HashMap<String, LeaderboardEntry> = HashMap::new();
+        for (i, addr) in creator_addrs.iter().enumerate() {
+            let agg_key = format!("CreatorAggregate:{}:{}", addr, BUCKET_ALL_TIME);
+            if let Some(entry) = self
+                .rpc
+                .get_persistent_leaderboard_entry(contract_id, &agg_key)?
+            {
+                creator_agg.insert(format!("{}:{}", addr, BUCKET_ALL_TIME), entry);
+            }
+            if (i + 1) % batch == 0 {
+                println!("    … {} creator aggregates read", i + 1);
+            }
+        }
+
+        Ok((tipper_agg, creator_agg))
+    }
+
+    /// Reads all `Subscription` entries.
+    fn export_subscriptions(
+        &self,
+        contract_id: &str,
+    ) -> Result<HashMap<String, Subscription>, String> {
+        let batch = self.config.migration.progress_batch_size;
+        let raw = self.rpc.scan_persistent_prefix(contract_id, "Subscription")?;
+        let mut subs: HashMap<String, Subscription> = HashMap::new();
+
+        for (i, (key, _)) in raw.iter().enumerate() {
+            // key: "Subscription:GSUBSCRIBER:GCREATOR"
+            let parts: Vec<&str> = key.splitn(3, ':').collect();
+            if parts.len() == 3 {
+                let sub_key = format!("{}:{}", parts[1], parts[2]);
+                if let Some(sub) = self
+                    .rpc
+                    .get_persistent_subscription(contract_id, key)?
+                {
+                    subs.insert(sub_key, sub);
+                }
+            }
+            if (i + 1) % batch == 0 {
+                println!("    … {} subscriptions read", i + 1);
+            }
+        }
+
+        Ok(subs)
+    }
+
+    /// Reads all `TimeLock` entries via `NextLockId` counter.
+    fn export_time_locks(&self, contract_id: &str) -> Result<Vec<TimeLock>, String> {
+        let batch = self.config.migration.progress_batch_size;
+        let next_id = self
+            .rpc
+            .get_persistent_u64(contract_id, "NextLockId")
+            .unwrap_or(0);
+
+        let mut locks: Vec<TimeLock> = Vec::new();
+        for id in 0..next_id {
+            let key = format!("TimeLock:{}", id);
+            if let Some(lock) = self.rpc.get_persistent_time_lock(contract_id, &key, id)? {
+                locks.push(lock);
+            }
+            if (id as usize + 1) % batch == 0 {
+                println!("    … {} time locks read", id + 1);
+            }
+        }
+
+        Ok(locks)
+    }
+
+    /// Reads all `Milestone` entries for every known creator.
+    fn export_milestones(
+        &self,
+        contract_id: &str,
+        creator_balances: &HashMap<String, i128>,
+    ) -> Result<HashMap<String, Milestone>, String> {
+        let batch = self.config.migration.progress_batch_size;
+        let creators: std::collections::HashSet<String> = creator_balances
+            .keys()
+            .filter_map(|k| k.split(':').next().map(|s| s.to_string()))
+            .collect();
+
+        let mut milestones: HashMap<String, Milestone> = HashMap::new();
+        let mut total_read = 0usize;
+
+        for creator in &creators {
+            let counter_key = format!("MilestoneCounter:{}", creator);
+            let count: u64 = self
+                .rpc
+                .get_persistent_u64(contract_id, &counter_key)
+                .unwrap_or(0);
+
+            for id in 0..count {
+                let key = format!("Milestone:{}:{}", creator, id);
+                if let Some(ms) = self.rpc.get_persistent_milestone(contract_id, &key)? {
+                    milestones.insert(format!("{}:{}", creator, id), ms);
+                }
+                total_read += 1;
+                if total_read % batch == 0 {
+                    println!("    … {} milestones read", total_read);
+                }
+            }
+        }
+
+        Ok(milestones)
+    }
+
+    /// Reads all `MatchingProgram` entries via the global counter.
+    fn export_matching_programs(
+        &self,
+        contract_id: &str,
+        counter: u64,
+    ) -> Result<Vec<MatchingProgram>, String> {
+        let batch = self.config.migration.progress_batch_size;
+        let mut programs: Vec<MatchingProgram> = Vec::new();
+
+        for id in 0..counter {
+            let key = format!("MatchingProgram:{}", id);
+            if let Some(prog) = self
+                .rpc
+                .get_persistent_matching_program(contract_id, &key)?
+            {
+                programs.push(prog);
+            }
+            if (id as usize + 1) % batch == 0 {
+                println!("    … {} matching programs read", id + 1);
+            }
+        }
+
+        Ok(programs)
+    }
+
+    /// Reads all global `TipRecord` entries via `TipCounter`.
+    fn export_tip_records(
+        &self,
+        contract_id: &str,
+        tip_counter: u64,
+    ) -> Result<Vec<TipRecord>, String> {
+        let batch = self.config.migration.progress_batch_size;
+        let mut records: Vec<TipRecord> = Vec::new();
+
+        for id in 0..tip_counter {
+            let key = format!("TipRecord:{}", id);
+            if let Some(rec) = self.rpc.get_persistent_tip_record(contract_id, &key)? {
+                records.push(rec);
+            }
+            if (id as usize + 1) % batch == 0 {
+                println!("    … {} tip records read", id + 1);
+            }
+        }
+
+        Ok(records)
+    }
+
+    /// Reads all `LockedTip` entries for every known creator.
+    fn export_locked_tips(
+        &self,
+        contract_id: &str,
+        creator_balances: &HashMap<String, i128>,
+    ) -> Result<Vec<LockedTip>, String> {
+        let batch = self.config.migration.progress_batch_size;
+        let creators: std::collections::HashSet<String> = creator_balances
+            .keys()
+            .filter_map(|k| k.split(':').next().map(|s| s.to_string()))
+            .collect();
+
+        let mut locked: Vec<LockedTip> = Vec::new();
+        let mut total_read = 0usize;
+
+        for creator in &creators {
+            let counter_key = format!("LockedTipCounter:{}", creator);
+            let count: u64 = self
+                .rpc
+                .get_persistent_u64(contract_id, &counter_key)
+                .unwrap_or(0);
+
+            for tip_id in 0..count {
+                let key = format!("LockedTip:{}:{}", creator, tip_id);
+                if let Some(lt) = self.rpc.get_persistent_locked_tip(contract_id, &key, tip_id)? {
+                    locked.push(lt);
+                }
+                total_read += 1;
+                if total_read % batch == 0 {
+                    println!("    … {} locked tips read", total_read);
+                }
+            }
+        }
+
+        Ok(locked)
+    }
+
+    /// Reads all `UserRole` entries.
+    fn export_user_roles(
+        &self,
+        contract_id: &str,
+    ) -> Result<HashMap<String, String>, String> {
+        let raw = self.rpc.scan_persistent_prefix(contract_id, "UserRole")?;
+        let mut roles: HashMap<String, String> = HashMap::new();
+
+        for (key, value) in raw {
+            // key: "UserRole:GADDRESS"
+            let parts: Vec<&str> = key.splitn(2, ':').collect();
+            if parts.len() == 2 {
+                roles.insert(parts[1].to_string(), value);
+            }
+        }
+
+        Ok(roles)
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Checksum helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Computes a SHA-256 checksum over the canonical JSON of the snapshot's data
+/// fields (everything except `checksum` itself).
+pub fn compute_checksum(snapshot: &StateSnapshot) -> Result<String, String> {
+    // Temporarily zero out the checksum field so the hash is deterministic.
+    let mut copy = snapshot.clone();
+    copy.checksum = String::new();
+
+    let canonical = serde_json::to_string(&copy)
+        .map_err(|e| format!("Checksum serialisation error: {}", e))?;
+
+    let mut hasher = Sha256::new();
+    hasher.update(canonical.as_bytes());
+    let result = hasher.finalize();
+    Ok(hex::encode(result))
+}
+
+/// Verifies that `snapshot.checksum` matches the recomputed checksum.
+pub fn verify_checksum(snapshot: &StateSnapshot) -> Result<(), String> {
+    let expected = compute_checksum(snapshot)?;
+    if snapshot.checksum != expected {
+        return Err(format!(
+            "Checksum mismatch: stored={}, computed={}",
+            snapshot.checksum, expected
+        ));
+    }
+    Ok(())
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// CLI entry point
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Parses CLI args, loads config, and runs the export.
+pub fn run_export(args: &[String]) -> Result<(), String> {
+    let config_path = parse_flag(args, "--config")
+        .unwrap_or_else(|| "scripts/migrate/config.toml".to_string());
+    let dry_run_override = args.contains(&"--dry-run".to_string());
+
+    let toml_str = std::fs::read_to_string(&config_path)
+        .map_err(|e| format!("Cannot read config {}: {}", config_path, e))?;
+    let mut config: MigrationConfig = toml::from_str(&toml_str)
+        .map_err(|e| format!("Config parse error: {}", e))?;
+
+    if dry_run_override {
+        config.migration.dry_run = true;
+    }
+
+    let migrator = StateMigrator::new(config);
+    migrator.export_state()?;
+    Ok(())
+}
+
+fn parse_flag(args: &[String], flag: &str) -> Option<String> {
+    args.windows(2)
+        .find(|w| w[0] == flag)
+        .map(|w| w[1].clone())
+}

--- a/scripts/migrate/history.rs
+++ b/scripts/migrate/history.rs
@@ -1,0 +1,130 @@
+//! Migration history log — persists every run to a local JSON file.
+//!
+//! The history file is a JSON object with a single `"runs"` array.
+//! Each entry records the outcome of one migration run so operators can
+//! audit what happened and when.
+
+use std::fs;
+use std::path::Path;
+
+use crate::types::{MigrationHistory, MigrationHistoryEntry};
+
+/// Appends `entry` to the history file at `path`.
+///
+/// Creates the file (and parent directories) if it does not exist.
+pub fn append_history_entry(path: &str, entry: MigrationHistoryEntry) -> Result<(), String> {
+    let file_path = Path::new(path);
+
+    // Load existing history or start fresh.
+    let mut history: MigrationHistory = if file_path.exists() {
+        let json = fs::read_to_string(file_path)
+            .map_err(|e| format!("Cannot read history file {}: {}", path, e))?;
+        serde_json::from_str(&json).unwrap_or_default()
+    } else {
+        MigrationHistory::default()
+    };
+
+    history.runs.push(entry);
+
+    // Write back.
+    if let Some(parent) = file_path.parent() {
+        fs::create_dir_all(parent)
+            .map_err(|e| format!("Cannot create history dir: {}", e))?;
+    }
+    let json = serde_json::to_string_pretty(&history)
+        .map_err(|e| format!("History serialisation error: {}", e))?;
+    fs::write(file_path, json)
+        .map_err(|e| format!("Cannot write history file {}: {}", path, e))?;
+
+    Ok(())
+}
+
+/// Reads and prints the migration history from `path`.
+pub fn print_history(path: &str) -> Result<(), String> {
+    let json = fs::read_to_string(path)
+        .map_err(|e| format!("Cannot read history file {}: {}", path, e))?;
+    let history: MigrationHistory = serde_json::from_str(&json)
+        .map_err(|e| format!("History parse error: {}", e))?;
+
+    println!("Migration History — {} run(s)", history.runs.len());
+    println!("{:-<70}", "");
+    for (i, run) in history.runs.iter().enumerate() {
+        println!(
+            "[{}] {} | {} → {} | {} | {:?} | exported={} imported={}{}",
+            i + 1,
+            run.started_at,
+            run.source_contract_id,
+            run.target_contract_id,
+            run.network,
+            run.status,
+            run.records_exported,
+            run.records_imported,
+            run.error
+                .as_deref()
+                .map(|e| format!(" | ERROR: {}", e))
+                .unwrap_or_default(),
+        );
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::MigrationStatus;
+    use std::fs;
+
+    #[test]
+    fn test_append_and_read_history() {
+        let path = "/tmp/test-migration-history.json";
+        // Clean up from previous runs.
+        let _ = fs::remove_file(path);
+
+        let entry = MigrationHistoryEntry {
+            started_at: "2024-01-01T00:00:00Z".into(),
+            finished_at: "2024-01-01T00:01:00Z".into(),
+            label: "test-run".into(),
+            source_contract_id: "CSOURCE".into(),
+            target_contract_id: "CTARGET".into(),
+            network: "testnet".into(),
+            dry_run: false,
+            status: MigrationStatus::Success,
+            records_exported: 100,
+            records_imported: 100,
+            error: None,
+            backup_path: Some("/tmp/backup.json".into()),
+        };
+
+        append_history_entry(path, entry.clone()).unwrap();
+
+        let json = fs::read_to_string(path).unwrap();
+        let history: MigrationHistory = serde_json::from_str(&json).unwrap();
+        assert_eq!(history.runs.len(), 1);
+        assert_eq!(history.runs[0].label, "test-run");
+        assert_eq!(history.runs[0].records_exported, 100);
+
+        // Append a second entry.
+        let entry2 = MigrationHistoryEntry {
+            started_at: "2024-01-02T00:00:00Z".into(),
+            finished_at: "2024-01-02T00:01:00Z".into(),
+            label: "test-run-2".into(),
+            source_contract_id: "CSOURCE".into(),
+            target_contract_id: "CTARGET".into(),
+            network: "testnet".into(),
+            dry_run: true,
+            status: MigrationStatus::DryRun,
+            records_exported: 50,
+            records_imported: 0,
+            error: None,
+            backup_path: None,
+        };
+        append_history_entry(path, entry2).unwrap();
+
+        let json2 = fs::read_to_string(path).unwrap();
+        let history2: MigrationHistory = serde_json::from_str(&json2).unwrap();
+        assert_eq!(history2.runs.len(), 2);
+        assert_eq!(history2.runs[1].status, MigrationStatus::DryRun);
+
+        fs::remove_file(path).unwrap();
+    }
+}

--- a/scripts/migrate/import_state.rs
+++ b/scripts/migrate/import_state.rs
@@ -1,0 +1,477 @@
+//! # State Import — `StateMigrator::import_state()`
+//!
+//! Imports a transformed [`StateSnapshot`] into the **target** TipJar contract
+//! atomically.  Before any write the current target state is backed up so that
+//! [`rollback`] can restore it if anything goes wrong.
+//!
+//! ## Atomicity guarantee
+//! Soroban does not expose multi-key atomic transactions from off-chain tooling,
+//! so we achieve logical atomicity through the following protocol:
+//!
+//! 1. **Backup** — export the target contract's current state to a backup file.
+//! 2. **Pause** — pause the target contract so no user transactions can race.
+//! 3. **Import** — write every record in the snapshot to the target contract.
+//!    If any write fails the loop aborts immediately.
+//! 4. **Verify** — run [`verify_migration`] to confirm every record landed.
+//! 5. **Unpause** — resume normal operations.
+//!
+//! If step 3 or 4 fails, [`rollback`] is called automatically, which re-imports
+//! the backup snapshot and unpauses the contract.
+//!
+//! ## Dry-run mode
+//! When `config.migration.dry_run` is `true` steps 2–5 are skipped entirely.
+//! The snapshot is validated and progress is reported but nothing is written.
+//!
+//! ## Usage
+//! ```bash
+//! cargo run --manifest-path scripts/migrate/Cargo.toml \
+//!     --bin import -- --config scripts/migrate/config.toml
+//! ```
+
+use std::fs;
+use std::path::Path;
+
+use crate::export_state::{StateMigrator, verify_checksum};
+use crate::history::append_history_entry;
+use crate::types::{
+    MigrationConfig, MigrationHistoryEntry, MigrationStatus, StateSnapshot,
+};
+use crate::verify_migration::VerificationEngine;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Import implementation on StateMigrator
+// ─────────────────────────────────────────────────────────────────────────────
+
+impl StateMigrator {
+    /// Imports `snapshot` into the target contract.
+    ///
+    /// Returns the number of records successfully imported.
+    ///
+    /// # Errors
+    /// Returns an error string if the import fails.  The contract is left in a
+    /// paused state; call [`rollback`] to restore the backup.
+    pub fn import_state(&self, snapshot: &StateSnapshot) -> Result<usize, String> {
+        let cfg = &self.config.migration;
+        let target = &cfg.target_contract_id;
+        let started_at = iso_now();
+
+        println!("╔══════════════════════════════════════════════════════════╗");
+        println!("║           TipJar State Import — v{:<26}║", snapshot.schema_version);
+        println!("╚══════════════════════════════════════════════════════════╝");
+        println!("  Target   : {}", target);
+        println!("  Network  : {}", cfg.network);
+        println!("  Dry-run  : {}", cfg.dry_run);
+        println!("  Records  : {}", snapshot.total_records());
+        println!();
+
+        // ── 0. Verify snapshot checksum ───────────────────────────────────────
+        println!("[0/7] Verifying snapshot checksum …");
+        verify_checksum(snapshot)?;
+        println!("    ✓ Checksum OK");
+
+        if cfg.dry_run {
+            println!();
+            println!("[dry-run] All import steps skipped — no on-chain writes performed.");
+            self.record_history(
+                &started_at,
+                snapshot.total_records(),
+                0,
+                MigrationStatus::DryRun,
+                None,
+                None,
+            );
+            return Ok(0);
+        }
+
+        // ── 1. Backup current target state ────────────────────────────────────
+        println!("[1/7] Creating pre-migration backup of target contract …");
+        let backup_path = self.create_backup(target)?;
+        println!("    ✓ Backup written → {}", backup_path);
+
+        // ── 2. Pause target contract ──────────────────────────────────────────
+        println!("[2/7] Pausing target contract …");
+        self.rpc
+            .invoke_contract(
+                target,
+                "pause",
+                &[
+                    ("admin", &cfg.source_contract_id), // admin key from env
+                    ("reason", "state-migration-in-progress"),
+                ],
+            )
+            .map_err(|e| format!("Failed to pause target contract: {}", e))?;
+        println!("    ✓ Contract paused");
+
+        // ── 3. Import records ─────────────────────────────────────────────────
+        println!("[3/7] Importing records …");
+        let import_result = self.do_import(snapshot, target);
+
+        match import_result {
+            Err(ref e) => {
+                eprintln!("    ✗ Import failed: {}", e);
+                eprintln!("    Initiating automatic rollback …");
+                let rollback_result = self.rollback(&backup_path, target);
+                let status = MigrationStatus::RolledBack;
+                self.record_history(
+                    &started_at,
+                    snapshot.total_records(),
+                    0,
+                    status,
+                    Some(e.clone()),
+                    Some(backup_path.clone()),
+                );
+                rollback_result?;
+                return Err(format!("Import failed and was rolled back: {}", e));
+            }
+            Ok(imported) => {
+                println!("    ✓ {} records imported", imported);
+
+                // ── 4. Verify ─────────────────────────────────────────────────
+                println!("[4/7] Verifying migration …");
+                let verifier = VerificationEngine::new(self.config.clone());
+                let report = verifier.verify_migration(snapshot, target)?;
+
+                if !report.is_clean() {
+                    let err = format!(
+                        "Verification failed with {} finding(s). Rolling back.",
+                        report.findings.len()
+                    );
+                    eprintln!("    ✗ {}", err);
+                    for f in &report.findings {
+                        eprintln!(
+                            "      [{:?}] {} — expected={} actual={}",
+                            f.severity, f.field, f.expected, f.actual
+                        );
+                    }
+                    let rollback_result = self.rollback(&backup_path, target);
+                    self.record_history(
+                        &started_at,
+                        snapshot.total_records(),
+                        imported,
+                        MigrationStatus::RolledBack,
+                        Some(err.clone()),
+                        Some(backup_path.clone()),
+                    );
+                    rollback_result?;
+                    return Err(err);
+                }
+                println!("    ✓ Verification passed — {} records checked", report.records_checked);
+
+                // ── 5. Unpause ────────────────────────────────────────────────
+                println!("[5/7] Unpausing target contract …");
+                self.rpc
+                    .invoke_contract(
+                        target,
+                        "unpause",
+                        &[("admin", &cfg.source_contract_id)],
+                    )
+                    .map_err(|e| format!("Failed to unpause target contract: {}", e))?;
+                println!("    ✓ Contract unpaused");
+
+                // ── 6. Write verification report ──────────────────────────────
+                println!("[6/7] Writing verification report …");
+                let report_path = format!(
+                    "{}/verification-report.json",
+                    cfg.snapshot_dir
+                );
+                let report_json = serde_json::to_string_pretty(&report)
+                    .map_err(|e| format!("Report serialisation error: {}", e))?;
+                fs::write(&report_path, report_json)
+                    .map_err(|e| format!("Failed to write report: {}", e))?;
+                println!("    ✓ Report written → {}", report_path);
+
+                // ── 7. Record history ─────────────────────────────────────────
+                println!("[7/7] Recording migration history …");
+                self.record_history(
+                    &started_at,
+                    snapshot.total_records(),
+                    imported,
+                    MigrationStatus::Success,
+                    None,
+                    Some(backup_path),
+                );
+                println!("    ✓ History updated → {}", cfg.history_file);
+
+                println!();
+                println!("✓ Migration complete — {} records imported", imported);
+                Ok(imported)
+            }
+        }
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Rollback
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /// Restores the target contract to the state captured in `backup_path`.
+    ///
+    /// This re-imports the backup snapshot and unpauses the contract.
+    pub fn rollback(&self, backup_path: &str, target: &str) -> Result<(), String> {
+        println!();
+        println!("╔══════════════════════════════════════════════════════════╗");
+        println!("║                   ROLLBACK IN PROGRESS                  ║");
+        println!("╚══════════════════════════════════════════════════════════╝");
+        println!("  Backup : {}", backup_path);
+
+        let json = fs::read_to_string(backup_path)
+            .map_err(|e| format!("Cannot read backup {}: {}", backup_path, e))?;
+        let backup: StateSnapshot = serde_json::from_str(&json)
+            .map_err(|e| format!("Backup parse error: {}", e))?;
+
+        verify_checksum(&backup)?;
+
+        println!("  Restoring {} records …", backup.total_records());
+        let restored = self.do_import(&backup, target)?;
+
+        // Unpause after rollback.
+        self.rpc
+            .invoke_contract(
+                target,
+                "unpause",
+                &[("admin", &self.config.migration.source_contract_id)],
+            )
+            .map_err(|e| format!("Failed to unpause after rollback: {}", e))?;
+
+        println!("✓ Rollback complete — {} records restored", restored);
+        Ok(())
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Private helpers
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /// Writes every record in `snapshot` to `target` via RPC calls.
+    /// Returns the number of records written.
+    fn do_import(&self, snapshot: &StateSnapshot, target: &str) -> Result<usize, String> {
+        let batch = self.config.migration.progress_batch_size;
+        let mut count = 0usize;
+
+        // ── instance storage ──────────────────────────────────────────────────
+        self.rpc.set_instance_value(target, "Admin", &snapshot.admin)?;
+        self.rpc.set_instance_value(target, "FeeBasisPoints", &snapshot.fee_basis_points.to_string())?;
+        self.rpc.set_instance_value(target, "RefundWindow", &snapshot.refund_window_seconds.to_string())?;
+        self.rpc.set_instance_value(target, "TipCounter", &snapshot.tip_counter.to_string())?;
+        self.rpc.set_instance_value(target, "MatchingCounter", &snapshot.matching_counter.to_string())?;
+        self.rpc.set_instance_value(target, "CurrentFeeBps", &snapshot.current_fee_bps.to_string())?;
+        self.rpc.set_instance_value(target, "ContractVersion", &snapshot.schema_version.to_string())?;
+        count += 7;
+
+        for token in &snapshot.whitelisted_tokens {
+            self.rpc.whitelist_token(target, token)?;
+            count += 1;
+        }
+
+        // ── creator balances ──────────────────────────────────────────────────
+        for (key, balance) in &snapshot.creator_balances {
+            let parts: Vec<&str> = key.splitn(2, ':').collect();
+            if parts.len() == 2 {
+                self.rpc.set_creator_balance(target, parts[0], parts[1], *balance)?;
+                count += 1;
+                if count % batch == 0 {
+                    println!("    … {} records imported", count);
+                }
+            }
+        }
+
+        // ── creator totals ────────────────────────────────────────────────────
+        for (key, total) in &snapshot.creator_totals {
+            let parts: Vec<&str> = key.splitn(2, ':').collect();
+            if parts.len() == 2 {
+                self.rpc.set_creator_total(target, parts[0], parts[1], *total)?;
+                count += 1;
+                if count % batch == 0 {
+                    println!("    … {} records imported", count);
+                }
+            }
+        }
+
+        // ── tip history ───────────────────────────────────────────────────────
+        for (creator, tips) in &snapshot.tip_history {
+            self.rpc.set_tip_count(target, creator, tips.len() as u64)?;
+            for (idx, meta) in tips.iter().enumerate() {
+                self.rpc.set_tip_history_entry(target, creator, idx as u64, meta)?;
+                count += 1;
+                if count % batch == 0 {
+                    println!("    … {} records imported", count);
+                }
+            }
+        }
+
+        // ── leaderboard aggregates ────────────────────────────────────────────
+        for (key, entry) in &snapshot.tipper_aggregates {
+            let parts: Vec<&str> = key.splitn(2, ':').collect();
+            if parts.len() == 2 {
+                let bucket: u32 = parts[1].parse().unwrap_or(0);
+                self.rpc.set_tipper_aggregate(target, parts[0], bucket, entry)?;
+                count += 1;
+            }
+        }
+        for (key, entry) in &snapshot.creator_aggregates {
+            let parts: Vec<&str> = key.splitn(2, ':').collect();
+            if parts.len() == 2 {
+                let bucket: u32 = parts[1].parse().unwrap_or(0);
+                self.rpc.set_creator_aggregate(target, parts[0], bucket, entry)?;
+                count += 1;
+            }
+        }
+
+        // ── subscriptions ─────────────────────────────────────────────────────
+        for sub in snapshot.subscriptions.values() {
+            self.rpc.set_subscription(target, sub)?;
+            count += 1;
+            if count % batch == 0 {
+                println!("    … {} records imported", count);
+            }
+        }
+
+        // ── time locks ────────────────────────────────────────────────────────
+        let mut max_lock_id = 0u64;
+        for lock in &snapshot.time_locks {
+            self.rpc.set_time_lock(target, lock)?;
+            if lock.lock_id >= max_lock_id {
+                max_lock_id = lock.lock_id + 1;
+            }
+            count += 1;
+        }
+        if !snapshot.time_locks.is_empty() {
+            self.rpc.set_instance_value(target, "NextLockId", &max_lock_id.to_string())?;
+        }
+
+        // ── milestones ────────────────────────────────────────────────────────
+        for (key, ms) in &snapshot.milestones {
+            let parts: Vec<&str> = key.splitn(2, ':').collect();
+            if parts.len() == 2 {
+                self.rpc.set_milestone(target, parts[0], ms)?;
+                count += 1;
+            }
+        }
+
+        // ── matching programs ─────────────────────────────────────────────────
+        for prog in &snapshot.matching_programs {
+            self.rpc.set_matching_program(target, prog)?;
+            count += 1;
+        }
+
+        // ── tip records ───────────────────────────────────────────────────────
+        for rec in &snapshot.tip_records {
+            self.rpc.set_tip_record(target, rec)?;
+            count += 1;
+            if count % batch == 0 {
+                println!("    … {} records imported", count);
+            }
+        }
+
+        // ── locked tips ───────────────────────────────────────────────────────
+        for lt in &snapshot.locked_tips {
+            self.rpc.set_locked_tip(target, lt)?;
+            count += 1;
+        }
+
+        // ── user roles ────────────────────────────────────────────────────────
+        for (addr, role) in &snapshot.user_roles {
+            self.rpc.set_user_role(target, addr, role)?;
+            count += 1;
+        }
+
+        Ok(count)
+    }
+
+    /// Exports the current state of `target` and writes it to the backup path.
+    fn create_backup(&self, target: &str) -> Result<String, String> {
+        let cfg = &self.config.migration;
+        let dir = Path::new(&cfg.snapshot_dir);
+        fs::create_dir_all(dir)
+            .map_err(|e| format!("Failed to create snapshot dir: {}", e))?;
+
+        // Point the migrator at the target for export, force dry_run=false
+        // so the backup is actually written to disk.
+        let mut backup_cfg = self.config.clone();
+        backup_cfg.migration.dry_run = false;
+        backup_cfg.migration.source_contract_id = target.to_string();
+        backup_cfg.migration.export_filename = cfg.backup_filename.clone();
+        let backup_migrator = StateMigrator::new(backup_cfg);
+
+        backup_migrator.export_state()?;
+
+        let path = dir.join(&cfg.backup_filename);
+        Ok(path.to_string_lossy().to_string())
+    }
+
+    /// Appends a run entry to the migration history file.
+    fn record_history(
+        &self,
+        started_at: &str,
+        records_exported: usize,
+        records_imported: usize,
+        status: MigrationStatus,
+        error: Option<String>,
+        backup_path: Option<String>,
+    ) {
+        let cfg = &self.config.migration;
+        let entry = MigrationHistoryEntry {
+            started_at: started_at.to_string(),
+            finished_at: iso_now(),
+            label: cfg.label.clone(),
+            source_contract_id: cfg.source_contract_id.clone(),
+            target_contract_id: cfg.target_contract_id.clone(),
+            network: cfg.network.clone(),
+            dry_run: cfg.dry_run,
+            status,
+            records_exported,
+            records_imported,
+            error,
+            backup_path,
+        };
+        if let Err(e) = append_history_entry(&cfg.history_file, entry) {
+            eprintln!("Warning: failed to write migration history: {}", e);
+        }
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// CLI entry point
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Loads a transformed snapshot from disk and imports it into the target contract.
+pub fn run_import(args: &[String]) -> Result<(), String> {
+    let config_path = parse_flag(args, "--config")
+        .unwrap_or_else(|| "scripts/migrate/config.toml".to_string());
+    let input_override = parse_flag(args, "--input");
+    let dry_run_override = args.contains(&"--dry-run".to_string());
+
+    let toml_str = fs::read_to_string(&config_path)
+        .map_err(|e| format!("Cannot read config {}: {}", config_path, e))?;
+    let mut config: MigrationConfig = toml::from_str(&toml_str)
+        .map_err(|e| format!("Config parse error: {}", e))?;
+
+    if dry_run_override {
+        config.migration.dry_run = true;
+    }
+
+    let input_path = input_override.unwrap_or_else(|| {
+        format!(
+            "{}/{}",
+            config.migration.snapshot_dir, config.migration.transformed_filename
+        )
+    });
+
+    let json = fs::read_to_string(&input_path)
+        .map_err(|e| format!("Cannot read snapshot {}: {}", input_path, e))?;
+    let snapshot: StateSnapshot = serde_json::from_str(&json)
+        .map_err(|e| format!("Snapshot parse error: {}", e))?;
+
+    let migrator = StateMigrator::new(config);
+    migrator.import_state(&snapshot)?;
+    Ok(())
+}
+
+fn parse_flag(args: &[String], flag: &str) -> Option<String> {
+    args.windows(2)
+        .find(|w| w[0] == flag)
+        .map(|w| w[1].clone())
+}
+
+fn iso_now() -> String {
+    use chrono::Utc;
+    Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string()
+}

--- a/scripts/migrate/main.rs
+++ b/scripts/migrate/main.rs
@@ -1,0 +1,152 @@
+//! TipJar Contract State Migration Toolkit
+//!
+//! # Subcommands
+//! | Command     | Description                                              |
+//! |-------------|----------------------------------------------------------|
+//! | `export`    | Export source contract state to a JSON snapshot          |
+//! | `transform` | Apply schema transformation rules to a snapshot          |
+//! | `import`    | Import a transformed snapshot into the target contract   |
+//! | `verify`    | Compare snapshot against live target contract state      |
+//! | `rollback`  | Restore target contract from a backup snapshot           |
+//! | `history`   | Print the migration history log                          |
+//!
+//! # Quick start
+//! ```bash
+//! # 1. Copy and edit the config
+//! cp scripts/migrate/config.toml config.local.toml
+//! # (edit source_contract_id, target_contract_id, network, dry_run)
+//!
+//! # 2. Export (dry-run first)
+//! cargo run --bin migrate -- export --config config.local.toml --dry-run
+//!
+//! # 3. Transform
+//! cargo run --bin migrate -- transform --config config.local.toml
+//!
+//! # 4. Import (dry-run first)
+//! cargo run --bin migrate -- import --config config.local.toml --dry-run
+//!
+//! # 5. Import for real
+//! cargo run --bin migrate -- import --config config.local.toml
+//!
+//! # 6. Verify
+//! cargo run --bin migrate -- verify --config config.local.toml
+//!
+//! # 7. View history
+//! cargo run --bin migrate -- history --config config.local.toml
+//! ```
+
+mod export_state;
+mod history;
+mod import_state;
+mod rpc_client;
+mod transform_state;
+mod types;
+mod verify_migration;
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+
+    if args.len() < 2 {
+        print_usage();
+        std::process::exit(1);
+    }
+
+    let result = match args[1].as_str() {
+        "export" => export_state::run_export(&args[2..].to_vec()),
+        "transform" => transform_state::run_transform(&args[2..].to_vec()),
+        "import" => import_state::run_import(&args[2..].to_vec()),
+        "verify" => verify_migration::run_verify(&args[2..].to_vec()),
+        "rollback" => run_rollback(&args[2..].to_vec()),
+        "history" => run_history(&args[2..].to_vec()),
+        "help" | "--help" | "-h" => {
+            print_usage();
+            Ok(())
+        }
+        cmd => Err(format!("Unknown subcommand: '{}'. Run with 'help' for usage.", cmd)),
+    };
+
+    if let Err(e) = result {
+        eprintln!("Error: {}", e);
+        std::process::exit(1);
+    }
+}
+
+fn run_rollback(args: &[String]) -> Result<(), String> {
+    let config_path = parse_flag(args, "--config")
+        .unwrap_or_else(|| "scripts/migrate/config.toml".to_string());
+    let backup_override = parse_flag(args, "--backup");
+
+    let toml_str = std::fs::read_to_string(&config_path)
+        .map_err(|e| format!("Cannot read config {}: {}", config_path, e))?;
+    let config: types::MigrationConfig = toml::from_str(&toml_str)
+        .map_err(|e| format!("Config parse error: {}", e))?;
+
+    let backup_path = backup_override.unwrap_or_else(|| {
+        format!(
+            "{}/{}",
+            config.migration.snapshot_dir, config.migration.backup_filename
+        )
+    });
+
+    let migrator = export_state::StateMigrator::new(config.clone());
+    migrator.rollback(&backup_path, &config.migration.target_contract_id)?;
+    Ok(())
+}
+
+fn run_history(args: &[String]) -> Result<(), String> {
+    let config_path = parse_flag(args, "--config")
+        .unwrap_or_else(|| "scripts/migrate/config.toml".to_string());
+
+    let toml_str = std::fs::read_to_string(&config_path)
+        .map_err(|e| format!("Cannot read config {}: {}", config_path, e))?;
+    let config: types::MigrationConfig = toml::from_str(&toml_str)
+        .map_err(|e| format!("Config parse error: {}", e))?;
+
+    history::print_history(&config.migration.history_file)
+}
+
+fn parse_flag(args: &[String], flag: &str) -> Option<String> {
+    args.windows(2)
+        .find(|w| w[0] == flag)
+        .map(|w| w[1].clone())
+}
+
+fn print_usage() {
+    println!(
+        r#"
+TipJar Contract State Migration Toolkit
+
+USAGE:
+    migrate <SUBCOMMAND> [OPTIONS]
+
+SUBCOMMANDS:
+    export      Export source contract state to a JSON snapshot
+    transform   Apply schema transformation rules to a snapshot
+    import      Import a transformed snapshot into the target contract
+    verify      Compare snapshot against live target contract state
+    rollback    Restore target contract from a backup snapshot
+    history     Print the migration history log
+    help        Print this help message
+
+OPTIONS (all subcommands):
+    --config <PATH>     Path to config.toml  [default: scripts/migrate/config.toml]
+    --dry-run           Override config dry_run to true (export/import only)
+
+OPTIONS (transform):
+    --input  <PATH>     Input snapshot path  [default: from config]
+    --output <PATH>     Output snapshot path [default: from config]
+    --from-version <N>  Source schema version override
+    --to-version   <N>  Target schema version override
+
+OPTIONS (verify):
+    --snapshot <PATH>   Snapshot to verify against [default: transformed snapshot]
+
+OPTIONS (rollback):
+    --backup <PATH>     Backup snapshot to restore from [default: from config]
+
+ENVIRONMENT VARIABLES:
+    MIGRATION_ADMIN_SECRET    Stellar secret key for signing write transactions
+    MIGRATION_ADMIN_ADDRESS   Stellar public key of the admin account
+"#
+    );
+}

--- a/scripts/migrate/rpc_client.rs
+++ b/scripts/migrate/rpc_client.rs
@@ -1,0 +1,621 @@
+//! Thin RPC client that wraps `stellar contract` CLI calls.
+//!
+//! All on-chain reads and writes go through this module so the rest of the
+//! toolkit stays decoupled from the Stellar RPC wire format.
+//!
+//! In production this would use the Stellar XDR / Horizon SDK directly.
+//! For portability the current implementation shells out to the `stellar`
+//! CLI, which is always available in CI and developer environments.
+
+use std::process::Command;
+use std::thread;
+use std::time::Duration;
+
+use crate::types::{
+    LeaderboardEntry, LockedTip, MatchingProgram, Milestone, Subscription,
+    TipMetadata, TipRecord, TimeLock,
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// RpcClient
+// ─────────────────────────────────────────────────────────────────────────────
+
+pub struct RpcClient {
+    rpc_url: String,
+    max_retries: u32,
+    retry_delay_ms: u64,
+}
+
+impl RpcClient {
+    pub fn new(rpc_url: String, max_retries: u32, retry_delay_ms: u64) -> Self {
+        Self {
+            rpc_url,
+            max_retries,
+            retry_delay_ms,
+        }
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Generic helpers
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /// Runs a `stellar contract invoke` read call with retry logic.
+    fn invoke_read(&self, contract_id: &str, function: &str, args: &[(&str, &str)]) -> Result<String, String> {
+        let mut attempt = 0u32;
+        loop {
+            let mut cmd = Command::new("stellar");
+            cmd.args(["contract", "invoke", "--id", contract_id, "--rpc-url", &self.rpc_url, "--"]);
+            cmd.arg(function);
+            for (k, v) in args {
+                cmd.arg(format!("--{}", k));
+                cmd.arg(v);
+            }
+            match cmd.output() {
+                Ok(out) if out.status.success() => {
+                    return Ok(String::from_utf8_lossy(&out.stdout).trim().to_string());
+                }
+                Ok(out) => {
+                    let err = String::from_utf8_lossy(&out.stderr).to_string();
+                    if attempt >= self.max_retries {
+                        return Err(format!("RPC call {}::{} failed: {}", contract_id, function, err));
+                    }
+                }
+                Err(e) => {
+                    if attempt >= self.max_retries {
+                        return Err(format!("RPC call {}::{} error: {}", contract_id, function, e));
+                    }
+                }
+            }
+            attempt += 1;
+            thread::sleep(Duration::from_millis(self.retry_delay_ms));
+        }
+    }
+
+    /// Runs a `stellar contract invoke` write call (requires source key).
+    pub fn invoke_contract(
+        &self,
+        contract_id: &str,
+        function: &str,
+        args: &[(&str, &str)],
+    ) -> Result<String, String> {
+        // The admin secret key is read from the environment variable
+        // MIGRATION_ADMIN_SECRET to avoid it appearing in process args.
+        let secret = std::env::var("MIGRATION_ADMIN_SECRET")
+            .map_err(|_| "MIGRATION_ADMIN_SECRET env var not set".to_string())?;
+
+        let mut attempt = 0u32;
+        loop {
+            let mut cmd = Command::new("stellar");
+            cmd.args([
+                "contract", "invoke",
+                "--id", contract_id,
+                "--rpc-url", &self.rpc_url,
+                "--source", &secret,
+                "--",
+            ]);
+            cmd.arg(function);
+            for (k, v) in args {
+                cmd.arg(format!("--{}", k));
+                cmd.arg(v);
+            }
+            match cmd.output() {
+                Ok(out) if out.status.success() => {
+                    return Ok(String::from_utf8_lossy(&out.stdout).trim().to_string());
+                }
+                Ok(out) => {
+                    let err = String::from_utf8_lossy(&out.stderr).to_string();
+                    if attempt >= self.max_retries {
+                        return Err(format!("Write call {}::{} failed: {}", contract_id, function, err));
+                    }
+                }
+                Err(e) => {
+                    if attempt >= self.max_retries {
+                        return Err(format!("Write call {}::{} error: {}", contract_id, function, e));
+                    }
+                }
+            }
+            attempt += 1;
+            thread::sleep(Duration::from_millis(self.retry_delay_ms));
+        }
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Instance storage reads
+    // ─────────────────────────────────────────────────────────────────────────
+
+    pub fn get_instance_string(&self, contract_id: &str, key: &str) -> Result<String, String> {
+        self.invoke_read(contract_id, &format!("get_{}", to_snake(key)), &[])
+    }
+
+    pub fn get_instance_string_opt(&self, contract_id: &str, key: &str) -> Option<String> {
+        self.invoke_read(contract_id, &format!("get_{}", to_snake(key)), &[]).ok()
+    }
+
+    pub fn get_instance_u32(&self, contract_id: &str, key: &str) -> Option<u32> {
+        self.invoke_read(contract_id, &format!("get_{}", to_snake(key)), &[])
+            .ok()
+            .and_then(|s| s.trim_matches('"').parse().ok())
+    }
+
+    pub fn get_instance_u64(&self, contract_id: &str, key: &str) -> Option<u64> {
+        self.invoke_read(contract_id, &format!("get_{}", to_snake(key)), &[])
+            .ok()
+            .and_then(|s| s.trim_matches('"').parse().ok())
+    }
+
+    pub fn get_instance_bool(&self, contract_id: &str, key: &str) -> Option<bool> {
+        self.invoke_read(contract_id, &format!("get_{}", to_snake(key)), &[])
+            .ok()
+            .and_then(|s| match s.trim_matches('"') {
+                "true" => Some(true),
+                "false" => Some(false),
+                _ => None,
+            })
+    }
+
+    pub fn get_latest_ledger_sequence(&self) -> Result<u32, String> {
+        let out = Command::new("stellar")
+            .args(["ledger", "latest", "--rpc-url", &self.rpc_url])
+            .output()
+            .map_err(|e| format!("ledger latest error: {}", e))?;
+        let text = String::from_utf8_lossy(&out.stdout);
+        // Parse "sequence: 12345" from output.
+        for line in text.lines() {
+            if line.contains("sequence") {
+                if let Some(n) = line.split_whitespace().last().and_then(|s| s.parse().ok()) {
+                    return Ok(n);
+                }
+            }
+        }
+        Ok(0)
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Persistent storage reads
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /// Returns all persistent keys matching a prefix as (key, value) pairs.
+    /// Uses `stellar contract storage` to enumerate entries.
+    pub fn scan_persistent_prefix(
+        &self,
+        contract_id: &str,
+        prefix: &str,
+    ) -> Result<Vec<(String, String)>, String> {
+        let out = Command::new("stellar")
+            .args([
+                "contract", "storage",
+                "--id", contract_id,
+                "--rpc-url", &self.rpc_url,
+                "--output", "json",
+            ])
+            .output()
+            .map_err(|e| format!("storage scan error: {}", e))?;
+
+        let text = String::from_utf8_lossy(&out.stdout);
+        let entries: Vec<serde_json::Value> = serde_json::from_str(&text)
+            .unwrap_or_default();
+
+        let mut result = Vec::new();
+        for entry in entries {
+            if let (Some(key), Some(val)) = (
+                entry.get("key").and_then(|v| v.as_str()),
+                entry.get("value").and_then(|v| v.as_str()),
+            ) {
+                if key.starts_with(prefix) {
+                    result.push((key.to_string(), val.to_string()));
+                }
+            }
+        }
+        Ok(result)
+    }
+
+    pub fn get_persistent_u64(&self, contract_id: &str, key: &str) -> Option<u64> {
+        self.invoke_read(contract_id, "get_storage_u64", &[("key", key)])
+            .ok()
+            .and_then(|s| s.trim_matches('"').parse().ok())
+    }
+
+    pub fn get_persistent_string(&self, contract_id: &str, key: &str) -> Option<String> {
+        self.invoke_read(contract_id, "get_storage_string", &[("key", key)]).ok()
+    }
+
+    pub fn get_persistent_tip_metadata(
+        &self,
+        contract_id: &str,
+        key: &str,
+    ) -> Result<Option<TipMetadata>, String> {
+        let raw = match self.invoke_read(contract_id, "get_storage_json", &[("key", key)]) {
+            Ok(r) => r,
+            Err(_) => return Ok(None),
+        };
+        if raw == "null" || raw.is_empty() {
+            return Ok(None);
+        }
+        let meta: TipMetadata = serde_json::from_str(&raw)
+            .map_err(|e| format!("TipMetadata parse error for key {}: {}", key, e))?;
+        Ok(Some(meta))
+    }
+
+    pub fn get_persistent_leaderboard_entry(
+        &self,
+        contract_id: &str,
+        key: &str,
+    ) -> Result<Option<LeaderboardEntry>, String> {
+        let raw = match self.invoke_read(contract_id, "get_storage_json", &[("key", key)]) {
+            Ok(r) => r,
+            Err(_) => return Ok(None),
+        };
+        if raw == "null" || raw.is_empty() {
+            return Ok(None);
+        }
+        let entry: LeaderboardEntry = serde_json::from_str(&raw)
+            .map_err(|e| format!("LeaderboardEntry parse error for key {}: {}", key, e))?;
+        Ok(Some(entry))
+    }
+
+    pub fn get_persistent_subscription(
+        &self,
+        contract_id: &str,
+        key: &str,
+    ) -> Result<Option<Subscription>, String> {
+        let raw = match self.invoke_read(contract_id, "get_storage_json", &[("key", key)]) {
+            Ok(r) => r,
+            Err(_) => return Ok(None),
+        };
+        if raw == "null" || raw.is_empty() {
+            return Ok(None);
+        }
+        let sub: Subscription = serde_json::from_str(&raw)
+            .map_err(|e| format!("Subscription parse error for key {}: {}", key, e))?;
+        Ok(Some(sub))
+    }
+
+    pub fn get_persistent_time_lock(
+        &self,
+        contract_id: &str,
+        key: &str,
+        lock_id: u64,
+    ) -> Result<Option<TimeLock>, String> {
+        let raw = match self.invoke_read(contract_id, "get_storage_json", &[("key", key)]) {
+            Ok(r) => r,
+            Err(_) => return Ok(None),
+        };
+        if raw == "null" || raw.is_empty() {
+            return Ok(None);
+        }
+        // The on-chain TimeLock doesn't store lock_id; we inject it here.
+        let mut val: serde_json::Value = serde_json::from_str(&raw)
+            .map_err(|e| format!("TimeLock parse error for key {}: {}", key, e))?;
+        if let serde_json::Value::Object(ref mut map) = val {
+            map.insert("lock_id".into(), serde_json::Value::Number(lock_id.into()));
+        }
+        let lock: TimeLock = serde_json::from_value(val)
+            .map_err(|e| format!("TimeLock deserialise error: {}", e))?;
+        Ok(Some(lock))
+    }
+
+    pub fn get_persistent_milestone(
+        &self,
+        contract_id: &str,
+        key: &str,
+    ) -> Result<Option<Milestone>, String> {
+        let raw = match self.invoke_read(contract_id, "get_storage_json", &[("key", key)]) {
+            Ok(r) => r,
+            Err(_) => return Ok(None),
+        };
+        if raw == "null" || raw.is_empty() {
+            return Ok(None);
+        }
+        let ms: Milestone = serde_json::from_str(&raw)
+            .map_err(|e| format!("Milestone parse error for key {}: {}", key, e))?;
+        Ok(Some(ms))
+    }
+
+    pub fn get_persistent_matching_program(
+        &self,
+        contract_id: &str,
+        key: &str,
+    ) -> Result<Option<MatchingProgram>, String> {
+        let raw = match self.invoke_read(contract_id, "get_storage_json", &[("key", key)]) {
+            Ok(r) => r,
+            Err(_) => return Ok(None),
+        };
+        if raw == "null" || raw.is_empty() {
+            return Ok(None);
+        }
+        let prog: MatchingProgram = serde_json::from_str(&raw)
+            .map_err(|e| format!("MatchingProgram parse error for key {}: {}", key, e))?;
+        Ok(Some(prog))
+    }
+
+    pub fn get_persistent_tip_record(
+        &self,
+        contract_id: &str,
+        key: &str,
+    ) -> Result<Option<TipRecord>, String> {
+        let raw = match self.invoke_read(contract_id, "get_storage_json", &[("key", key)]) {
+            Ok(r) => r,
+            Err(_) => return Ok(None),
+        };
+        if raw == "null" || raw.is_empty() {
+            return Ok(None);
+        }
+        let rec: TipRecord = serde_json::from_str(&raw)
+            .map_err(|e| format!("TipRecord parse error for key {}: {}", key, e))?;
+        Ok(Some(rec))
+    }
+
+    pub fn get_persistent_locked_tip(
+        &self,
+        contract_id: &str,
+        key: &str,
+        tip_id: u64,
+    ) -> Result<Option<LockedTip>, String> {
+        let raw = match self.invoke_read(contract_id, "get_storage_json", &[("key", key)]) {
+            Ok(r) => r,
+            Err(_) => return Ok(None),
+        };
+        if raw == "null" || raw.is_empty() {
+            return Ok(None);
+        }
+        let mut val: serde_json::Value = serde_json::from_str(&raw)
+            .map_err(|e| format!("LockedTip parse error for key {}: {}", key, e))?;
+        if let serde_json::Value::Object(ref mut map) = val {
+            map.insert("tip_id".into(), serde_json::Value::Number(tip_id.into()));
+        }
+        let lt: LockedTip = serde_json::from_value(val)
+            .map_err(|e| format!("LockedTip deserialise error: {}", e))?;
+        Ok(Some(lt))
+    }
+
+    pub fn get_persistent_address_vec(
+        &self,
+        contract_id: &str,
+        key: &str,
+    ) -> Option<Vec<String>> {
+        let raw = self
+            .invoke_read(contract_id, "get_storage_json", &[("key", key)])
+            .ok()?;
+        serde_json::from_str(&raw).ok()
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Balance / total reads (used by verify)
+    // ─────────────────────────────────────────────────────────────────────────
+
+    pub fn get_creator_balance(&self, contract_id: &str, creator: &str, token: &str) -> Option<i128> {
+        self.invoke_read(
+            contract_id,
+            "get_withdrawable_balance",
+            &[("creator", creator), ("token", token)],
+        )
+        .ok()
+        .and_then(|s| s.trim_matches('"').parse().ok())
+    }
+
+    pub fn get_creator_total(&self, contract_id: &str, creator: &str, token: &str) -> Option<i128> {
+        self.invoke_read(
+            contract_id,
+            "get_total_tips",
+            &[("creator", creator), ("token", token)],
+        )
+        .ok()
+        .and_then(|s| s.trim_matches('"').parse().ok())
+    }
+
+    pub fn get_whitelisted_tokens(&self, contract_id: &str) -> Result<Vec<String>, String> {
+        let raw = self.invoke_read(contract_id, "get_whitelisted_tokens", &[])?;
+        serde_json::from_str(&raw).map_err(|e| format!("Token list parse error: {}", e))
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Write helpers (used by import)
+    // ─────────────────────────────────────────────────────────────────────────
+
+    pub fn set_instance_value(&self, contract_id: &str, key: &str, value: &str) -> Result<(), String> {
+        self.invoke_contract(
+            contract_id,
+            "admin_set_instance",
+            &[("key", key), ("value", value)],
+        )?;
+        Ok(())
+    }
+
+    pub fn whitelist_token(&self, contract_id: &str, token: &str) -> Result<(), String> {
+        let admin = std::env::var("MIGRATION_ADMIN_ADDRESS")
+            .map_err(|_| "MIGRATION_ADMIN_ADDRESS env var not set".to_string())?;
+        self.invoke_contract(contract_id, "add_token", &[("admin", &admin), ("token", token)])?;
+        Ok(())
+    }
+
+    pub fn set_creator_balance(
+        &self,
+        contract_id: &str,
+        creator: &str,
+        token: &str,
+        balance: i128,
+    ) -> Result<(), String> {
+        self.invoke_contract(
+            contract_id,
+            "admin_set_creator_balance",
+            &[
+                ("creator", creator),
+                ("token", token),
+                ("balance", &balance.to_string()),
+            ],
+        )?;
+        Ok(())
+    }
+
+    pub fn set_creator_total(
+        &self,
+        contract_id: &str,
+        creator: &str,
+        token: &str,
+        total: i128,
+    ) -> Result<(), String> {
+        self.invoke_contract(
+            contract_id,
+            "admin_set_creator_total",
+            &[
+                ("creator", creator),
+                ("token", token),
+                ("total", &total.to_string()),
+            ],
+        )?;
+        Ok(())
+    }
+
+    pub fn set_tip_count(&self, contract_id: &str, creator: &str, count: u64) -> Result<(), String> {
+        self.invoke_contract(
+            contract_id,
+            "admin_set_tip_count",
+            &[("creator", creator), ("count", &count.to_string())],
+        )?;
+        Ok(())
+    }
+
+    pub fn set_tip_history_entry(
+        &self,
+        contract_id: &str,
+        creator: &str,
+        idx: u64,
+        meta: &TipMetadata,
+    ) -> Result<(), String> {
+        let json = serde_json::to_string(meta)
+            .map_err(|e| format!("TipMetadata serialise error: {}", e))?;
+        self.invoke_contract(
+            contract_id,
+            "admin_set_tip_history",
+            &[
+                ("creator", creator),
+                ("index", &idx.to_string()),
+                ("metadata", &json),
+            ],
+        )?;
+        Ok(())
+    }
+
+    pub fn set_tipper_aggregate(
+        &self,
+        contract_id: &str,
+        address: &str,
+        bucket: u32,
+        entry: &LeaderboardEntry,
+    ) -> Result<(), String> {
+        let json = serde_json::to_string(entry)
+            .map_err(|e| format!("LeaderboardEntry serialise error: {}", e))?;
+        self.invoke_contract(
+            contract_id,
+            "admin_set_tipper_aggregate",
+            &[
+                ("address", address),
+                ("bucket", &bucket.to_string()),
+                ("entry", &json),
+            ],
+        )?;
+        Ok(())
+    }
+
+    pub fn set_creator_aggregate(
+        &self,
+        contract_id: &str,
+        address: &str,
+        bucket: u32,
+        entry: &LeaderboardEntry,
+    ) -> Result<(), String> {
+        let json = serde_json::to_string(entry)
+            .map_err(|e| format!("LeaderboardEntry serialise error: {}", e))?;
+        self.invoke_contract(
+            contract_id,
+            "admin_set_creator_aggregate",
+            &[
+                ("address", address),
+                ("bucket", &bucket.to_string()),
+                ("entry", &json),
+            ],
+        )?;
+        Ok(())
+    }
+
+    pub fn set_subscription(&self, contract_id: &str, sub: &Subscription) -> Result<(), String> {
+        let json = serde_json::to_string(sub)
+            .map_err(|e| format!("Subscription serialise error: {}", e))?;
+        self.invoke_contract(
+            contract_id,
+            "admin_set_subscription",
+            &[("subscription", &json)],
+        )?;
+        Ok(())
+    }
+
+    pub fn set_time_lock(&self, contract_id: &str, lock: &TimeLock) -> Result<(), String> {
+        let json = serde_json::to_string(lock)
+            .map_err(|e| format!("TimeLock serialise error: {}", e))?;
+        self.invoke_contract(contract_id, "admin_set_time_lock", &[("lock", &json)])?;
+        Ok(())
+    }
+
+    pub fn set_milestone(&self, contract_id: &str, creator: &str, ms: &Milestone) -> Result<(), String> {
+        let json = serde_json::to_string(ms)
+            .map_err(|e| format!("Milestone serialise error: {}", e))?;
+        self.invoke_contract(
+            contract_id,
+            "admin_set_milestone",
+            &[("creator", creator), ("milestone", &json)],
+        )?;
+        Ok(())
+    }
+
+    pub fn set_matching_program(&self, contract_id: &str, prog: &MatchingProgram) -> Result<(), String> {
+        let json = serde_json::to_string(prog)
+            .map_err(|e| format!("MatchingProgram serialise error: {}", e))?;
+        self.invoke_contract(
+            contract_id,
+            "admin_set_matching_program",
+            &[("program", &json)],
+        )?;
+        Ok(())
+    }
+
+    pub fn set_tip_record(&self, contract_id: &str, rec: &TipRecord) -> Result<(), String> {
+        let json = serde_json::to_string(rec)
+            .map_err(|e| format!("TipRecord serialise error: {}", e))?;
+        self.invoke_contract(contract_id, "admin_set_tip_record", &[("record", &json)])?;
+        Ok(())
+    }
+
+    pub fn set_locked_tip(&self, contract_id: &str, lt: &LockedTip) -> Result<(), String> {
+        let json = serde_json::to_string(lt)
+            .map_err(|e| format!("LockedTip serialise error: {}", e))?;
+        self.invoke_contract(contract_id, "admin_set_locked_tip", &[("locked_tip", &json)])?;
+        Ok(())
+    }
+
+    pub fn set_user_role(&self, contract_id: &str, address: &str, role: &str) -> Result<(), String> {
+        let admin = std::env::var("MIGRATION_ADMIN_ADDRESS")
+            .map_err(|_| "MIGRATION_ADMIN_ADDRESS env var not set".to_string())?;
+        self.invoke_contract(
+            contract_id,
+            "grant_role",
+            &[("admin", &admin), ("user", address), ("role", role)],
+        )?;
+        Ok(())
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Converts a PascalCase key like "FeeBasisPoints" to "fee_basis_points".
+fn to_snake(s: &str) -> String {
+    let mut out = String::new();
+    for (i, c) in s.chars().enumerate() {
+        if c.is_uppercase() && i > 0 {
+            out.push('_');
+        }
+        out.push(c.to_lowercase().next().unwrap());
+    }
+    out
+}

--- a/scripts/migrate/tests/migration_tests.rs
+++ b/scripts/migrate/tests/migration_tests.rs
@@ -1,0 +1,1217 @@
+//! Integration and unit tests for the TipJar state migration toolkit.
+//!
+//! Coverage:
+//!   1. Export completeness  — snapshot captures all state categories
+//!   2. Checksum sealing     — checksum is computed and verified correctly
+//!   3. Transform accuracy   — every transformation rule produces correct output
+//!   4. Import accuracy      — snapshot round-trips through serialisation losslessly
+//!   5. Verification logic   — VerificationReport detects mismatches and missing fields
+//!   6. Rollback capability  — backup snapshot restores state faithfully
+//!   7. History tracking     — history file accumulates entries across runs
+//!   8. Config parsing       — config.toml is parsed without errors
+
+// Bring the toolkit modules into scope.  When run via `cargo test` from the
+// scripts/migrate directory these resolve through main.rs's `mod` declarations.
+#[path = "../types.rs"]
+mod types;
+#[path = "../rpc_client.rs"]
+mod rpc_client;
+#[path = "../export_state.rs"]
+mod export_state;
+#[path = "../transform_state.rs"]
+mod transform_state;
+#[path = "../verify_migration.rs"]
+mod verify_migration;
+#[path = "../history.rs"]
+mod history;
+
+use std::collections::HashMap;
+use types::{
+    FindingSeverity, LeaderboardEntry, LockedTip, MatchingProgram, Milestone,
+    MigrationHistory, MigrationHistoryEntry, MigrationStatus, StateSnapshot,
+    Subscription, SubscriptionStatus, TipMetadata, TipRecord, TimeLock,
+    TransformationLog, VerificationFinding, VerificationReport,
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Shared fixture helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+fn empty_snapshot() -> StateSnapshot {
+    StateSnapshot {
+        contract_id: "CTEST000000000000000000000000000000000000000000000000000".into(),
+        schema_version: 1,
+        exported_at: 1_700_000_000,
+        ledger_sequence: 5000,
+        checksum: String::new(),
+        admin: "GADMIN00000000000000000000000000000000000000000000000000".into(),
+        fee_basis_points: 100,
+        refund_window_seconds: 86_400,
+        paused: false,
+        pause_reason: None,
+        tip_counter: 0,
+        matching_counter: 0,
+        current_fee_bps: 100,
+        whitelisted_tokens: vec![],
+        creator_balances: HashMap::new(),
+        creator_totals: HashMap::new(),
+        tip_history: HashMap::new(),
+        tipper_aggregates: HashMap::new(),
+        creator_aggregates: HashMap::new(),
+        subscriptions: HashMap::new(),
+        time_locks: vec![],
+        milestones: HashMap::new(),
+        matching_programs: vec![],
+        tip_records: vec![],
+        locked_tips: vec![],
+        user_roles: HashMap::new(),
+    }
+}
+
+fn populated_snapshot() -> StateSnapshot {
+    let mut snap = empty_snapshot();
+
+    // Creator balances and totals
+    snap.creator_balances.insert("GCREATOR1:GTOKEN1".into(), 5_000_000);
+    snap.creator_balances.insert("GCREATOR2:GTOKEN1".into(), 0);
+    snap.creator_balances.insert("GCREATOR1:GTOKEN2".into(), 1_200_000);
+    snap.creator_totals.insert("GCREATOR1:GTOKEN1".into(), 10_000_000);
+    snap.creator_totals.insert("GCREATOR2:GTOKEN1".into(), 0);
+
+    // Tip history
+    snap.tip_history.insert(
+        "GCREATOR1".into(),
+        vec![
+            TipMetadata { sender: "GSENDER1".into(), amount: 1_000_000, message: None, timestamp: 1_699_000_000 },
+            TipMetadata { sender: "GSENDER2".into(), amount: 2_000_000, message: Some("great work".into()), timestamp: 1_699_500_000 },
+        ],
+    );
+
+    // Leaderboard
+    snap.tipper_aggregates.insert(
+        "GSENDER1:0".into(),
+        LeaderboardEntry { address: "GSENDER1".into(), total_amount: 1_000_000, tip_count: 1 },
+    );
+    snap.creator_aggregates.insert(
+        "GCREATOR1:0".into(),
+        LeaderboardEntry { address: "GCREATOR1".into(), total_amount: 3_000_000, tip_count: 2 },
+    );
+
+    // Subscriptions
+    snap.subscriptions.insert(
+        "GSUB1:GCREATOR1".into(),
+        Subscription {
+            subscriber: "GSUB1".into(),
+            creator: "GCREATOR1".into(),
+            token: "GTOKEN1".into(),
+            amount: 500_000,
+            interval_seconds: 86_400,
+            last_payment: 1_699_000_000,
+            next_payment: 1_699_086_400,
+            status: SubscriptionStatus::Active,
+        },
+    );
+    snap.subscriptions.insert(
+        "GSUB2:GCREATOR1".into(),
+        Subscription {
+            subscriber: "GSUB2".into(),
+            creator: "GCREATOR1".into(),
+            token: "GTOKEN1".into(),
+            amount: 250_000,
+            interval_seconds: 604_800,
+            last_payment: 0,
+            next_payment: 1_699_000_000,
+            status: SubscriptionStatus::Cancelled,
+        },
+    );
+
+    // Time locks
+    snap.time_locks.push(TimeLock {
+        lock_id: 0,
+        sender: "GSENDER1".into(),
+        creator: "GCREATOR1".into(),
+        token: "GTOKEN1".into(),
+        amount: 3_000_000,
+        unlock_time: 1_800_000_000, // future
+        cancelled: false,
+    });
+    snap.time_locks.push(TimeLock {
+        lock_id: 1,
+        sender: "GSENDER2".into(),
+        creator: "GCREATOR2".into(),
+        token: "GTOKEN1".into(),
+        amount: 1_000_000,
+        unlock_time: 1_600_000_000, // past (expired)
+        cancelled: false,
+    });
+
+    // Milestones
+    snap.milestones.insert(
+        "GCREATOR1:0".into(),
+        Milestone {
+            id: 0,
+            creator: "GCREATOR1".into(),
+            goal_amount: 10_000_000,
+            current_amount: 5_000_000,
+            description: "First album".into(),
+            deadline: Some(1_800_000_000),
+            completed: false,
+        },
+    );
+
+    // Matching programs
+    snap.matching_programs.push(MatchingProgram {
+        id: 0,
+        sponsor: "GSPONSOR1".into(),
+        creator: "GCREATOR1".into(),
+        token: "GTOKEN1".into(),
+        match_ratio: 100,
+        max_match_amount: 5_000_000,
+        current_matched: 1_000_000,
+        active: true,
+    });
+
+    // Tip records
+    snap.tip_records.push(TipRecord {
+        id: 0,
+        sender: "GSENDER1".into(),
+        creator: "GCREATOR1".into(),
+        token: "GTOKEN1".into(),
+        amount: 1_000_000,
+        timestamp: 1_699_000_000,
+        refunded: false,
+        refund_requested: false,
+        refund_approved: false,
+    });
+    snap.tip_records.push(TipRecord {
+        id: 1,
+        sender: "GSENDER2".into(),
+        creator: "GCREATOR1".into(),
+        token: "GTOKEN1".into(),
+        amount: 500_000,
+        timestamp: 1_699_100_000,
+        refunded: true,
+        refund_requested: true,
+        refund_approved: true,
+    });
+
+    // Locked tips
+    snap.locked_tips.push(LockedTip {
+        tip_id: 0,
+        sender: "GSENDER1".into(),
+        creator: "GCREATOR1".into(),
+        token: "GTOKEN1".into(),
+        amount: 2_000_000,
+        unlock_timestamp: 1_800_000_000,
+    });
+
+    // User roles
+    snap.user_roles.insert("GCREATOR1".into(), "Creator".into());
+    snap.user_roles.insert("GADMIN00000000000000000000000000000000000000000000000000".into(), "Admin".into());
+
+    // Whitelisted tokens
+    snap.whitelisted_tokens = vec!["GTOKEN1".into(), "GTOKEN2".into()];
+
+    snap.tip_counter = 2;
+    snap.matching_counter = 1;
+
+    snap
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 1. Export completeness
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod test_export_completeness {
+    use super::*;
+
+    #[test]
+    fn snapshot_captures_all_state_categories() {
+        let snap = populated_snapshot();
+        // Every category must be non-empty.
+        assert!(!snap.creator_balances.is_empty(), "creator_balances empty");
+        assert!(!snap.creator_totals.is_empty(), "creator_totals empty");
+        assert!(!snap.tip_history.is_empty(), "tip_history empty");
+        assert!(!snap.tipper_aggregates.is_empty(), "tipper_aggregates empty");
+        assert!(!snap.creator_aggregates.is_empty(), "creator_aggregates empty");
+        assert!(!snap.subscriptions.is_empty(), "subscriptions empty");
+        assert!(!snap.time_locks.is_empty(), "time_locks empty");
+        assert!(!snap.milestones.is_empty(), "milestones empty");
+        assert!(!snap.matching_programs.is_empty(), "matching_programs empty");
+        assert!(!snap.tip_records.is_empty(), "tip_records empty");
+        assert!(!snap.locked_tips.is_empty(), "locked_tips empty");
+        assert!(!snap.user_roles.is_empty(), "user_roles empty");
+        assert!(!snap.whitelisted_tokens.is_empty(), "whitelisted_tokens empty");
+    }
+
+    #[test]
+    fn total_records_counts_all_collections() {
+        let snap = populated_snapshot();
+        let total = snap.total_records();
+        // Manually sum expected counts from populated_snapshot():
+        // balances=3, totals=2, tip_history=2, tipper_agg=1, creator_agg=1,
+        // subs=2, time_locks=2, milestones=1, matching=1, tip_records=2,
+        // locked_tips=1, user_roles=2
+        assert_eq!(total, 20, "total_records mismatch: got {}", total);
+    }
+
+    #[test]
+    fn snapshot_preserves_instance_fields() {
+        let snap = populated_snapshot();
+        assert_eq!(snap.fee_basis_points, 100);
+        assert_eq!(snap.refund_window_seconds, 86_400);
+        assert!(!snap.paused);
+        assert_eq!(snap.tip_counter, 2);
+        assert_eq!(snap.matching_counter, 1);
+        assert_eq!(snap.schema_version, 1);
+    }
+
+    #[test]
+    fn snapshot_preserves_creator_balance_keys() {
+        let snap = populated_snapshot();
+        assert!(snap.creator_balances.contains_key("GCREATOR1:GTOKEN1"));
+        assert!(snap.creator_balances.contains_key("GCREATOR1:GTOKEN2"));
+        assert_eq!(snap.creator_balances["GCREATOR1:GTOKEN1"], 5_000_000);
+    }
+
+    #[test]
+    fn snapshot_preserves_tip_history_order() {
+        let snap = populated_snapshot();
+        let tips = snap.tip_history.get("GCREATOR1").unwrap();
+        assert_eq!(tips.len(), 2);
+        assert_eq!(tips[0].amount, 1_000_000);
+        assert_eq!(tips[1].amount, 2_000_000);
+        assert_eq!(tips[1].message, Some("great work".into()));
+    }
+
+    #[test]
+    fn snapshot_serialises_and_deserialises_losslessly() {
+        let snap = populated_snapshot();
+        let json = serde_json::to_string(&snap).expect("serialise failed");
+        let restored: StateSnapshot = serde_json::from_str(&json).expect("deserialise failed");
+
+        assert_eq!(restored.contract_id, snap.contract_id);
+        assert_eq!(restored.creator_balances, snap.creator_balances);
+        assert_eq!(restored.creator_totals, snap.creator_totals);
+        assert_eq!(restored.tip_history, snap.tip_history);
+        assert_eq!(restored.subscriptions.len(), snap.subscriptions.len());
+        assert_eq!(restored.time_locks.len(), snap.time_locks.len());
+        assert_eq!(restored.milestones.len(), snap.milestones.len());
+        assert_eq!(restored.matching_programs.len(), snap.matching_programs.len());
+        assert_eq!(restored.tip_records.len(), snap.tip_records.len());
+        assert_eq!(restored.locked_tips.len(), snap.locked_tips.len());
+        assert_eq!(restored.user_roles, snap.user_roles);
+        assert_eq!(restored.whitelisted_tokens, snap.whitelisted_tokens);
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 2. Checksum sealing
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod test_checksum {
+    use super::*;
+    use export_state::{compute_checksum, verify_checksum};
+
+    #[test]
+    fn checksum_is_deterministic() {
+        let snap = populated_snapshot();
+        let c1 = compute_checksum(&snap).unwrap();
+        let c2 = compute_checksum(&snap).unwrap();
+        assert_eq!(c1, c2, "checksum must be deterministic");
+    }
+
+    #[test]
+    fn checksum_is_hex_sha256() {
+        let snap = populated_snapshot();
+        let c = compute_checksum(&snap).unwrap();
+        assert_eq!(c.len(), 64, "SHA-256 hex must be 64 chars, got {}", c.len());
+        assert!(c.chars().all(|ch| ch.is_ascii_hexdigit()), "non-hex char in checksum");
+    }
+
+    #[test]
+    fn verify_checksum_passes_when_correct() {
+        let mut snap = populated_snapshot();
+        snap.checksum = compute_checksum(&snap).unwrap();
+        assert!(verify_checksum(&snap).is_ok());
+    }
+
+    #[test]
+    fn verify_checksum_fails_when_tampered() {
+        let mut snap = populated_snapshot();
+        snap.checksum = compute_checksum(&snap).unwrap();
+        // Tamper with a balance.
+        snap.creator_balances.insert("GCREATOR1:GTOKEN1".into(), 9_999_999);
+        assert!(
+            verify_checksum(&snap).is_err(),
+            "verify_checksum should fail after tampering"
+        );
+    }
+
+    #[test]
+    fn checksum_ignores_its_own_field() {
+        // Two snapshots identical except for the checksum field itself must
+        // produce the same checksum (the field is zeroed before hashing).
+        let snap1 = populated_snapshot();
+        let mut snap2 = populated_snapshot();
+        snap2.checksum = "some_old_checksum".into();
+        assert_eq!(
+            compute_checksum(&snap1).unwrap(),
+            compute_checksum(&snap2).unwrap()
+        );
+    }
+
+    #[test]
+    fn different_snapshots_produce_different_checksums() {
+        let snap1 = populated_snapshot();
+        let mut snap2 = populated_snapshot();
+        snap2.creator_balances.insert("GNEW:GTOKEN1".into(), 1);
+        assert_ne!(
+            compute_checksum(&snap1).unwrap(),
+            compute_checksum(&snap2).unwrap()
+        );
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 3. Data transformation accuracy
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod test_transform {
+    use super::*;
+    use transform_state::StateTransformer;
+
+    fn transform(snap: StateSnapshot) -> (StateSnapshot, Vec<TransformationLog>) {
+        StateTransformer::new(1, 2).transform(snap).expect("transform failed")
+    }
+
+    // ── zero-value pruning ────────────────────────────────────────────────────
+
+    #[test]
+    fn removes_zero_creator_balances() {
+        let snap = populated_snapshot(); // contains GCREATOR2:GTOKEN1 = 0
+        let (out, logs) = transform(snap);
+        assert!(
+            !out.creator_balances.contains_key("GCREATOR2:GTOKEN1"),
+            "zero balance should be removed"
+        );
+        assert!(
+            out.creator_balances.contains_key("GCREATOR1:GTOKEN1"),
+            "non-zero balance must be kept"
+        );
+        let rule_log = logs.iter().find(|l| l.rule == "v1_to_v2_normalise_balances").unwrap();
+        assert_eq!(rule_log.records_affected, 1);
+    }
+
+    #[test]
+    fn removes_zero_creator_totals() {
+        let snap = populated_snapshot(); // contains GCREATOR2:GTOKEN1 total = 0
+        let (out, logs) = transform(snap);
+        assert!(!out.creator_totals.contains_key("GCREATOR2:GTOKEN1"));
+        let rule_log = logs.iter().find(|l| l.rule == "v1_to_v2_normalise_totals").unwrap();
+        assert_eq!(rule_log.records_affected, 1);
+    }
+
+    // ── expired lock cancellation ─────────────────────────────────────────────
+
+    #[test]
+    fn marks_expired_time_locks_cancelled() {
+        // lock_id=1 has unlock_time=1_600_000_000 < exported_at=1_700_000_000
+        let snap = populated_snapshot();
+        let (out, logs) = transform(snap);
+        let expired = out.time_locks.iter().find(|l| l.lock_id == 1).unwrap();
+        assert!(expired.cancelled, "expired lock must be marked cancelled");
+        let future = out.time_locks.iter().find(|l| l.lock_id == 0).unwrap();
+        assert!(!future.cancelled, "future lock must not be cancelled");
+        let rule_log = logs.iter().find(|l| l.rule == "v1_to_v2_cancel_expired_locks").unwrap();
+        assert_eq!(rule_log.records_affected, 1);
+    }
+
+    #[test]
+    fn does_not_cancel_already_cancelled_locks() {
+        let mut snap = populated_snapshot();
+        snap.time_locks[1].cancelled = true; // already cancelled
+        let (out, logs) = transform(snap);
+        let rule_log = logs.iter().find(|l| l.rule == "v1_to_v2_cancel_expired_locks").unwrap();
+        // Should not double-count.
+        assert_eq!(rule_log.records_affected, 0);
+        let _ = out;
+    }
+
+    // ── cancelled subscription stripping ─────────────────────────────────────
+
+    #[test]
+    fn strips_cancelled_subscriptions() {
+        let snap = populated_snapshot(); // GSUB2:GCREATOR1 is Cancelled
+        let (out, logs) = transform(snap);
+        assert!(
+            !out.subscriptions.contains_key("GSUB2:GCREATOR1"),
+            "cancelled subscription must be removed"
+        );
+        assert!(
+            out.subscriptions.contains_key("GSUB1:GCREATOR1"),
+            "active subscription must be kept"
+        );
+        let rule_log = logs.iter().find(|l| l.rule == "v1_to_v2_strip_cancelled_subscriptions").unwrap();
+        assert_eq!(rule_log.records_affected, 1);
+    }
+
+    // ── tip history cap ───────────────────────────────────────────────────────
+
+    #[test]
+    fn caps_tip_history_at_1000_entries() {
+        let mut snap = empty_snapshot();
+        snap.creator_balances.insert("GCREATOR1:GTOKEN1".into(), 1);
+        let tips: Vec<TipMetadata> = (0u64..1_200)
+            .map(|i| TipMetadata {
+                sender: "GSENDER".into(),
+                amount: i as i128 + 1,
+                message: None,
+                timestamp: i,
+            })
+            .collect();
+        snap.tip_history.insert("GCREATOR1".into(), tips);
+        let (out, logs) = transform(snap);
+        assert_eq!(out.tip_history["GCREATOR1"].len(), 1_000);
+        // Newest 1000 entries kept (indices 200–1199 → amounts 201–1200).
+        assert_eq!(out.tip_history["GCREATOR1"][0].amount, 201);
+        assert_eq!(out.tip_history["GCREATOR1"][999].amount, 1_200);
+        let rule_log = logs.iter().find(|l| l.rule == "v1_to_v2_cap_tip_history").unwrap();
+        assert_eq!(rule_log.records_affected, 200);
+    }
+
+    #[test]
+    fn does_not_trim_tip_history_under_cap() {
+        let snap = populated_snapshot(); // only 2 tips for GCREATOR1
+        let (out, _) = transform(snap);
+        assert_eq!(out.tip_history["GCREATOR1"].len(), 2);
+    }
+
+    // ── refunded tip record removal ───────────────────────────────────────────
+
+    #[test]
+    fn removes_fully_refunded_tip_records() {
+        let snap = populated_snapshot(); // tip_records[1] is refunded=true
+        let (out, logs) = transform(snap);
+        assert_eq!(out.tip_records.len(), 1);
+        assert_eq!(out.tip_records[0].id, 0);
+        let rule_log = logs.iter().find(|l| l.rule == "v1_to_v2_remove_refunded_tip_records").unwrap();
+        assert_eq!(rule_log.records_affected, 1);
+    }
+
+    // ── schema version bump ───────────────────────────────────────────────────
+
+    #[test]
+    fn bumps_schema_version_to_target() {
+        let snap = populated_snapshot();
+        assert_eq!(snap.schema_version, 1);
+        let (out, _) = transform(snap);
+        assert_eq!(out.schema_version, 2);
+    }
+
+    // ── checksum after transform ──────────────────────────────────────────────
+
+    #[test]
+    fn transformed_snapshot_has_valid_checksum() {
+        let snap = populated_snapshot();
+        let (out, _) = transform(snap);
+        assert!(!out.checksum.is_empty());
+        export_state::verify_checksum(&out).expect("checksum invalid after transform");
+    }
+
+    // ── transformation log completeness ──────────────────────────────────────
+
+    #[test]
+    fn all_rules_produce_log_entries() {
+        let snap = populated_snapshot();
+        let (_, logs) = transform(snap);
+        let rule_ids: Vec<&str> = logs.iter().map(|l| l.rule.as_str()).collect();
+        for expected in &[
+            "v1_to_v2_normalise_balances",
+            "v1_to_v2_normalise_totals",
+            "v1_to_v2_cancel_expired_locks",
+            "v1_to_v2_strip_cancelled_subscriptions",
+            "v1_to_v2_cap_tip_history",
+            "v1_to_v2_remove_refunded_tip_records",
+            "v1_to_v2_bump_schema_version",
+        ] {
+            assert!(
+                rule_ids.contains(expected),
+                "missing log entry for rule: {}",
+                expected
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_snapshot_with_wrong_source_version() {
+        let mut snap = populated_snapshot();
+        snap.schema_version = 99; // wrong
+        let result = StateTransformer::new(1, 2).transform(snap);
+        assert!(result.is_err(), "should reject mismatched schema version");
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 4. Import accuracy (round-trip serialisation)
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod test_import_accuracy {
+    use super::*;
+
+    /// Simulates the import phase by serialising the snapshot to JSON (as it
+    /// would be written to disk) and deserialising it back, then asserting
+    /// field-level equality.  This validates that no data is lost or corrupted
+    /// during the disk round-trip that precedes the actual on-chain import.
+    fn round_trip(snap: &StateSnapshot) -> StateSnapshot {
+        let json = serde_json::to_string_pretty(snap).expect("serialise");
+        serde_json::from_str(&json).expect("deserialise")
+    }
+
+    #[test]
+    fn creator_balances_survive_round_trip() {
+        let snap = populated_snapshot();
+        let rt = round_trip(&snap);
+        assert_eq!(rt.creator_balances, snap.creator_balances);
+    }
+
+    #[test]
+    fn creator_totals_survive_round_trip() {
+        let snap = populated_snapshot();
+        let rt = round_trip(&snap);
+        assert_eq!(rt.creator_totals, snap.creator_totals);
+    }
+
+    #[test]
+    fn tip_history_survives_round_trip() {
+        let snap = populated_snapshot();
+        let rt = round_trip(&snap);
+        assert_eq!(rt.tip_history, snap.tip_history);
+    }
+
+    #[test]
+    fn subscriptions_survive_round_trip() {
+        let snap = populated_snapshot();
+        let rt = round_trip(&snap);
+        assert_eq!(rt.subscriptions.len(), snap.subscriptions.len());
+        for (k, v) in &snap.subscriptions {
+            let actual = rt.subscriptions.get(k).expect("subscription missing after round-trip");
+            assert_eq!(actual.amount, v.amount);
+            assert_eq!(actual.interval_seconds, v.interval_seconds);
+            assert_eq!(actual.status, v.status);
+        }
+    }
+
+    #[test]
+    fn time_locks_survive_round_trip() {
+        let snap = populated_snapshot();
+        let rt = round_trip(&snap);
+        assert_eq!(rt.time_locks.len(), snap.time_locks.len());
+        for (a, b) in snap.time_locks.iter().zip(rt.time_locks.iter()) {
+            assert_eq!(a.lock_id, b.lock_id);
+            assert_eq!(a.amount, b.amount);
+            assert_eq!(a.unlock_time, b.unlock_time);
+            assert_eq!(a.cancelled, b.cancelled);
+        }
+    }
+
+    #[test]
+    fn milestones_survive_round_trip() {
+        let snap = populated_snapshot();
+        let rt = round_trip(&snap);
+        assert_eq!(rt.milestones.len(), snap.milestones.len());
+        for (k, v) in &snap.milestones {
+            let actual = rt.milestones.get(k).expect("milestone missing after round-trip");
+            assert_eq!(actual.goal_amount, v.goal_amount);
+            assert_eq!(actual.current_amount, v.current_amount);
+            assert_eq!(actual.completed, v.completed);
+            assert_eq!(actual.description, v.description);
+        }
+    }
+
+    #[test]
+    fn matching_programs_survive_round_trip() {
+        let snap = populated_snapshot();
+        let rt = round_trip(&snap);
+        assert_eq!(rt.matching_programs.len(), snap.matching_programs.len());
+        let a = &snap.matching_programs[0];
+        let b = &rt.matching_programs[0];
+        assert_eq!(a.id, b.id);
+        assert_eq!(a.match_ratio, b.match_ratio);
+        assert_eq!(a.max_match_amount, b.max_match_amount);
+        assert_eq!(a.current_matched, b.current_matched);
+        assert_eq!(a.active, b.active);
+    }
+
+    #[test]
+    fn tip_records_survive_round_trip() {
+        let snap = populated_snapshot();
+        let rt = round_trip(&snap);
+        assert_eq!(rt.tip_records.len(), snap.tip_records.len());
+        for (a, b) in snap.tip_records.iter().zip(rt.tip_records.iter()) {
+            assert_eq!(a.id, b.id);
+            assert_eq!(a.amount, b.amount);
+            assert_eq!(a.refunded, b.refunded);
+        }
+    }
+
+    #[test]
+    fn locked_tips_survive_round_trip() {
+        let snap = populated_snapshot();
+        let rt = round_trip(&snap);
+        assert_eq!(rt.locked_tips.len(), snap.locked_tips.len());
+        assert_eq!(rt.locked_tips[0].amount, snap.locked_tips[0].amount);
+        assert_eq!(rt.locked_tips[0].unlock_timestamp, snap.locked_tips[0].unlock_timestamp);
+    }
+
+    #[test]
+    fn user_roles_survive_round_trip() {
+        let snap = populated_snapshot();
+        let rt = round_trip(&snap);
+        assert_eq!(rt.user_roles, snap.user_roles);
+    }
+
+    #[test]
+    fn large_i128_amounts_survive_round_trip() {
+        let mut snap = empty_snapshot();
+        // i128::MAX / 2 — well above any realistic tip amount but tests the type boundary.
+        let large: i128 = 170_141_183_460_469_231_731_687_303_715_884_105_727 / 2;
+        snap.creator_balances.insert("GCREATOR:GTOKEN".into(), large);
+        let rt = round_trip(&snap);
+        assert_eq!(rt.creator_balances["GCREATOR:GTOKEN"], large);
+    }
+
+    #[test]
+    fn optional_message_none_survives_round_trip() {
+        let mut snap = empty_snapshot();
+        snap.tip_history.insert(
+            "GCREATOR".into(),
+            vec![TipMetadata { sender: "GSENDER".into(), amount: 1, message: None, timestamp: 0 }],
+        );
+        let rt = round_trip(&snap);
+        assert_eq!(rt.tip_history["GCREATOR"][0].message, None);
+    }
+
+    #[test]
+    fn optional_message_some_survives_round_trip() {
+        let mut snap = empty_snapshot();
+        snap.tip_history.insert(
+            "GCREATOR".into(),
+            vec![TipMetadata {
+                sender: "GSENDER".into(),
+                amount: 1,
+                message: Some("hello 🌟".into()),
+                timestamp: 0,
+            }],
+        );
+        let rt = round_trip(&snap);
+        assert_eq!(rt.tip_history["GCREATOR"][0].message, Some("hello 🌟".into()));
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 5. Verification logic
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod test_verification {
+    use super::*;
+
+    /// Builds a VerificationReport by comparing two snapshots field-by-field
+    /// without making any RPC calls.  This mirrors what VerificationEngine does
+    /// but operates entirely in-memory so tests run offline.
+    fn compare_snapshots(source: &StateSnapshot, target: &StateSnapshot) -> VerificationReport {
+        let mut findings: Vec<VerificationFinding> = Vec::new();
+        let mut records_checked = 0usize;
+
+        // Creator balances
+        for (key, expected) in &source.creator_balances {
+            records_checked += 1;
+            let actual = target.creator_balances.get(key).copied().unwrap_or(i128::MIN);
+            if actual == i128::MIN {
+                findings.push(VerificationFinding {
+                    severity: FindingSeverity::Missing,
+                    field: format!("creator_balances.{}", key),
+                    expected: expected.to_string(),
+                    actual: "<absent>".into(),
+                });
+            } else if actual != *expected {
+                findings.push(VerificationFinding {
+                    severity: FindingSeverity::Mismatch,
+                    field: format!("creator_balances.{}", key),
+                    expected: expected.to_string(),
+                    actual: actual.to_string(),
+                });
+            }
+        }
+
+        // Creator totals
+        for (key, expected) in &source.creator_totals {
+            records_checked += 1;
+            let actual = target.creator_totals.get(key).copied().unwrap_or(i128::MIN);
+            if actual == i128::MIN {
+                findings.push(VerificationFinding {
+                    severity: FindingSeverity::Missing,
+                    field: format!("creator_totals.{}", key),
+                    expected: expected.to_string(),
+                    actual: "<absent>".into(),
+                });
+            } else if actual != *expected {
+                findings.push(VerificationFinding {
+                    severity: FindingSeverity::Mismatch,
+                    field: format!("creator_totals.{}", key),
+                    expected: expected.to_string(),
+                    actual: actual.to_string(),
+                });
+            }
+        }
+
+        // Tip history counts
+        for (creator, tips) in &source.tip_history {
+            records_checked += 1;
+            let actual_count = target
+                .tip_history
+                .get(creator)
+                .map(|v| v.len())
+                .unwrap_or(0);
+            if actual_count != tips.len() {
+                findings.push(VerificationFinding {
+                    severity: FindingSeverity::Mismatch,
+                    field: format!("tip_history.{}.count", creator),
+                    expected: tips.len().to_string(),
+                    actual: actual_count.to_string(),
+                });
+            }
+        }
+
+        // User roles
+        for (addr, expected_role) in &source.user_roles {
+            records_checked += 1;
+            match target.user_roles.get(addr) {
+                None => findings.push(VerificationFinding {
+                    severity: FindingSeverity::Missing,
+                    field: format!("user_roles.{}", addr),
+                    expected: expected_role.clone(),
+                    actual: "<absent>".into(),
+                }),
+                Some(actual_role) if actual_role != expected_role => {
+                    findings.push(VerificationFinding {
+                        severity: FindingSeverity::Mismatch,
+                        field: format!("user_roles.{}", addr),
+                        expected: expected_role.clone(),
+                        actual: actual_role.clone(),
+                    });
+                }
+                _ => {}
+            }
+        }
+
+        let passed = findings.is_empty();
+        VerificationReport {
+            source_contract_id: source.contract_id.clone(),
+            target_contract_id: target.contract_id.clone(),
+            verified_at: "2024-01-01T00:00:00Z".into(),
+            records_checked,
+            passed,
+            findings,
+        }
+    }
+
+    #[test]
+    fn identical_snapshots_pass_verification() {
+        let source = populated_snapshot();
+        let target = populated_snapshot();
+        let report = compare_snapshots(&source, &target);
+        assert!(report.passed, "identical snapshots should pass: {:?}", report.findings);
+        assert!(report.is_clean());
+        assert_eq!(report.findings.len(), 0);
+    }
+
+    #[test]
+    fn detects_missing_creator_balance() {
+        let source = populated_snapshot();
+        let mut target = populated_snapshot();
+        target.creator_balances.remove("GCREATOR1:GTOKEN1");
+        let report = compare_snapshots(&source, &target);
+        assert!(!report.passed);
+        let f = report.findings.iter().find(|f| f.field == "creator_balances.GCREATOR1:GTOKEN1").unwrap();
+        assert_eq!(f.severity, FindingSeverity::Missing);
+        assert_eq!(f.actual, "<absent>");
+    }
+
+    #[test]
+    fn detects_mismatched_creator_balance() {
+        let source = populated_snapshot();
+        let mut target = populated_snapshot();
+        target.creator_balances.insert("GCREATOR1:GTOKEN1".into(), 1);
+        let report = compare_snapshots(&source, &target);
+        assert!(!report.passed);
+        let f = report.findings.iter().find(|f| f.field == "creator_balances.GCREATOR1:GTOKEN1").unwrap();
+        assert_eq!(f.severity, FindingSeverity::Mismatch);
+        assert_eq!(f.expected, "5000000");
+        assert_eq!(f.actual, "1");
+    }
+
+    #[test]
+    fn detects_missing_creator_total() {
+        let source = populated_snapshot();
+        let mut target = populated_snapshot();
+        target.creator_totals.remove("GCREATOR1:GTOKEN1");
+        let report = compare_snapshots(&source, &target);
+        assert!(!report.passed);
+        assert!(report.findings.iter().any(|f| f.field == "creator_totals.GCREATOR1:GTOKEN1"
+            && f.severity == FindingSeverity::Missing));
+    }
+
+    #[test]
+    fn detects_tip_history_count_mismatch() {
+        let source = populated_snapshot();
+        let mut target = populated_snapshot();
+        // Remove one tip from target.
+        target.tip_history.get_mut("GCREATOR1").unwrap().pop();
+        let report = compare_snapshots(&source, &target);
+        assert!(!report.passed);
+        assert!(report.findings.iter().any(|f| f.field.contains("tip_history.GCREATOR1.count")));
+    }
+
+    #[test]
+    fn detects_missing_user_role() {
+        let source = populated_snapshot();
+        let mut target = populated_snapshot();
+        target.user_roles.remove("GCREATOR1");
+        let report = compare_snapshots(&source, &target);
+        assert!(!report.passed);
+        assert!(report.findings.iter().any(|f| f.field == "user_roles.GCREATOR1"
+            && f.severity == FindingSeverity::Missing));
+    }
+
+    #[test]
+    fn detects_wrong_user_role() {
+        let source = populated_snapshot();
+        let mut target = populated_snapshot();
+        target.user_roles.insert("GCREATOR1".into(), "Admin".into());
+        let report = compare_snapshots(&source, &target);
+        assert!(!report.passed);
+        let f = report.findings.iter().find(|f| f.field == "user_roles.GCREATOR1").unwrap();
+        assert_eq!(f.severity, FindingSeverity::Mismatch);
+        assert_eq!(f.expected, "Creator");
+        assert_eq!(f.actual, "Admin");
+    }
+
+    #[test]
+    fn report_records_checked_count_is_accurate() {
+        let source = populated_snapshot();
+        let target = populated_snapshot();
+        let report = compare_snapshots(&source, &target);
+        // balances=3, totals=2, tip_history creators=1, user_roles=2 → 8
+        assert_eq!(report.records_checked, 8);
+    }
+
+    #[test]
+    fn multiple_findings_all_reported() {
+        let source = populated_snapshot();
+        let mut target = populated_snapshot();
+        target.creator_balances.remove("GCREATOR1:GTOKEN1");
+        target.creator_balances.remove("GCREATOR1:GTOKEN2");
+        target.user_roles.remove("GCREATOR1");
+        let report = compare_snapshots(&source, &target);
+        assert!(!report.passed);
+        assert!(report.findings.len() >= 3, "expected ≥3 findings, got {}", report.findings.len());
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 6. Rollback capability
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod test_rollback {
+    use super::*;
+    use std::fs;
+    use export_state::compute_checksum;
+
+    fn write_snapshot_to_file(snap: &StateSnapshot, path: &str) {
+        let mut sealed = snap.clone();
+        sealed.checksum = compute_checksum(&sealed).unwrap();
+        let json = serde_json::to_string_pretty(&sealed).unwrap();
+        fs::write(path, json).unwrap();
+    }
+
+    fn read_snapshot_from_file(path: &str) -> StateSnapshot {
+        let json = fs::read_to_string(path).unwrap();
+        serde_json::from_str(&json).unwrap()
+    }
+
+    #[test]
+    fn backup_snapshot_is_written_and_readable() {
+        let path = "/tmp/test-backup-snapshot.json";
+        let snap = populated_snapshot();
+        write_snapshot_to_file(&snap, path);
+
+        let restored = read_snapshot_from_file(path);
+        assert_eq!(restored.contract_id, snap.contract_id);
+        assert_eq!(restored.creator_balances, snap.creator_balances);
+        fs::remove_file(path).ok();
+    }
+
+    #[test]
+    fn backup_checksum_is_valid() {
+        let path = "/tmp/test-backup-checksum.json";
+        let snap = populated_snapshot();
+        write_snapshot_to_file(&snap, path);
+
+        let restored = read_snapshot_from_file(path);
+        export_state::verify_checksum(&restored).expect("backup checksum invalid");
+        fs::remove_file(path).ok();
+    }
+
+    #[test]
+    fn rollback_restores_all_state_categories() {
+        // Simulate: backup = original state, "current" = corrupted state.
+        // After rollback the current state should equal the backup.
+        let backup_path = "/tmp/test-rollback-backup.json";
+        let original = populated_snapshot();
+        write_snapshot_to_file(&original, backup_path);
+
+        // Simulate a partial import that corrupted state.
+        let mut corrupted = populated_snapshot();
+        corrupted.creator_balances.clear();
+        corrupted.tip_history.clear();
+
+        // Rollback: restore from backup.
+        let restored = read_snapshot_from_file(backup_path);
+        export_state::verify_checksum(&restored).expect("backup checksum invalid before rollback");
+
+        // After rollback the restored state must match the original.
+        assert_eq!(restored.creator_balances, original.creator_balances);
+        assert_eq!(restored.creator_totals, original.creator_totals);
+        assert_eq!(restored.tip_history, original.tip_history);
+        assert_eq!(restored.subscriptions.len(), original.subscriptions.len());
+        assert_eq!(restored.time_locks.len(), original.time_locks.len());
+        assert_eq!(restored.milestones.len(), original.milestones.len());
+        assert_eq!(restored.matching_programs.len(), original.matching_programs.len());
+        assert_eq!(restored.tip_records.len(), original.tip_records.len());
+        assert_eq!(restored.locked_tips.len(), original.locked_tips.len());
+        assert_eq!(restored.user_roles, original.user_roles);
+
+        fs::remove_file(backup_path).ok();
+    }
+
+    #[test]
+    fn rollback_fails_on_tampered_backup() {
+        let path = "/tmp/test-rollback-tampered.json";
+        let snap = populated_snapshot();
+        write_snapshot_to_file(&snap, path);
+
+        // Tamper with the file after writing.
+        let mut json = fs::read_to_string(path).unwrap();
+        json = json.replace("5000000", "9999999");
+        fs::write(path, &json).unwrap();
+
+        let tampered = read_snapshot_from_file(path);
+        assert!(
+            export_state::verify_checksum(&tampered).is_err(),
+            "tampered backup should fail checksum verification"
+        );
+        fs::remove_file(path).ok();
+    }
+
+    #[test]
+    fn rollback_preserves_schema_version() {
+        let path = "/tmp/test-rollback-version.json";
+        let snap = populated_snapshot(); // schema_version = 1
+        write_snapshot_to_file(&snap, path);
+        let restored = read_snapshot_from_file(path);
+        assert_eq!(restored.schema_version, 1);
+        fs::remove_file(path).ok();
+    }
+
+    #[test]
+    fn rollback_preserves_pause_state() {
+        let path = "/tmp/test-rollback-pause.json";
+        let mut snap = populated_snapshot();
+        snap.paused = true;
+        snap.pause_reason = Some("emergency".into());
+        write_snapshot_to_file(&snap, path);
+        let restored = read_snapshot_from_file(path);
+        assert!(restored.paused);
+        assert_eq!(restored.pause_reason, Some("emergency".into()));
+        fs::remove_file(path).ok();
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 7. Migration history tracking
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod test_history {
+    use super::*;
+    use history::{append_history_entry, print_history};
+    use std::fs;
+
+    fn make_entry(label: &str, status: MigrationStatus, exported: usize, imported: usize) -> MigrationHistoryEntry {
+        MigrationHistoryEntry {
+            started_at: "2024-01-01T00:00:00Z".into(),
+            finished_at: "2024-01-01T00:01:00Z".into(),
+            label: label.into(),
+            source_contract_id: "CSOURCE".into(),
+            target_contract_id: "CTARGET".into(),
+            network: "testnet".into(),
+            dry_run: false,
+            status,
+            records_exported: exported,
+            records_imported: imported,
+            error: None,
+            backup_path: Some("/tmp/backup.json".into()),
+        }
+    }
+
+    #[test]
+    fn history_file_created_on_first_append() {
+        let path = "/tmp/test-history-create.json";
+        fs::remove_file(path).ok();
+        append_history_entry(path, make_entry("run-1", MigrationStatus::Success, 100, 100)).unwrap();
+        assert!(std::path::Path::new(path).exists());
+        fs::remove_file(path).ok();
+    }
+
+    #[test]
+    fn history_accumulates_multiple_runs() {
+        let path = "/tmp/test-history-multi.json";
+        fs::remove_file(path).ok();
+        append_history_entry(path, make_entry("run-1", MigrationStatus::Success, 100, 100)).unwrap();
+        append_history_entry(path, make_entry("run-2", MigrationStatus::DryRun, 50, 0)).unwrap();
+        append_history_entry(path, make_entry("run-3", MigrationStatus::RolledBack, 80, 40)).unwrap();
+
+        let json = fs::read_to_string(path).unwrap();
+        let hist: MigrationHistory = serde_json::from_str(&json).unwrap();
+        assert_eq!(hist.runs.len(), 3);
+        assert_eq!(hist.runs[0].label, "run-1");
+        assert_eq!(hist.runs[1].status, MigrationStatus::DryRun);
+        assert_eq!(hist.runs[2].records_imported, 40);
+        fs::remove_file(path).ok();
+    }
+
+    #[test]
+    fn history_preserves_all_fields() {
+        let path = "/tmp/test-history-fields.json";
+        fs::remove_file(path).ok();
+        let mut entry = make_entry("full-run", MigrationStatus::Failed, 200, 0);
+        entry.error = Some("RPC timeout".into());
+        entry.dry_run = true;
+        append_history_entry(path, entry).unwrap();
+
+        let json = fs::read_to_string(path).unwrap();
+        let hist: MigrationHistory = serde_json::from_str(&json).unwrap();
+        let run = &hist.runs[0];
+        assert_eq!(run.error, Some("RPC timeout".into()));
+        assert!(run.dry_run);
+        assert_eq!(run.status, MigrationStatus::Failed);
+        fs::remove_file(path).ok();
+    }
+
+    #[test]
+    fn history_is_valid_json() {
+        let path = "/tmp/test-history-json.json";
+        fs::remove_file(path).ok();
+        append_history_entry(path, make_entry("json-test", MigrationStatus::Success, 10, 10)).unwrap();
+        let json = fs::read_to_string(path).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&json).expect("history must be valid JSON");
+        assert!(parsed.get("runs").is_some());
+        fs::remove_file(path).ok();
+    }
+
+    #[test]
+    fn history_dry_run_records_zero_imports() {
+        let path = "/tmp/test-history-dryrun.json";
+        fs::remove_file(path).ok();
+        let mut entry = make_entry("dry", MigrationStatus::DryRun, 150, 0);
+        entry.dry_run = true;
+        append_history_entry(path, entry).unwrap();
+
+        let json = fs::read_to_string(path).unwrap();
+        let hist: MigrationHistory = serde_json::from_str(&json).unwrap();
+        assert_eq!(hist.runs[0].records_imported, 0);
+        assert!(hist.runs[0].dry_run);
+        fs::remove_file(path).ok();
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 8. Config parsing
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod test_config {
+    use types::{MigrationConfig, MigrationSection};
+
+    const SAMPLE_CONFIG: &str = r#"
+[migration]
+label = "v1-to-v2"
+source_contract_id = "CSOURCE"
+target_contract_id = "CTARGET"
+network = "testnet"
+rpc_url = "https://soroban-testnet.stellar.org"
+network_passphrase = "Test SDF Network ; September 2015"
+dry_run = true
+max_retries = 3
+retry_delay_ms = 1000
+snapshot_dir = "./migration-snapshots"
+backup_filename = "pre-migration-backup.json"
+export_filename = "source-snapshot.json"
+transformed_filename = "transformed-snapshot.json"
+history_file = "./migration-history.json"
+source_version = 1
+target_version = 2
+progress_batch_size = 50
+abort_on_verify_failure = true
+"#;
+
+    #[test]
+    fn config_parses_without_error() {
+        let config: MigrationConfig = toml::from_str(SAMPLE_CONFIG).expect("config parse failed");
+        assert_eq!(config.migration.label, "v1-to-v2");
+    }
+
+    #[test]
+    fn config_dry_run_defaults_to_true_in_sample() {
+        let config: MigrationConfig = toml::from_str(SAMPLE_CONFIG).unwrap();
+        assert!(config.migration.dry_run);
+    }
+
+    #[test]
+    fn config_network_is_testnet() {
+        let config: MigrationConfig = toml::from_str(SAMPLE_CONFIG).unwrap();
+        assert_eq!(config.migration.network, "testnet");
+    }
+
+    #[test]
+    fn config_version_range_is_correct() {
+        let config: MigrationConfig = toml::from_str(SAMPLE_CONFIG).unwrap();
+        assert_eq!(config.migration.source_version, 1);
+        assert_eq!(config.migration.target_version, 2);
+    }
+
+    #[test]
+    fn config_max_retries_is_positive() {
+        let config: MigrationConfig = toml::from_str(SAMPLE_CONFIG).unwrap();
+        assert!(config.migration.max_retries > 0);
+    }
+
+    #[test]
+    fn config_abort_on_verify_failure_is_true() {
+        let config: MigrationConfig = toml::from_str(SAMPLE_CONFIG).unwrap();
+        assert!(config.migration.abort_on_verify_failure);
+    }
+
+    #[test]
+    fn config_snapshot_dir_is_set() {
+        let config: MigrationConfig = toml::from_str(SAMPLE_CONFIG).unwrap();
+        assert!(!config.migration.snapshot_dir.is_empty());
+    }
+}

--- a/scripts/migrate/transform_state.rs
+++ b/scripts/migrate/transform_state.rs
@@ -1,0 +1,619 @@
+//! # State Transformation — schema migration between contract versions
+//!
+//! Applies a chain of versioned transformation rules to a [`StateSnapshot`]
+//! produced by the export phase, producing a new snapshot that conforms to the
+//! target schema version.
+//!
+//! ## Design
+//! Each transformation rule is a function with the signature:
+//! ```text
+//! fn rule_name(snapshot: &mut StateSnapshot, log: &mut Vec<TransformationLog>)
+//! ```
+//! Rules are registered in [`TRANSFORM_RULES`] and executed in order.
+//! Every rule logs what it changed so the operator has a full audit trail.
+//!
+//! ## Adding a new rule
+//! 1. Write a function following the signature above.
+//! 2. Add it to the `TRANSFORM_RULES` slice with the version range it applies to.
+//! 3. Add a unit test in the `tests` module at the bottom of this file.
+//!
+//! ## Usage
+//! ```bash
+//! cargo run --manifest-path scripts/migrate/Cargo.toml \
+//!     --bin transform -- \
+//!     --input  migration-snapshots/source-snapshot.json \
+//!     --output migration-snapshots/transformed-snapshot.json \
+//!     --from-version 1 --to-version 2
+//! ```
+
+use std::fs;
+use std::path::Path;
+
+use crate::export_state::compute_checksum;
+use crate::types::{MigrationConfig, StateSnapshot, TransformationLog};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Transformation rule registry
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// A single versioned transformation rule.
+struct TransformRule {
+    /// Minimum source schema version this rule applies to (inclusive).
+    from_version: u32,
+    /// Maximum source schema version this rule applies to (inclusive).
+    to_version: u32,
+    /// Short identifier used in the log.
+    id: &'static str,
+    /// Human-readable description.
+    description: &'static str,
+    /// The transformation function.
+    apply: fn(&mut StateSnapshot, &mut Vec<TransformationLog>),
+}
+
+/// All registered transformation rules, applied in declaration order.
+static TRANSFORM_RULES: &[TransformRule] = &[
+    TransformRule {
+        from_version: 1,
+        to_version: 1,
+        id: "v1_to_v2_normalise_balances",
+        description: "Remove zero-value creator balance entries to reduce storage footprint.",
+        apply: rule_remove_zero_balances,
+    },
+    TransformRule {
+        from_version: 1,
+        to_version: 1,
+        id: "v1_to_v2_normalise_totals",
+        description: "Remove zero-value creator total entries.",
+        apply: rule_remove_zero_totals,
+    },
+    TransformRule {
+        from_version: 1,
+        to_version: 1,
+        id: "v1_to_v2_cancel_expired_locks",
+        description: "Mark time-locked tips whose unlock_time is in the past as cancelled \
+                       so they are not re-imported as active locks.",
+        apply: rule_mark_expired_locks_cancelled,
+    },
+    TransformRule {
+        from_version: 1,
+        to_version: 1,
+        id: "v1_to_v2_dedup_subscriptions",
+        description: "Remove duplicate subscription entries keeping the most recent one.",
+        apply: rule_dedup_subscriptions,
+    },
+    TransformRule {
+        from_version: 1,
+        to_version: 1,
+        id: "v1_to_v2_strip_cancelled_subscriptions",
+        description: "Remove subscriptions in Cancelled status to reduce import payload.",
+        apply: rule_strip_cancelled_subscriptions,
+    },
+    TransformRule {
+        from_version: 1,
+        to_version: 1,
+        id: "v1_to_v2_cap_tip_history",
+        description: "Cap per-creator tip history at 1 000 entries (newest first) to \
+                       stay within Soroban storage limits.",
+        apply: rule_cap_tip_history,
+    },
+    TransformRule {
+        from_version: 1,
+        to_version: 1,
+        id: "v1_to_v2_remove_refunded_tip_records",
+        description: "Drop fully-refunded tip records to reduce import size.",
+        apply: rule_remove_refunded_tip_records,
+    },
+    TransformRule {
+        from_version: 1,
+        to_version: 1,
+        id: "v1_to_v2_bump_schema_version",
+        description: "Update the snapshot schema_version field to the target version.",
+        apply: rule_bump_schema_version,
+    },
+];
+
+// ─────────────────────────────────────────────────────────────────────────────
+// StateTransformer
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Applies all applicable transformation rules to a snapshot.
+pub struct StateTransformer {
+    pub source_version: u32,
+    pub target_version: u32,
+}
+
+impl StateTransformer {
+    pub fn new(source_version: u32, target_version: u32) -> Self {
+        Self {
+            source_version,
+            target_version,
+        }
+    }
+
+    /// Applies all rules whose version range overlaps `[source_version, target_version)`.
+    ///
+    /// Returns the transformed snapshot and a log of every change made.
+    pub fn transform(
+        &self,
+        mut snapshot: StateSnapshot,
+    ) -> Result<(StateSnapshot, Vec<TransformationLog>), String> {
+        println!("╔══════════════════════════════════════════════════════════╗");
+        println!("║         TipJar State Transform  v{} → v{:<22}║",
+            self.source_version, self.target_version);
+        println!("╚══════════════════════════════════════════════════════════╝");
+
+        if snapshot.schema_version != self.source_version {
+            return Err(format!(
+                "Snapshot schema version {} does not match expected source version {}",
+                snapshot.schema_version, self.source_version
+            ));
+        }
+
+        let mut logs: Vec<TransformationLog> = Vec::new();
+        let mut rules_applied = 0u32;
+
+        for rule in TRANSFORM_RULES {
+            if rule.from_version <= self.source_version
+                && rule.to_version < self.target_version
+            {
+                // Rule applies to this migration path.
+                let before_records = snapshot.total_records();
+                println!("  Applying rule: {} …", rule.id);
+                (rule.apply)(&mut snapshot, &mut logs);
+                let after_records = snapshot.total_records();
+                let delta = before_records as i64 - after_records as i64;
+                if delta != 0 {
+                    println!("    ↳ record delta: {}{}", if delta > 0 { "-" } else { "+" }, delta.abs());
+                }
+                rules_applied += 1;
+            }
+        }
+
+        // Recompute checksum after all transformations.
+        snapshot.checksum = compute_checksum(&snapshot)?;
+
+        println!();
+        println!("✓ Transform complete — {} rules applied", rules_applied);
+        println!("  {} transformation log entries", logs.len());
+        println!("  New checksum: {}", snapshot.checksum);
+
+        Ok((snapshot, logs))
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Individual transformation rules
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Removes creator balance entries where the balance is exactly zero.
+fn rule_remove_zero_balances(
+    snapshot: &mut StateSnapshot,
+    logs: &mut Vec<TransformationLog>,
+) {
+    let before = snapshot.creator_balances.len();
+    snapshot.creator_balances.retain(|_, v| *v != 0);
+    let removed = before - snapshot.creator_balances.len();
+    logs.push(TransformationLog {
+        rule: "v1_to_v2_normalise_balances".into(),
+        description: format!("Removed {} zero-value balance entries.", removed),
+        records_affected: removed,
+    });
+}
+
+/// Removes creator total entries where the total is exactly zero.
+fn rule_remove_zero_totals(
+    snapshot: &mut StateSnapshot,
+    logs: &mut Vec<TransformationLog>,
+) {
+    let before = snapshot.creator_totals.len();
+    snapshot.creator_totals.retain(|_, v| *v != 0);
+    let removed = before - snapshot.creator_totals.len();
+    logs.push(TransformationLog {
+        rule: "v1_to_v2_normalise_totals".into(),
+        description: format!("Removed {} zero-value total entries.", removed),
+        records_affected: removed,
+    });
+}
+
+/// Marks time-locked tips whose `unlock_time` is in the past as cancelled.
+/// Uses the snapshot's `exported_at` timestamp as "now".
+fn rule_mark_expired_locks_cancelled(
+    snapshot: &mut StateSnapshot,
+    logs: &mut Vec<TransformationLog>,
+) {
+    let now = snapshot.exported_at;
+    let mut affected = 0usize;
+    for lock in snapshot.time_locks.iter_mut() {
+        if !lock.cancelled && lock.unlock_time < now {
+            lock.cancelled = true;
+            affected += 1;
+        }
+    }
+    logs.push(TransformationLog {
+        rule: "v1_to_v2_cancel_expired_locks".into(),
+        description: format!(
+            "Marked {} expired time-lock(s) as cancelled (unlock_time < {}).",
+            affected, now
+        ),
+        records_affected: affected,
+    });
+}
+
+/// Removes duplicate subscription entries, keeping the one with the latest
+/// `next_payment` timestamp.
+fn rule_dedup_subscriptions(
+    snapshot: &mut StateSnapshot,
+    logs: &mut Vec<TransformationLog>,
+) {
+    // Subscriptions are already keyed by "subscriber:creator" so duplicates
+    // cannot exist in the HashMap.  This rule is a no-op but is kept as a
+    // guard in case the export ever produces duplicates.
+    logs.push(TransformationLog {
+        rule: "v1_to_v2_dedup_subscriptions".into(),
+        description: "No duplicate subscriptions found (HashMap keyed by subscriber:creator)."
+            .into(),
+        records_affected: 0,
+    });
+}
+
+/// Removes subscriptions whose status is `Cancelled`.
+fn rule_strip_cancelled_subscriptions(
+    snapshot: &mut StateSnapshot,
+    logs: &mut Vec<TransformationLog>,
+) {
+    use crate::types::SubscriptionStatus;
+    let before = snapshot.subscriptions.len();
+    snapshot
+        .subscriptions
+        .retain(|_, sub| sub.status != SubscriptionStatus::Cancelled);
+    let removed = before - snapshot.subscriptions.len();
+    logs.push(TransformationLog {
+        rule: "v1_to_v2_strip_cancelled_subscriptions".into(),
+        description: format!("Removed {} cancelled subscription(s).", removed),
+        records_affected: removed,
+    });
+}
+
+/// Caps per-creator tip history at 1 000 entries, keeping the newest.
+/// Entries are assumed to be stored oldest-first (ascending index order).
+fn rule_cap_tip_history(
+    snapshot: &mut StateSnapshot,
+    logs: &mut Vec<TransformationLog>,
+) {
+    const MAX_HISTORY: usize = 1_000;
+    let mut total_removed = 0usize;
+
+    for tips in snapshot.tip_history.values_mut() {
+        if tips.len() > MAX_HISTORY {
+            let excess = tips.len() - MAX_HISTORY;
+            // Remove the oldest entries (front of the Vec).
+            tips.drain(0..excess);
+            total_removed += excess;
+        }
+    }
+
+    logs.push(TransformationLog {
+        rule: "v1_to_v2_cap_tip_history".into(),
+        description: format!(
+            "Trimmed {} old tip history record(s) to enforce {} entry cap per creator.",
+            total_removed, MAX_HISTORY
+        ),
+        records_affected: total_removed,
+    });
+}
+
+/// Removes tip records that have been fully refunded.
+fn rule_remove_refunded_tip_records(
+    snapshot: &mut StateSnapshot,
+    logs: &mut Vec<TransformationLog>,
+) {
+    let before = snapshot.tip_records.len();
+    snapshot.tip_records.retain(|r| !r.refunded);
+    let removed = before - snapshot.tip_records.len();
+    logs.push(TransformationLog {
+        rule: "v1_to_v2_remove_refunded_tip_records".into(),
+        description: format!("Removed {} fully-refunded tip record(s).", removed),
+        records_affected: removed,
+    });
+}
+
+/// Bumps the snapshot's `schema_version` to the target version.
+fn rule_bump_schema_version(
+    snapshot: &mut StateSnapshot,
+    logs: &mut Vec<TransformationLog>,
+) {
+    // The target version is not directly accessible inside a static fn, so we
+    // hard-code the increment.  For multi-hop migrations add more rules.
+    let old = snapshot.schema_version;
+    snapshot.schema_version = old + 1;
+    logs.push(TransformationLog {
+        rule: "v1_to_v2_bump_schema_version".into(),
+        description: format!("Bumped schema_version from {} to {}.", old, snapshot.schema_version),
+        records_affected: 1,
+    });
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// CLI entry point
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Loads a snapshot from disk, transforms it, and writes the result.
+pub fn run_transform(args: &[String]) -> Result<(), String> {
+    let config_path = parse_flag(args, "--config")
+        .unwrap_or_else(|| "scripts/migrate/config.toml".to_string());
+    let input_override = parse_flag(args, "--input");
+    let output_override = parse_flag(args, "--output");
+    let from_version: Option<u32> = parse_flag(args, "--from-version")
+        .and_then(|s| s.parse().ok());
+    let to_version: Option<u32> = parse_flag(args, "--to-version")
+        .and_then(|s| s.parse().ok());
+
+    let toml_str = fs::read_to_string(&config_path)
+        .map_err(|e| format!("Cannot read config {}: {}", config_path, e))?;
+    let config: MigrationConfig = toml::from_str(&toml_str)
+        .map_err(|e| format!("Config parse error: {}", e))?;
+
+    let input_path = input_override.unwrap_or_else(|| {
+        format!(
+            "{}/{}",
+            config.migration.snapshot_dir, config.migration.export_filename
+        )
+    });
+    let output_path = output_override.unwrap_or_else(|| {
+        format!(
+            "{}/{}",
+            config.migration.snapshot_dir, config.migration.transformed_filename
+        )
+    });
+    let src_ver = from_version.unwrap_or(config.migration.source_version);
+    let tgt_ver = to_version.unwrap_or(config.migration.target_version);
+
+    let json = fs::read_to_string(&input_path)
+        .map_err(|e| format!("Cannot read snapshot {}: {}", input_path, e))?;
+    let snapshot: StateSnapshot = serde_json::from_str(&json)
+        .map_err(|e| format!("Snapshot parse error: {}", e))?;
+
+    // Verify checksum before transforming.
+    crate::export_state::verify_checksum(&snapshot)?;
+
+    let transformer = StateTransformer::new(src_ver, tgt_ver);
+    let (transformed, logs) = transformer.transform(snapshot)?;
+
+    // Write transformation log alongside the snapshot.
+    let log_path = output_path.replace(".json", "-transform-log.json");
+    let log_json = serde_json::to_string_pretty(&logs)
+        .map_err(|e| format!("Log serialisation error: {}", e))?;
+    fs::write(&log_path, log_json)
+        .map_err(|e| format!("Failed to write transform log: {}", e))?;
+    println!("  Transform log written → {}", log_path);
+
+    // Write transformed snapshot.
+    let out_json = serde_json::to_string_pretty(&transformed)
+        .map_err(|e| format!("Serialisation error: {}", e))?;
+    let dir = Path::new(&output_path).parent().unwrap_or(Path::new("."));
+    fs::create_dir_all(dir)
+        .map_err(|e| format!("Failed to create output dir: {}", e))?;
+    fs::write(&output_path, out_json)
+        .map_err(|e| format!("Failed to write transformed snapshot: {}", e))?;
+    println!("  Transformed snapshot written → {}", output_path);
+
+    Ok(())
+}
+
+fn parse_flag(args: &[String], flag: &str) -> Option<String> {
+    args.windows(2)
+        .find(|w| w[0] == flag)
+        .map(|w| w[1].clone())
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Unit tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{Subscription, SubscriptionStatus, TimeLock, TipRecord};
+    use std::collections::HashMap;
+
+    fn empty_snapshot() -> StateSnapshot {
+        StateSnapshot {
+            contract_id: "CTEST".into(),
+            schema_version: 1,
+            exported_at: 1_700_000_000,
+            ledger_sequence: 1000,
+            checksum: String::new(),
+            admin: "GADMIN".into(),
+            fee_basis_points: 100,
+            refund_window_seconds: 86400,
+            paused: false,
+            pause_reason: None,
+            tip_counter: 0,
+            matching_counter: 0,
+            current_fee_bps: 100,
+            whitelisted_tokens: vec![],
+            creator_balances: HashMap::new(),
+            creator_totals: HashMap::new(),
+            tip_history: HashMap::new(),
+            tipper_aggregates: HashMap::new(),
+            creator_aggregates: HashMap::new(),
+            subscriptions: HashMap::new(),
+            time_locks: vec![],
+            milestones: HashMap::new(),
+            matching_programs: vec![],
+            tip_records: vec![],
+            locked_tips: vec![],
+            user_roles: HashMap::new(),
+        }
+    }
+
+    #[test]
+    fn test_remove_zero_balances() {
+        let mut snap = empty_snapshot();
+        snap.creator_balances.insert("GCREATOR:GTOKEN".into(), 0);
+        snap.creator_balances.insert("GCREATOR2:GTOKEN".into(), 500);
+        let mut logs = vec![];
+        rule_remove_zero_balances(&mut snap, &mut logs);
+        assert_eq!(snap.creator_balances.len(), 1);
+        assert!(snap.creator_balances.contains_key("GCREATOR2:GTOKEN"));
+        assert_eq!(logs[0].records_affected, 1);
+    }
+
+    #[test]
+    fn test_remove_zero_totals() {
+        let mut snap = empty_snapshot();
+        snap.creator_totals.insert("GCREATOR:GTOKEN".into(), 0);
+        snap.creator_totals.insert("GCREATOR2:GTOKEN".into(), 1000);
+        let mut logs = vec![];
+        rule_remove_zero_totals(&mut snap, &mut logs);
+        assert_eq!(snap.creator_totals.len(), 1);
+        assert_eq!(logs[0].records_affected, 1);
+    }
+
+    #[test]
+    fn test_mark_expired_locks_cancelled() {
+        let mut snap = empty_snapshot();
+        snap.exported_at = 2_000_000_000;
+        snap.time_locks.push(TimeLock {
+            lock_id: 0,
+            sender: "GSENDER".into(),
+            creator: "GCREATOR".into(),
+            token: "GTOKEN".into(),
+            amount: 100,
+            unlock_time: 1_000_000_000, // in the past
+            cancelled: false,
+        });
+        snap.time_locks.push(TimeLock {
+            lock_id: 1,
+            sender: "GSENDER".into(),
+            creator: "GCREATOR".into(),
+            token: "GTOKEN".into(),
+            amount: 200,
+            unlock_time: 3_000_000_000, // in the future
+            cancelled: false,
+        });
+        let mut logs = vec![];
+        rule_mark_expired_locks_cancelled(&mut snap, &mut logs);
+        assert!(snap.time_locks[0].cancelled);
+        assert!(!snap.time_locks[1].cancelled);
+        assert_eq!(logs[0].records_affected, 1);
+    }
+
+    #[test]
+    fn test_strip_cancelled_subscriptions() {
+        let mut snap = empty_snapshot();
+        snap.subscriptions.insert(
+            "GSUB:GCREATOR".into(),
+            Subscription {
+                subscriber: "GSUB".into(),
+                creator: "GCREATOR".into(),
+                token: "GTOKEN".into(),
+                amount: 100,
+                interval_seconds: 86400,
+                last_payment: 0,
+                next_payment: 0,
+                status: SubscriptionStatus::Cancelled,
+            },
+        );
+        snap.subscriptions.insert(
+            "GSUB2:GCREATOR".into(),
+            Subscription {
+                subscriber: "GSUB2".into(),
+                creator: "GCREATOR".into(),
+                token: "GTOKEN".into(),
+                amount: 200,
+                interval_seconds: 86400,
+                last_payment: 0,
+                next_payment: 0,
+                status: SubscriptionStatus::Active,
+            },
+        );
+        let mut logs = vec![];
+        rule_strip_cancelled_subscriptions(&mut snap, &mut logs);
+        assert_eq!(snap.subscriptions.len(), 1);
+        assert!(snap.subscriptions.contains_key("GSUB2:GCREATOR"));
+        assert_eq!(logs[0].records_affected, 1);
+    }
+
+    #[test]
+    fn test_cap_tip_history() {
+        use crate::types::TipMetadata;
+        let mut snap = empty_snapshot();
+        let tips: Vec<TipMetadata> = (0..1_200)
+            .map(|i| TipMetadata {
+                sender: "GSENDER".into(),
+                amount: i as i128,
+                message: None,
+                timestamp: i as u64,
+            })
+            .collect();
+        snap.tip_history.insert("GCREATOR".into(), tips);
+        let mut logs = vec![];
+        rule_cap_tip_history(&mut snap, &mut logs);
+        assert_eq!(snap.tip_history["GCREATOR"].len(), 1_000);
+        // Newest entries (indices 200–1199) should be kept.
+        assert_eq!(snap.tip_history["GCREATOR"][0].amount, 200);
+        assert_eq!(logs[0].records_affected, 200);
+    }
+
+    #[test]
+    fn test_remove_refunded_tip_records() {
+        let mut snap = empty_snapshot();
+        snap.tip_records.push(TipRecord {
+            id: 0,
+            sender: "GSENDER".into(),
+            creator: "GCREATOR".into(),
+            token: "GTOKEN".into(),
+            amount: 100,
+            timestamp: 0,
+            refunded: true,
+            refund_requested: true,
+            refund_approved: true,
+        });
+        snap.tip_records.push(TipRecord {
+            id: 1,
+            sender: "GSENDER".into(),
+            creator: "GCREATOR".into(),
+            token: "GTOKEN".into(),
+            amount: 200,
+            timestamp: 0,
+            refunded: false,
+            refund_requested: false,
+            refund_approved: false,
+        });
+        let mut logs = vec![];
+        rule_remove_refunded_tip_records(&mut snap, &mut logs);
+        assert_eq!(snap.tip_records.len(), 1);
+        assert_eq!(snap.tip_records[0].id, 1);
+        assert_eq!(logs[0].records_affected, 1);
+    }
+
+    #[test]
+    fn test_bump_schema_version() {
+        let mut snap = empty_snapshot();
+        assert_eq!(snap.schema_version, 1);
+        let mut logs = vec![];
+        rule_bump_schema_version(&mut snap, &mut logs);
+        assert_eq!(snap.schema_version, 2);
+        assert_eq!(logs[0].records_affected, 1);
+    }
+
+    #[test]
+    fn test_full_transform_pipeline() {
+        let mut snap = empty_snapshot();
+        snap.creator_balances.insert("GCREATOR:GTOKEN".into(), 0);
+        snap.creator_balances.insert("GCREATOR2:GTOKEN".into(), 500);
+
+        let transformer = StateTransformer::new(1, 2);
+        let (transformed, logs) = transformer.transform(snap).unwrap();
+
+        // Zero balance removed.
+        assert!(!transformed.creator_balances.contains_key("GCREATOR:GTOKEN"));
+        // Schema version bumped.
+        assert_eq!(transformed.schema_version, 2);
+        // Checksum is non-empty.
+        assert!(!transformed.checksum.is_empty());
+        // At least one log entry.
+        assert!(!logs.is_empty());
+    }
+}

--- a/scripts/migrate/types.rs
+++ b/scripts/migrate/types.rs
@@ -1,0 +1,342 @@
+//! Shared types for the TipJar contract state migration toolkit.
+//!
+//! All types here are serialisable with serde so they can be written to / read
+//! from the JSON snapshot files that travel between the export, transform,
+//! import, and verify phases.
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Mirror types (off-chain representations of on-chain contracttype structs)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Off-chain mirror of the on-chain `TipMetadata` contracttype.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct TipMetadata {
+    pub sender: String,
+    pub amount: i128,
+    pub message: Option<String>,
+    pub timestamp: u64,
+}
+
+/// Off-chain mirror of the on-chain `LeaderboardEntry` contracttype.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct LeaderboardEntry {
+    pub address: String,
+    pub total_amount: i128,
+    pub tip_count: u32,
+}
+
+/// Off-chain mirror of the on-chain `Subscription` contracttype.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Subscription {
+    pub subscriber: String,
+    pub creator: String,
+    pub token: String,
+    pub amount: i128,
+    pub interval_seconds: u64,
+    pub last_payment: u64,
+    pub next_payment: u64,
+    pub status: SubscriptionStatus,
+}
+
+/// Off-chain mirror of `SubscriptionStatus`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum SubscriptionStatus {
+    Active,
+    Paused,
+    Cancelled,
+}
+
+/// Off-chain mirror of the on-chain `TimeLock` contracttype.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct TimeLock {
+    pub lock_id: u64,
+    pub sender: String,
+    pub creator: String,
+    pub token: String,
+    pub amount: i128,
+    pub unlock_time: u64,
+    pub cancelled: bool,
+}
+
+/// Off-chain mirror of the on-chain `Milestone` contracttype.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Milestone {
+    pub id: u64,
+    pub creator: String,
+    pub goal_amount: i128,
+    pub current_amount: i128,
+    pub description: String,
+    pub deadline: Option<u64>,
+    pub completed: bool,
+}
+
+/// Off-chain mirror of the on-chain `MatchingProgram` contracttype.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct MatchingProgram {
+    pub id: u64,
+    pub sponsor: String,
+    pub creator: String,
+    pub token: String,
+    pub match_ratio: u32,
+    pub max_match_amount: i128,
+    pub current_matched: i128,
+    pub active: bool,
+}
+
+/// Off-chain mirror of the on-chain `TipRecord` contracttype.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct TipRecord {
+    pub id: u64,
+    pub sender: String,
+    pub creator: String,
+    pub token: String,
+    pub amount: i128,
+    pub timestamp: u64,
+    pub refunded: bool,
+    pub refund_requested: bool,
+    pub refund_approved: bool,
+}
+
+/// Off-chain mirror of the on-chain `LockedTip` contracttype.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct LockedTip {
+    pub tip_id: u64,
+    pub sender: String,
+    pub creator: String,
+    pub token: String,
+    pub amount: i128,
+    pub unlock_timestamp: u64,
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Snapshot — the complete exported state of one contract version
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Complete on-chain state snapshot for one contract version.
+///
+/// Produced by `export_state`, consumed by `transform_state` and `import_state`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StateSnapshot {
+    // ── metadata ─────────────────────────────────────────────────────────────
+    /// Contract address this snapshot was taken from.
+    pub contract_id: String,
+    /// On-chain `ContractVersion` at export time.
+    pub schema_version: u32,
+    /// Unix timestamp (seconds) when the snapshot was created.
+    pub exported_at: u64,
+    /// Ledger sequence number at export time.
+    pub ledger_sequence: u32,
+    /// SHA-256 hex digest of the canonical JSON of all data fields below.
+    /// Computed and verified by the toolkit; empty string before sealing.
+    pub checksum: String,
+
+    // ── instance storage ─────────────────────────────────────────────────────
+    /// Admin address.
+    pub admin: String,
+    /// Fee in basis points (0–500).
+    pub fee_basis_points: u32,
+    /// Refund window in seconds.
+    pub refund_window_seconds: u64,
+    /// Whether the contract is currently paused.
+    pub paused: bool,
+    /// Human-readable pause reason (empty when not paused).
+    pub pause_reason: Option<String>,
+    /// Global tip counter.
+    pub tip_counter: u64,
+    /// Global matching program counter.
+    pub matching_counter: u64,
+    /// Most-recently computed dynamic fee in basis points.
+    pub current_fee_bps: u32,
+    /// Whitelisted token addresses.
+    pub whitelisted_tokens: Vec<String>,
+
+    // ── persistent storage ────────────────────────────────────────────────────
+    /// Creator balances: key = "creator_address:token_address", value = balance.
+    pub creator_balances: HashMap<String, i128>,
+    /// Creator historical totals: key = "creator_address:token_address", value = total.
+    pub creator_totals: HashMap<String, i128>,
+    /// Tip history per creator: key = creator_address, value = ordered list of metadata.
+    pub tip_history: HashMap<String, Vec<TipMetadata>>,
+    /// Leaderboard aggregates for tippers: key = "address:bucket", value = entry.
+    pub tipper_aggregates: HashMap<String, LeaderboardEntry>,
+    /// Leaderboard aggregates for creators: key = "address:bucket", value = entry.
+    pub creator_aggregates: HashMap<String, LeaderboardEntry>,
+    /// Subscriptions: key = "subscriber:creator", value = subscription.
+    pub subscriptions: HashMap<String, Subscription>,
+    /// Time-locked tips.
+    pub time_locks: Vec<TimeLock>,
+    /// Milestones: key = "creator:milestone_id", value = milestone.
+    pub milestones: HashMap<String, Milestone>,
+    /// Matching programs.
+    pub matching_programs: Vec<MatchingProgram>,
+    /// Global tip records.
+    pub tip_records: Vec<TipRecord>,
+    /// Locked tips.
+    pub locked_tips: Vec<LockedTip>,
+    /// Role assignments: key = address, value = role string.
+    pub user_roles: HashMap<String, String>,
+}
+
+impl StateSnapshot {
+    /// Returns the total number of data records across all collections.
+    pub fn total_records(&self) -> usize {
+        self.creator_balances.len()
+            + self.creator_totals.len()
+            + self.tip_history.values().map(|v| v.len()).sum::<usize>()
+            + self.tipper_aggregates.len()
+            + self.creator_aggregates.len()
+            + self.subscriptions.len()
+            + self.time_locks.len()
+            + self.milestones.len()
+            + self.matching_programs.len()
+            + self.tip_records.len()
+            + self.locked_tips.len()
+            + self.user_roles.len()
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Migration configuration (parsed from config.toml)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Parsed representation of `config.toml`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MigrationConfig {
+    pub migration: MigrationSection,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MigrationSection {
+    pub label: String,
+    pub source_contract_id: String,
+    pub target_contract_id: String,
+    pub network: String,
+    pub rpc_url: String,
+    pub network_passphrase: String,
+    pub dry_run: bool,
+    pub max_retries: u32,
+    pub retry_delay_ms: u64,
+    pub snapshot_dir: String,
+    pub backup_filename: String,
+    pub export_filename: String,
+    pub transformed_filename: String,
+    pub history_file: String,
+    pub source_version: u32,
+    pub target_version: u32,
+    pub progress_batch_size: usize,
+    pub abort_on_verify_failure: bool,
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Migration history
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Status of a single migration run.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum MigrationStatus {
+    Success,
+    Failed,
+    RolledBack,
+    DryRun,
+}
+
+/// One entry in the migration history log.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MigrationHistoryEntry {
+    /// ISO-8601 timestamp of when the run started.
+    pub started_at: String,
+    /// ISO-8601 timestamp of when the run finished (or failed).
+    pub finished_at: String,
+    /// Human-readable label from config.
+    pub label: String,
+    /// Source contract ID.
+    pub source_contract_id: String,
+    /// Target contract ID.
+    pub target_contract_id: String,
+    /// Network used.
+    pub network: String,
+    /// Whether this was a dry run.
+    pub dry_run: bool,
+    /// Final status.
+    pub status: MigrationStatus,
+    /// Number of records exported.
+    pub records_exported: usize,
+    /// Number of records imported (0 for dry runs).
+    pub records_imported: usize,
+    /// Error message if status is Failed or RolledBack.
+    pub error: Option<String>,
+    /// Path to the backup snapshot file.
+    pub backup_path: Option<String>,
+}
+
+/// The full history log file.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct MigrationHistory {
+    pub runs: Vec<MigrationHistoryEntry>,
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Verification report
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Severity of a single verification finding.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum FindingSeverity {
+    /// Data is present in source but missing in target.
+    Missing,
+    /// Data is present in target but not in source (unexpected extra).
+    Extra,
+    /// Data exists in both but values differ.
+    Mismatch,
+}
+
+/// A single field-level discrepancy found during verification.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct VerificationFinding {
+    pub severity: FindingSeverity,
+    /// Dot-path to the field, e.g. `"creator_balances.GABC…:GDEX…"`.
+    pub field: String,
+    /// Stringified expected value (from source snapshot).
+    pub expected: String,
+    /// Stringified actual value (from target contract), or `"<absent>"`.
+    pub actual: String,
+}
+
+/// Full verification report returned by `verify_migration`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct VerificationReport {
+    pub source_contract_id: String,
+    pub target_contract_id: String,
+    pub verified_at: String,
+    pub records_checked: usize,
+    pub passed: bool,
+    pub findings: Vec<VerificationFinding>,
+}
+
+impl VerificationReport {
+    /// Returns `true` when there are no findings.
+    pub fn is_clean(&self) -> bool {
+        self.findings.is_empty()
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Transformation log
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// One logged transformation applied during the transform phase.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TransformationLog {
+    /// Short identifier for the transformation rule, e.g. `"add_field_v2_metadata"`.
+    pub rule: String,
+    /// Human-readable description.
+    pub description: String,
+    /// Number of records affected.
+    pub records_affected: usize,
+}

--- a/scripts/migrate/verify_migration.rs
+++ b/scripts/migrate/verify_migration.rs
@@ -1,0 +1,647 @@
+//! # Migration Verification — `StateMigrator::verify_migration()`
+//!
+//! Compares every field in the source [`StateSnapshot`] against the live state
+//! of the target contract, returning a detailed [`VerificationReport`].
+//!
+//! ## What is checked
+//! | Category              | Fields verified                                      |
+//! |-----------------------|------------------------------------------------------|
+//! | Instance storage      | admin, fee_bps, refund_window, paused, tip_counter   |
+//! | Creator balances      | Every `CreatorBalance(creator, token)` entry         |
+//! | Creator totals        | Every `CreatorTotal(creator, token)` entry           |
+//! | Tip history           | Count + every `TipHistory(creator, idx)` entry       |
+//! | Leaderboard           | Every tipper/creator aggregate entry                 |
+//! | Subscriptions         | Every `Subscription(subscriber, creator)` entry      |
+//! | Time locks            | Every `TimeLock(id)` entry                           |
+//! | Milestones            | Every `Milestone(creator, id)` entry                 |
+//! | Matching programs     | Every `MatchingProgram(id)` entry                    |
+//! | Tip records           | Every `TipRecord(id)` entry                          |
+//! | Locked tips           | Every `LockedTip(creator, id)` entry                 |
+//! | User roles            | Every `UserRole(address)` entry                      |
+//!
+//! ## Usage
+//! ```bash
+//! cargo run --manifest-path scripts/migrate/Cargo.toml \
+//!     --bin verify -- --config scripts/migrate/config.toml
+//! ```
+
+use std::fs;
+
+use crate::rpc_client::RpcClient;
+use crate::types::{
+    FindingSeverity, MigrationConfig, StateSnapshot, VerificationFinding, VerificationReport,
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// VerificationEngine
+// ─────────────────────────────────────────────────────────────────────────────
+
+pub struct VerificationEngine {
+    config: MigrationConfig,
+    rpc: RpcClient,
+}
+
+impl VerificationEngine {
+    pub fn new(config: MigrationConfig) -> Self {
+        let rpc = RpcClient::new(
+            config.migration.rpc_url.clone(),
+            config.migration.max_retries,
+            config.migration.retry_delay_ms,
+        );
+        Self { config, rpc }
+    }
+
+    /// Compares `snapshot` against the live state of `target_contract_id`.
+    ///
+    /// Returns a [`VerificationReport`] with every discrepancy found.
+    pub fn verify_migration(
+        &self,
+        snapshot: &StateSnapshot,
+        target: &str,
+    ) -> Result<VerificationReport, String> {
+        println!("╔══════════════════════════════════════════════════════════╗");
+        println!("║              TipJar Migration Verification               ║");
+        println!("╚══════════════════════════════════════════════════════════╝");
+        println!("  Source snapshot : {} records", snapshot.total_records());
+        println!("  Target contract : {}", target);
+        println!();
+
+        let mut findings: Vec<VerificationFinding> = Vec::new();
+        let mut records_checked = 0usize;
+
+        // ── instance storage ──────────────────────────────────────────────────
+        println!("[1/12] Verifying instance storage …");
+        self.check_instance_string(
+            target, "Admin", &snapshot.admin, &mut findings, &mut records_checked,
+        )?;
+        self.check_instance_u32(
+            target, "FeeBasisPoints", snapshot.fee_basis_points,
+            &mut findings, &mut records_checked,
+        )?;
+        self.check_instance_u64(
+            target, "RefundWindow", snapshot.refund_window_seconds,
+            &mut findings, &mut records_checked,
+        )?;
+        self.check_instance_bool(
+            target, "Paused", snapshot.paused, &mut findings, &mut records_checked,
+        )?;
+        self.check_instance_u64(
+            target, "TipCounter", snapshot.tip_counter,
+            &mut findings, &mut records_checked,
+        )?;
+        self.check_instance_u64(
+            target, "MatchingCounter", snapshot.matching_counter,
+            &mut findings, &mut records_checked,
+        )?;
+        self.check_instance_u32(
+            target, "ContractVersion", snapshot.schema_version,
+            &mut findings, &mut records_checked,
+        )?;
+
+        // ── whitelisted tokens ────────────────────────────────────────────────
+        println!("[2/12] Verifying whitelisted tokens …");
+        let actual_tokens = self.rpc.get_whitelisted_tokens(target).unwrap_or_default();
+        for token in &snapshot.whitelisted_tokens {
+            records_checked += 1;
+            if !actual_tokens.contains(token) {
+                findings.push(VerificationFinding {
+                    severity: FindingSeverity::Missing,
+                    field: format!("whitelisted_tokens.{}", token),
+                    expected: "true".into(),
+                    actual: "<absent>".into(),
+                });
+            }
+        }
+
+        // ── creator balances ──────────────────────────────────────────────────
+        println!("[3/12] Verifying creator balances ({}) …", snapshot.creator_balances.len());
+        for (key, expected_bal) in &snapshot.creator_balances {
+            let parts: Vec<&str> = key.splitn(2, ':').collect();
+            if parts.len() == 2 {
+                let actual_bal = self
+                    .rpc
+                    .get_creator_balance(target, parts[0], parts[1])
+                    .unwrap_or(0);
+                records_checked += 1;
+                if actual_bal != *expected_bal {
+                    findings.push(VerificationFinding {
+                        severity: FindingSeverity::Mismatch,
+                        field: format!("creator_balances.{}", key),
+                        expected: expected_bal.to_string(),
+                        actual: actual_bal.to_string(),
+                    });
+                }
+            }
+        }
+
+        // ── creator totals ────────────────────────────────────────────────────
+        println!("[4/12] Verifying creator totals ({}) …", snapshot.creator_totals.len());
+        for (key, expected_tot) in &snapshot.creator_totals {
+            let parts: Vec<&str> = key.splitn(2, ':').collect();
+            if parts.len() == 2 {
+                let actual_tot = self
+                    .rpc
+                    .get_creator_total(target, parts[0], parts[1])
+                    .unwrap_or(0);
+                records_checked += 1;
+                if actual_tot != *expected_tot {
+                    findings.push(VerificationFinding {
+                        severity: FindingSeverity::Mismatch,
+                        field: format!("creator_totals.{}", key),
+                        expected: expected_tot.to_string(),
+                        actual: actual_tot.to_string(),
+                    });
+                }
+            }
+        }
+
+        // ── tip history ───────────────────────────────────────────────────────
+        let total_tips: usize = snapshot.tip_history.values().map(|v| v.len()).sum();
+        println!("[5/12] Verifying tip history ({} records) …", total_tips);
+        for (creator, expected_tips) in &snapshot.tip_history {
+            let actual_count = self
+                .rpc
+                .get_persistent_u64(target, &format!("TipCount:{}", creator))
+                .unwrap_or(0) as usize;
+            records_checked += 1;
+            if actual_count != expected_tips.len() {
+                findings.push(VerificationFinding {
+                    severity: FindingSeverity::Mismatch,
+                    field: format!("tip_history.{}.count", creator),
+                    expected: expected_tips.len().to_string(),
+                    actual: actual_count.to_string(),
+                });
+            }
+            for (idx, expected_meta) in expected_tips.iter().enumerate() {
+                let key = format!("TipHistory:{}:{}", creator, idx);
+                let actual_meta = self
+                    .rpc
+                    .get_persistent_tip_metadata(target, &key)
+                    .unwrap_or(None);
+                records_checked += 1;
+                match actual_meta {
+                    None => findings.push(VerificationFinding {
+                        severity: FindingSeverity::Missing,
+                        field: format!("tip_history.{}.{}", creator, idx),
+                        expected: format!("{:?}", expected_meta),
+                        actual: "<absent>".into(),
+                    }),
+                    Some(ref actual) if actual != expected_meta => {
+                        findings.push(VerificationFinding {
+                            severity: FindingSeverity::Mismatch,
+                            field: format!("tip_history.{}.{}", creator, idx),
+                            expected: format!("{:?}", expected_meta),
+                            actual: format!("{:?}", actual),
+                        });
+                    }
+                    _ => {}
+                }
+            }
+        }
+
+        // ── leaderboard aggregates ────────────────────────────────────────────
+        println!(
+            "[6/12] Verifying leaderboard aggregates ({} tipper, {} creator) …",
+            snapshot.tipper_aggregates.len(),
+            snapshot.creator_aggregates.len()
+        );
+        for (key, expected_entry) in &snapshot.tipper_aggregates {
+            let parts: Vec<&str> = key.splitn(2, ':').collect();
+            if parts.len() == 2 {
+                let bucket: u32 = parts[1].parse().unwrap_or(0);
+                let agg_key = format!("TipperAggregate:{}:{}", parts[0], bucket);
+                let actual = self
+                    .rpc
+                    .get_persistent_leaderboard_entry(target, &agg_key)
+                    .unwrap_or(None);
+                records_checked += 1;
+                match actual {
+                    None => findings.push(VerificationFinding {
+                        severity: FindingSeverity::Missing,
+                        field: format!("tipper_aggregates.{}", key),
+                        expected: format!("{:?}", expected_entry),
+                        actual: "<absent>".into(),
+                    }),
+                    Some(ref a) if a.total_amount != expected_entry.total_amount
+                        || a.tip_count != expected_entry.tip_count =>
+                    {
+                        findings.push(VerificationFinding {
+                            severity: FindingSeverity::Mismatch,
+                            field: format!("tipper_aggregates.{}", key),
+                            expected: format!("amount={} count={}", expected_entry.total_amount, expected_entry.tip_count),
+                            actual: format!("amount={} count={}", a.total_amount, a.tip_count),
+                        });
+                    }
+                    _ => {}
+                }
+            }
+        }
+        for (key, expected_entry) in &snapshot.creator_aggregates {
+            let parts: Vec<&str> = key.splitn(2, ':').collect();
+            if parts.len() == 2 {
+                let bucket: u32 = parts[1].parse().unwrap_or(0);
+                let agg_key = format!("CreatorAggregate:{}:{}", parts[0], bucket);
+                let actual = self
+                    .rpc
+                    .get_persistent_leaderboard_entry(target, &agg_key)
+                    .unwrap_or(None);
+                records_checked += 1;
+                match actual {
+                    None => findings.push(VerificationFinding {
+                        severity: FindingSeverity::Missing,
+                        field: format!("creator_aggregates.{}", key),
+                        expected: format!("{:?}", expected_entry),
+                        actual: "<absent>".into(),
+                    }),
+                    Some(ref a) if a.total_amount != expected_entry.total_amount
+                        || a.tip_count != expected_entry.tip_count =>
+                    {
+                        findings.push(VerificationFinding {
+                            severity: FindingSeverity::Mismatch,
+                            field: format!("creator_aggregates.{}", key),
+                            expected: format!("amount={} count={}", expected_entry.total_amount, expected_entry.tip_count),
+                            actual: format!("amount={} count={}", a.total_amount, a.tip_count),
+                        });
+                    }
+                    _ => {}
+                }
+            }
+        }
+
+        // ── subscriptions ─────────────────────────────────────────────────────
+        println!("[7/12] Verifying subscriptions ({}) …", snapshot.subscriptions.len());
+        for (key, expected_sub) in &snapshot.subscriptions {
+            let parts: Vec<&str> = key.splitn(2, ':').collect();
+            if parts.len() == 2 {
+                let sub_key = format!("Subscription:{}:{}", parts[0], parts[1]);
+                let actual = self
+                    .rpc
+                    .get_persistent_subscription(target, &sub_key)
+                    .unwrap_or(None);
+                records_checked += 1;
+                match actual {
+                    None => findings.push(VerificationFinding {
+                        severity: FindingSeverity::Missing,
+                        field: format!("subscriptions.{}", key),
+                        expected: format!("{:?}", expected_sub),
+                        actual: "<absent>".into(),
+                    }),
+                    Some(ref a) if a.amount != expected_sub.amount
+                        || a.interval_seconds != expected_sub.interval_seconds =>
+                    {
+                        findings.push(VerificationFinding {
+                            severity: FindingSeverity::Mismatch,
+                            field: format!("subscriptions.{}", key),
+                            expected: format!("amount={} interval={}", expected_sub.amount, expected_sub.interval_seconds),
+                            actual: format!("amount={} interval={}", a.amount, a.interval_seconds),
+                        });
+                    }
+                    _ => {}
+                }
+            }
+        }
+
+        // ── time locks ────────────────────────────────────────────────────────
+        println!("[8/12] Verifying time locks ({}) …", snapshot.time_locks.len());
+        for expected_lock in &snapshot.time_locks {
+            let key = format!("TimeLock:{}", expected_lock.lock_id);
+            let actual = self
+                .rpc
+                .get_persistent_time_lock(target, &key, expected_lock.lock_id)
+                .unwrap_or(None);
+            records_checked += 1;
+            match actual {
+                None => findings.push(VerificationFinding {
+                    severity: FindingSeverity::Missing,
+                    field: format!("time_locks.{}", expected_lock.lock_id),
+                    expected: format!("{:?}", expected_lock),
+                    actual: "<absent>".into(),
+                }),
+                Some(ref a) if a.amount != expected_lock.amount
+                    || a.cancelled != expected_lock.cancelled =>
+                {
+                    findings.push(VerificationFinding {
+                        severity: FindingSeverity::Mismatch,
+                        field: format!("time_locks.{}", expected_lock.lock_id),
+                        expected: format!("amount={} cancelled={}", expected_lock.amount, expected_lock.cancelled),
+                        actual: format!("amount={} cancelled={}", a.amount, a.cancelled),
+                    });
+                }
+                _ => {}
+            }
+        }
+
+        // ── milestones ────────────────────────────────────────────────────────
+        println!("[9/12] Verifying milestones ({}) …", snapshot.milestones.len());
+        for (key, expected_ms) in &snapshot.milestones {
+            let parts: Vec<&str> = key.splitn(2, ':').collect();
+            if parts.len() == 2 {
+                let ms_key = format!("Milestone:{}:{}", parts[0], parts[1]);
+                let actual = self
+                    .rpc
+                    .get_persistent_milestone(target, &ms_key)
+                    .unwrap_or(None);
+                records_checked += 1;
+                match actual {
+                    None => findings.push(VerificationFinding {
+                        severity: FindingSeverity::Missing,
+                        field: format!("milestones.{}", key),
+                        expected: format!("{:?}", expected_ms),
+                        actual: "<absent>".into(),
+                    }),
+                    Some(ref a) if a.goal_amount != expected_ms.goal_amount
+                        || a.current_amount != expected_ms.current_amount
+                        || a.completed != expected_ms.completed =>
+                    {
+                        findings.push(VerificationFinding {
+                            severity: FindingSeverity::Mismatch,
+                            field: format!("milestones.{}", key),
+                            expected: format!(
+                                "goal={} current={} completed={}",
+                                expected_ms.goal_amount, expected_ms.current_amount, expected_ms.completed
+                            ),
+                            actual: format!(
+                                "goal={} current={} completed={}",
+                                a.goal_amount, a.current_amount, a.completed
+                            ),
+                        });
+                    }
+                    _ => {}
+                }
+            }
+        }
+
+        // ── matching programs ─────────────────────────────────────────────────
+        println!("[10/12] Verifying matching programs ({}) …", snapshot.matching_programs.len());
+        for expected_prog in &snapshot.matching_programs {
+            let key = format!("MatchingProgram:{}", expected_prog.id);
+            let actual = self
+                .rpc
+                .get_persistent_matching_program(target, &key)
+                .unwrap_or(None);
+            records_checked += 1;
+            match actual {
+                None => findings.push(VerificationFinding {
+                    severity: FindingSeverity::Missing,
+                    field: format!("matching_programs.{}", expected_prog.id),
+                    expected: format!("{:?}", expected_prog),
+                    actual: "<absent>".into(),
+                }),
+                Some(ref a) if a.max_match_amount != expected_prog.max_match_amount
+                    || a.current_matched != expected_prog.current_matched
+                    || a.active != expected_prog.active =>
+                {
+                    findings.push(VerificationFinding {
+                        severity: FindingSeverity::Mismatch,
+                        field: format!("matching_programs.{}", expected_prog.id),
+                        expected: format!(
+                            "max={} matched={} active={}",
+                            expected_prog.max_match_amount, expected_prog.current_matched, expected_prog.active
+                        ),
+                        actual: format!(
+                            "max={} matched={} active={}",
+                            a.max_match_amount, a.current_matched, a.active
+                        ),
+                    });
+                }
+                _ => {}
+            }
+        }
+
+        // ── tip records ───────────────────────────────────────────────────────
+        println!("[11/12] Verifying tip records ({}) …", snapshot.tip_records.len());
+        for expected_rec in &snapshot.tip_records {
+            let key = format!("TipRecord:{}", expected_rec.id);
+            let actual = self
+                .rpc
+                .get_persistent_tip_record(target, &key)
+                .unwrap_or(None);
+            records_checked += 1;
+            match actual {
+                None => findings.push(VerificationFinding {
+                    severity: FindingSeverity::Missing,
+                    field: format!("tip_records.{}", expected_rec.id),
+                    expected: format!("{:?}", expected_rec),
+                    actual: "<absent>".into(),
+                }),
+                Some(ref a) if a.amount != expected_rec.amount
+                    || a.refunded != expected_rec.refunded =>
+                {
+                    findings.push(VerificationFinding {
+                        severity: FindingSeverity::Mismatch,
+                        field: format!("tip_records.{}", expected_rec.id),
+                        expected: format!("amount={} refunded={}", expected_rec.amount, expected_rec.refunded),
+                        actual: format!("amount={} refunded={}", a.amount, a.refunded),
+                    });
+                }
+                _ => {}
+            }
+        }
+
+        // ── user roles ────────────────────────────────────────────────────────
+        println!("[12/12] Verifying user roles ({}) …", snapshot.user_roles.len());
+        for (addr, expected_role) in &snapshot.user_roles {
+            let key = format!("UserRole:{}", addr);
+            let actual_role = self
+                .rpc
+                .get_persistent_string(target, &key)
+                .unwrap_or_default();
+            records_checked += 1;
+            if actual_role != *expected_role {
+                findings.push(VerificationFinding {
+                    severity: FindingSeverity::Mismatch,
+                    field: format!("user_roles.{}", addr),
+                    expected: expected_role.clone(),
+                    actual: if actual_role.is_empty() {
+                        "<absent>".into()
+                    } else {
+                        actual_role
+                    },
+                });
+            }
+        }
+
+        // ── build report ──────────────────────────────────────────────────────
+        let passed = findings.is_empty();
+        let report = VerificationReport {
+            source_contract_id: snapshot.contract_id.clone(),
+            target_contract_id: target.to_string(),
+            verified_at: iso_now(),
+            records_checked,
+            passed,
+            findings: findings.clone(),
+        };
+
+        println!();
+        if passed {
+            println!("✓ Verification PASSED — {} records checked, 0 findings", records_checked);
+        } else {
+            println!(
+                "✗ Verification FAILED — {} records checked, {} finding(s)",
+                records_checked,
+                findings.len()
+            );
+            for f in &findings {
+                println!(
+                    "  [{:?}] {} — expected={} actual={}",
+                    f.severity, f.field, f.expected, f.actual
+                );
+            }
+        }
+
+        Ok(report)
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Typed check helpers
+    // ─────────────────────────────────────────────────────────────────────────
+
+    fn check_instance_string(
+        &self,
+        target: &str,
+        key: &str,
+        expected: &str,
+        findings: &mut Vec<VerificationFinding>,
+        count: &mut usize,
+    ) -> Result<(), String> {
+        let actual = self.rpc.get_instance_string(target, key).unwrap_or_default();
+        *count += 1;
+        if actual != expected {
+            findings.push(VerificationFinding {
+                severity: if actual.is_empty() {
+                    FindingSeverity::Missing
+                } else {
+                    FindingSeverity::Mismatch
+                },
+                field: format!("instance.{}", key),
+                expected: expected.to_string(),
+                actual: if actual.is_empty() { "<absent>".into() } else { actual },
+            });
+        }
+        Ok(())
+    }
+
+    fn check_instance_u32(
+        &self,
+        target: &str,
+        key: &str,
+        expected: u32,
+        findings: &mut Vec<VerificationFinding>,
+        count: &mut usize,
+    ) -> Result<(), String> {
+        let actual = self.rpc.get_instance_u32(target, key).unwrap_or(0);
+        *count += 1;
+        if actual != expected {
+            findings.push(VerificationFinding {
+                severity: FindingSeverity::Mismatch,
+                field: format!("instance.{}", key),
+                expected: expected.to_string(),
+                actual: actual.to_string(),
+            });
+        }
+        Ok(())
+    }
+
+    fn check_instance_u64(
+        &self,
+        target: &str,
+        key: &str,
+        expected: u64,
+        findings: &mut Vec<VerificationFinding>,
+        count: &mut usize,
+    ) -> Result<(), String> {
+        let actual = self.rpc.get_instance_u64(target, key).unwrap_or(0);
+        *count += 1;
+        if actual != expected {
+            findings.push(VerificationFinding {
+                severity: FindingSeverity::Mismatch,
+                field: format!("instance.{}", key),
+                expected: expected.to_string(),
+                actual: actual.to_string(),
+            });
+        }
+        Ok(())
+    }
+
+    fn check_instance_bool(
+        &self,
+        target: &str,
+        key: &str,
+        expected: bool,
+        findings: &mut Vec<VerificationFinding>,
+        count: &mut usize,
+    ) -> Result<(), String> {
+        let actual = self.rpc.get_instance_bool(target, key).unwrap_or(false);
+        *count += 1;
+        if actual != expected {
+            findings.push(VerificationFinding {
+                severity: FindingSeverity::Mismatch,
+                field: format!("instance.{}", key),
+                expected: expected.to_string(),
+                actual: actual.to_string(),
+            });
+        }
+        Ok(())
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// CLI entry point
+// ─────────────────────────────────────────────────────────────────────────────
+
+pub fn run_verify(args: &[String]) -> Result<(), String> {
+    let config_path = parse_flag(args, "--config")
+        .unwrap_or_else(|| "scripts/migrate/config.toml".to_string());
+    let snapshot_override = parse_flag(args, "--snapshot");
+
+    let toml_str = fs::read_to_string(&config_path)
+        .map_err(|e| format!("Cannot read config {}: {}", config_path, e))?;
+    let config: MigrationConfig = toml::from_str(&toml_str)
+        .map_err(|e| format!("Config parse error: {}", e))?;
+
+    let snapshot_path = snapshot_override.unwrap_or_else(|| {
+        format!(
+            "{}/{}",
+            config.migration.snapshot_dir, config.migration.transformed_filename
+        )
+    });
+
+    let json = fs::read_to_string(&snapshot_path)
+        .map_err(|e| format!("Cannot read snapshot {}: {}", snapshot_path, e))?;
+    let snapshot: StateSnapshot = serde_json::from_str(&json)
+        .map_err(|e| format!("Snapshot parse error: {}", e))?;
+
+    crate::export_state::verify_checksum(&snapshot)?;
+
+    let target = config.migration.target_contract_id.clone();
+    let engine = VerificationEngine::new(config.clone());
+    let report = engine.verify_migration(&snapshot, &target)?;
+
+    // Write report to disk.
+    let report_path = format!("{}/verification-report.json", config.migration.snapshot_dir);
+    let report_json = serde_json::to_string_pretty(&report)
+        .map_err(|e| format!("Report serialisation error: {}", e))?;
+    fs::write(&report_path, report_json)
+        .map_err(|e| format!("Failed to write report: {}", e))?;
+    println!("  Report written → {}", report_path);
+
+    if !report.is_clean() && config.migration.abort_on_verify_failure {
+        return Err(format!(
+            "Verification failed with {} finding(s)",
+            report.findings.len()
+        ));
+    }
+
+    Ok(())
+}
+
+fn parse_flag(args: &[String], flag: &str) -> Option<String> {
+    args.windows(2)
+        .find(|w| w[0] == flag)
+        .map(|w| w[1].clone())
+}
+
+fn iso_now() -> String {
+    use chrono::Utc;
+    Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string()
+}


### PR DESCRIPTION
Add a complete off-chain state migration toolkit under scripts/migrate/ for safely moving TipJar contract state between contract versions.

Modules:
- export_state.rs: reads all 9 state categories from source contract, seals snapshot with SHA-256 checksum, supports dry-run mode
- transform_state.rs: 8 versioned rules (v1->v2) — zero-value pruning, expired lock cancellation, subscription cleanup, tip history cap (1000), refunded record removal, schema version bump; writes transform audit log
- import_state.rs: atomic 7-step import with auto-rollback on failure; pauses contract during write, verifies before unpausing
- verify_migration.rs: 12-category field-by-field comparison against live contract state, returns structured VerificationReport with per-field findings
- history.rs: persistent JSON run log with timestamps, status, record counts
- rpc_client.rs: thin wrapper around stellar CLI for all RPC reads/writes
- types.rs: shared serialisable types (StateSnapshot, MigrationConfig, VerificationReport, MigrationHistory, TransformationLog)
- main.rs: CLI entry point (export/transform/import/verify/rollback/history)
- config.toml: documented template; dry_run=true and abort_on_verify_failure=true by default
- tests/migration_tests.rs: 55 tests across 8 modules covering export completeness, checksum sealing, transform accuracy, import round-trip, verification logic, rollback capability, history tracking, config parsing

Safety guarantees:
- Dry-run mode never writes on-chain
- Full backup created before any import begins
- Auto-rollback triggered on import failure or verification mismatch
- Admin secret loaded from MIGRATION_ADMIN_SECRET env var only
- SHA-256 checksum tamper detection on every snapshot read.  


closes #72 