### PR TITLE
feat/docs: comprehensive developer docs, changelog, form validation, and creator categories (#41 #42 #43 #70)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,133 @@
+# Architecture Overview
+
+## Repository Layout
+
+```
+stellar-tipjar-contracts/
+├── contracts/tipjar/       # Core Soroban smart contract
+│   ├── src/lib.rs          # Contract entry point and all function implementations
+│   └── Cargo.toml
+├── sdk/typescript/         # TypeScript SDK wrapping contract calls
+│   └── src/
+│       ├── TipJarContract.ts
+│       ├── types.ts
+│       ├── errors.ts
+│       ├── events.ts
+│       └── utils.ts
+├── indexer/                # Off-chain event indexer (Rust + SQLite/Postgres)
+├── analytics/              # Metrics aggregation and dashboard
+├── security/               # Rate limiter, circuit breaker, anomaly detector
+├── simulator/              # Local contract simulator for development
+├── tools/
+│   ├── gas-estimator/      # Fee estimation tool
+│   ├── doc-generator/      # Auto-generates API docs from source
+│   └── backup/             # State export/import utilities
+├── monitoring/             # Prometheus + Grafana dashboards
+├── scripts/                # Deploy, upgrade, backup, and migration scripts
+└── docs/                   # This documentation
+```
+
+## Request / Data Flow
+
+```
+Frontend / CLI
+     │
+     ▼
+TypeScript SDK (sdk/typescript/)
+     │  builds + signs XDR transactions
+     ▼
+Stellar RPC (soroban-testnet / mainnet)
+     │  submits transaction
+     ▼
+Soroban Runtime
+     │  executes contract WASM
+     ▼
+TipJar Contract (contracts/tipjar/src/lib.rs)
+     │  reads/writes persistent storage
+     │  emits contract events
+     ▼
+Stellar Ledger (immutable)
+     │
+     ├──► Indexer (indexer/) — streams events → DB
+     └──► Analytics (analytics/) — aggregates metrics
+```
+
+## Contract Architecture
+
+The contract is a single Soroban contract with the following logical modules:
+
+| Module | File | Responsibility |
+|---|---|---|
+| Core tip/withdraw | `lib.rs` | `init`, `tip`, `withdraw`, `get_total_tips` |
+| Tip with message | `lib.rs` | `tip_with_message`, `get_messages` |
+| Batch tips | `lib.rs` | `tip_batch` |
+| Locked tips | `lib.rs` | `tip_locked`, `withdraw_locked` |
+| Subscriptions | `lib.rs` | `create_subscription`, `execute_subscription_payment` |
+| Leaderboard | `lib.rs` | `get_leaderboard` |
+| Matching programs | `lib.rs` | `create_matching_program`, `cancel_matching_program` |
+| Milestones | `lib.rs` | `create_milestone`, `complete_milestone` |
+| Roles / RBAC | `lib.rs` | `grant_role`, `revoke_role` |
+| Pause / unpause | `lib.rs` | `pause`, `unpause` |
+| Upgrade | `upgrade.rs` | `upgrade` (WASM hash replacement) |
+| Events | `events/` | Structured event emission helpers |
+| Privacy | `privacy/` | Commitment-based private tips |
+| Governance | `governance/` | On-chain proposals and voting |
+| Staking | `staking/` | Reward distribution |
+| AMM | `amm/` | Automated market maker primitives |
+
+## Storage Model
+
+All state lives in Soroban's key-value store. Keys are typed via `DataKey`:
+
+- **Instance storage** — shared contract-level data (token, admin, paused flag).
+- **Persistent storage** — per-creator data (balance, total, messages, leaderboard entries).
+
+See `docs/STORAGE.md` for the full key catalogue.
+
+## Off-Chain Components
+
+### Indexer
+Streams `getEvents` from the RPC, parses tip/withdraw events, and writes them to a relational database. Exposes a REST API for historical queries.
+
+### Analytics
+Reads from the indexer DB, computes aggregates (daily volume, top creators, tip counts), and serves a dashboard at `analytics/dashboard/index.html`.
+
+### Security Monitor
+Runs alongside the indexer. Detects anomalies (large single tips, rapid-fire tips), triggers circuit breakers, and sends alerts.
+
+## Diagrams
+
+### Wallet Interaction Flow
+
+```
+User clicks "Tip"
+      │
+      ▼
+SDK validates params (amount > 0, creator valid)
+      │
+      ▼
+Build TransactionBuilder with contract invocation
+      │
+      ▼
+simulateTransaction (dry-run, get fee)
+      │
+      ▼
+Sign with Keypair / Freighter wallet
+      │
+      ▼
+sendTransaction → poll getTransaction until SUCCESS/FAILED
+      │
+      ▼
+Parse result / emit UI feedback
+```
+
+### Component Hierarchy (TypeScript SDK)
+
+```
+TipJarContract
+  ├── connect(keypair)
+  ├── sendTip(params)          → buildTx → simulate → sign → submit
+  ├── withdraw(params)         → buildTx → simulate → sign → submit
+  ├── getTotalTips(creator)    → simulateTransaction (read-only)
+  └── getWithdrawableBalance   → simulateTransaction (read-only)
+```

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,0 +1,47 @@
+# Changelog
+
+All notable documentation changes are tracked here.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+---
+
+## [Unreleased]
+
+### Added
+- `ARCHITECTURE.md` — repository layout, request/data flow diagrams, component hierarchy.
+- `STATE_MANAGEMENT.md` — on-chain storage model, state transitions, off-chain indexer schema.
+- `WALLET_INTEGRATION.md` — Keypair, Freighter, and WalletConnect integration patterns.
+- `CODE_STYLE.md` — Rust and TypeScript formatting, linting, naming conventions, commit message format.
+- `CONTRIBUTING.md` (docs/) — development setup, branching strategy, PR checklist, test requirements.
+- `CHANGELOG.md` — this file; tracks incremental documentation improvements.
+
+---
+
+## [1.0.0] — 2026-03-24
+
+### Added
+- `API.md` — full contract function reference with parameters, errors, and events.
+- `CONTRACT_SPEC.md` — complete contract specification and error code table.
+- `DEPLOYMENT.md` — testnet and mainnet deployment instructions.
+- `EVENTS.md` — on-chain event catalogue.
+- `GAS_OPTIMIZATION.md` — gas profiling and optimization strategies.
+- `INTEGRATION.md` — TypeScript SDK and Stellar CLI integration examples.
+- `INTEGRATION_GUIDE.md` — extended integration guide with subscriptions and split tips.
+- `NETWORKS.md` — network configuration and funded account setup.
+- `SECURITY.md` — security model and threat mitigations.
+- `STORAGE.md` — storage key catalogue and TTL policy.
+- `TROUBLESHOOTING.md` — common errors and resolution steps.
+- `UPGRADE_GUIDE.md` — contract upgrade procedure.
+- `BEST_PRACTICES.md` — recommended patterns for contract consumers.
+- `BACKUP_RECOVERY.md` — state backup and recovery procedures.
+- `THREAT_MODEL.md` — threat model and attack surface analysis.
+- `MAINNET_CHECKLIST.md` — pre-mainnet deployment checklist.
+- `tutorials/getting-started.md` — quick-start tutorial.
+- `tutorials/frontend-integration.md` — frontend integration tutorial.
+- `tutorials/backend-integration.md` — backend integration tutorial.
+- `tutorials/testing-guide.md` — testing guide.
+- `examples/basic-tip.md` — basic tip example.
+- `examples/subscriptions.md` — subscription example.
+- `examples/batch-operations.md` — batch operations example.
+- `security/audit_prep.md` — audit preparation checklist.

--- a/docs/CODE_STYLE.md
+++ b/docs/CODE_STYLE.md
@@ -1,0 +1,105 @@
+# Code Style Guide
+
+## Rust
+
+### Formatting
+
+All Rust code is formatted with `rustfmt` using the default configuration:
+
+```bash
+cargo fmt --all
+```
+
+CI will reject PRs that are not formatted.
+
+### Linting
+
+```bash
+cargo clippy --all-targets -- -D warnings
+```
+
+All Clippy warnings are treated as errors. Common patterns to follow:
+
+- Prefer `if let` over `match` for single-arm matches.
+- Use `?` for error propagation instead of `unwrap()` in library code.
+- Avoid `clone()` where a reference suffices.
+
+### Contract-Specific Rules
+
+- All public contract functions must have a `///` doc comment.
+- Use `panic_with_error!(env, TipJarError::X)` instead of `panic!()` for user-facing errors.
+- Storage reads must use typed `DataKey` variants — no raw string keys.
+- Emit events for every state change visible to external observers.
+
+### Naming Conventions
+
+| Item | Convention | Example |
+|---|---|---|
+| Types / Structs | `PascalCase` | `TipWithMessage` |
+| Functions | `snake_case` | `tip_with_message` |
+| Constants | `SCREAMING_SNAKE_CASE` | `MAX_MESSAGE_LEN` |
+| Storage keys | `PascalCase` enum variants | `DataKey::CreatorBalance` |
+
+---
+
+## TypeScript (SDK)
+
+### Formatting
+
+The SDK uses Prettier with default settings:
+
+```bash
+cd sdk/typescript && npx prettier --write src/
+```
+
+### Linting
+
+```bash
+cd sdk/typescript && npx eslint src/ --ext .ts
+```
+
+### Type Safety
+
+- All public SDK functions must have explicit return types.
+- Avoid `any`; use `unknown` and narrow with type guards.
+- Use `bigint` for all on-chain amounts (Soroban `i128` maps to `bigint`).
+
+### Naming Conventions
+
+| Item | Convention | Example |
+|---|---|---|
+| Classes | `PascalCase` | `TipJarContract` |
+| Functions / methods | `camelCase` | `sendTip` |
+| Interfaces | `PascalCase` | `TipParams` |
+| Constants | `SCREAMING_SNAKE_CASE` | `BASE_FEE` |
+
+---
+
+## Documentation
+
+- Every public Rust function gets a `///` doc comment with `# Parameters`, `# Errors`, and `# Example` sections.
+- Every public TypeScript method gets a JSDoc comment with `@param`, `@returns`, `@throws`, and `@example`.
+- Markdown files use ATX-style headings (`#`, `##`, `###`).
+- Code blocks must specify the language (` ```rust `, ` ```typescript `, ` ```bash `).
+
+---
+
+## Git Commit Messages
+
+Follow [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+<type>(<scope>): <short description>
+
+[optional body]
+```
+
+Types: `feat`, `fix`, `docs`, `test`, `refactor`, `chore`, `perf`.
+
+Examples:
+```
+feat(contract): add tip_batch function
+fix(sdk): handle missing keypair in sendTip
+docs(api): document withdraw_locked parameters
+test(integration): add multi-token withdrawal test
+```

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,78 @@
+# Contributing Guide
+
+See the root [`CONTRIBUTING.md`](../CONTRIBUTING.md) for the full contribution workflow.
+
+This page supplements it with contract-specific details.
+
+## Development Setup
+
+```bash
+# Install Rust toolchain
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+
+# Add Soroban WASM target
+rustup target add wasm32v1-none
+
+# Install Stellar CLI
+cargo install --locked stellar-cli
+
+# Clone and build
+git clone https://github.com/your-org/stellar-tipjar-contracts
+cd stellar-tipjar-contracts
+cargo build -p tipjar --target wasm32v1-none --release
+```
+
+## Running Tests
+
+```bash
+# Unit + integration tests
+cargo test -p tipjar
+
+# All workspace tests
+cargo test --workspace
+
+# Specific test
+cargo test -p tipjar test_tipping_functionality
+```
+
+## Branching Strategy
+
+| Branch prefix | Purpose |
+|---|---|
+| `feature/<name>` | New functionality |
+| `fix/<name>` | Bug fixes |
+| `docs/<name>` | Documentation only |
+| `chore/<name>` | Tooling, CI, dependencies |
+| `refactor/<name>` | Code restructuring without behavior change |
+
+Branch from `main`, keep branches focused on one concern.
+
+## Pull Request Checklist
+
+- [ ] `cargo test --workspace` passes
+- [ ] `cargo fmt --all -- --check` passes
+- [ ] `cargo clippy --all-targets -- -D warnings` passes
+- [ ] New behavior is covered by tests
+- [ ] Storage key changes are backward-compatible or include a migration
+- [ ] Events are emitted for all observable state changes
+- [ ] Docs updated if public API changed
+- [ ] No secrets committed
+
+## Test Requirements
+
+Every PR that changes contract behavior must include:
+
+1. A **happy-path test** demonstrating the new behavior.
+2. At least one **error/edge-case test** (invalid input, unauthorized caller, paused state).
+3. Tests must use the Soroban test environment (`soroban_sdk::testutils`).
+
+## Commit Message Format
+
+```
+feat(contract): add tip_batch function
+fix(sdk): handle missing keypair in sendTip
+docs(api): document withdraw_locked parameters
+test(integration): add multi-token withdrawal test
+```
+
+See `docs/CODE_STYLE.md` for the full style guide.

--- a/docs/STATE_MANAGEMENT.md
+++ b/docs/STATE_MANAGEMENT.md
@@ -1,0 +1,91 @@
+# State Management
+
+## On-Chain State
+
+All contract state is stored in Soroban's key-value store. The `DataKey` enum defines every storage key used by the contract.
+
+### Instance Storage (shared, low-cost reads)
+
+| Key | Type | Description |
+|---|---|---|
+| `DataKey::Token` | `Address` | Whitelisted token contract address |
+| `DataKey::Admin` | `Address` | Contract administrator |
+| `DataKey::Paused` | `bool` | Emergency pause flag |
+
+### Persistent Storage (per-entity, TTL-extended on access)
+
+| Key | Type | Description |
+|---|---|---|
+| `DataKey::CreatorBalance(Address)` | `i128` | Withdrawable escrow balance |
+| `DataKey::CreatorTotal(Address)` | `i128` | Cumulative historical tips |
+| `DataKey::CreatorMessages(Address)` | `Vec<TipWithMessage>` | Tip messages |
+| `DataKey::LockedTip(u64)` | `TipWithExpiry` | Time-locked tip by ID |
+| `DataKey::Subscription(Address, Address)` | `Subscription` | Recurring tip subscription |
+| `DataKey::LeaderboardEntry(Address)` | `LeaderboardEntry` | Leaderboard aggregate |
+| `DataKey::MatchingProgram(u64)` | `MatchingProgram` | Tip matching program |
+| `DataKey::Milestone(u64)` | `Milestone` | Creator milestone |
+| `DataKey::Role(Address)` | `Role` | RBAC role assignment |
+
+## State Transitions
+
+### Tip Flow
+
+```
+Initial: CreatorBalance = B, CreatorTotal = T
+After tip(amount):
+  CreatorBalance = B + amount
+  CreatorTotal   = T + amount
+```
+
+### Withdraw Flow
+
+```
+Initial: CreatorBalance = B (B > 0)
+After withdraw():
+  CreatorBalance = 0
+  Token transferred: B tokens → creator address
+```
+
+### Locked Tip Flow
+
+```
+tip_locked(amount, unlock_time) → stores TipWithExpiry{claimed: false}
+withdraw_locked(tip_id)         → requires ledger_time >= unlock_time
+                                  sets claimed = true, transfers amount
+```
+
+### Pause / Unpause
+
+```
+pause()   → Paused = true  (blocks tip, withdraw, tip_with_message)
+unpause() → Paused = false (restores normal operation)
+```
+
+## Off-Chain State (Indexer)
+
+The indexer maintains a relational mirror of on-chain events:
+
+```sql
+-- events table (see indexer/migrations/0003_create_events.sql)
+CREATE TABLE events (
+  id          SERIAL PRIMARY KEY,
+  ledger      BIGINT NOT NULL,
+  tx_hash     TEXT NOT NULL,
+  event_type  TEXT NOT NULL,   -- 'tip' | 'withdraw' | 'tip_msg' | ...
+  creator     TEXT NOT NULL,
+  sender      TEXT,
+  amount      BIGINT NOT NULL,
+  timestamp   TIMESTAMPTZ NOT NULL
+);
+```
+
+The indexer processes events in order and is idempotent — re-processing the same ledger range produces the same DB state.
+
+## SDK State
+
+The TypeScript SDK is stateless between calls. The only mutable state it holds is:
+
+- `keypair` — set via `connect(keypair)`, used to sign transactions.
+- `server` — `SorobanRpc.Server` instance (connection pool managed by the SDK).
+
+No caching of on-chain values is performed; every read call issues a fresh `simulateTransaction`.

--- a/docs/WALLET_INTEGRATION.md
+++ b/docs/WALLET_INTEGRATION.md
@@ -1,0 +1,103 @@
+# Wallet Integration
+
+## Overview
+
+The TipJar contract requires transaction signing for all state-changing calls (`tip`, `withdraw`, `pause`, etc.). Signing can be done with:
+
+1. **Keypair** — a raw Stellar secret key (server-side or CLI use).
+2. **Freighter** — browser extension wallet (frontend use).
+3. **WalletConnect** — mobile wallet support.
+
+---
+
+## Keypair (Server / CLI)
+
+```typescript
+import { Keypair } from '@stellar/stellar-sdk';
+import { TipJarContract } from './sdk/typescript/src/TipJarContract';
+
+const sdk = new TipJarContract({
+  contractId: process.env.CONTRACT_ID!,
+  network: 'testnet',
+});
+
+sdk.connect(Keypair.fromSecret(process.env.STELLAR_SECRET!));
+
+const result = await sdk.sendTip({
+  creator: 'GCREATOR...',
+  amount: 10_000_000n,
+  tipper: Keypair.fromSecret(process.env.STELLAR_SECRET!).publicKey(),
+});
+```
+
+---
+
+## Freighter (Browser)
+
+Install the [Freighter](https://www.freighter.app/) browser extension.
+
+```typescript
+import {
+  isConnected,
+  getPublicKey,
+  signTransaction,
+} from '@stellar/freighter-api';
+
+// Check connection
+if (!(await isConnected())) {
+  throw new Error('Freighter not installed');
+}
+
+const publicKey = await getPublicKey();
+
+// Build the XDR transaction using the SDK, then sign with Freighter
+const xdr = await sdk.buildTipTransaction({
+  creator: 'GCREATOR...',
+  amount: 10_000_000n,
+  tipper: publicKey,
+});
+
+const signedXdr = await signTransaction(xdr, { network: 'TESTNET' });
+const result = await sdk.submitSignedTransaction(signedXdr);
+```
+
+---
+
+## Authorization Model
+
+Every state-changing contract function calls `require_auth()` on the relevant address:
+
+| Function | Who must authorize |
+|---|---|
+| `tip` | `sender` |
+| `tip_with_message` | `sender` |
+| `tip_batch` | `sender` |
+| `tip_locked` | `tipper` |
+| `withdraw` | `creator` |
+| `withdraw_locked` | `creator` |
+| `pause` / `unpause` | `admin` |
+| `grant_role` / `revoke_role` | `admin` |
+| `upgrade` | `admin` |
+
+Soroban enforces these at the runtime level — a transaction that does not include the required auth entry will be rejected.
+
+---
+
+## Network Configuration
+
+| Network | RPC URL | Network Passphrase |
+|---|---|---|
+| Testnet | `https://soroban-testnet.stellar.org` | `Test SDF Network ; September 2015` |
+| Mainnet | `https://mainnet.stellar.validationcloud.io/v1/...` | `Public Global Stellar Network ; September 2015` |
+| Futurenet | `https://rpc-futurenet.stellar.org` | `Test SDF Future Network ; October 2022` |
+
+See `docs/NETWORKS.md` for full network details and funded account setup.
+
+---
+
+## Security Considerations
+
+- Never expose secret keys in frontend code or version control.
+- Use environment variables or a secrets manager for server-side keys.
+- Always simulate a transaction before signing to verify the fee and outcome.
+- Validate the contract ID against the known deployed address before signing.

--- a/sdk/typescript/src/__tests__/categories.test.ts
+++ b/sdk/typescript/src/__tests__/categories.test.ts
@@ -1,0 +1,123 @@
+import {
+  CATEGORIES,
+  CATEGORY_MAP,
+  ALL_TAGS,
+  getCategoryForTag,
+  filterByCategory,
+  filterByTags,
+  isValidCategoryId,
+  isValidTag,
+} from '../categories';
+
+describe('CATEGORIES', () => {
+  it('has at least one category', () => {
+    expect(CATEGORIES.length).toBeGreaterThan(0);
+  });
+
+  it('every category has a non-empty id, label, and tags', () => {
+    for (const cat of CATEGORIES) {
+      expect(cat.id).toBeTruthy();
+      expect(cat.label).toBeTruthy();
+      expect(cat.tags.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe('CATEGORY_MAP', () => {
+  it('contains all category IDs', () => {
+    for (const cat of CATEGORIES) {
+      expect(CATEGORY_MAP[cat.id]).toBeDefined();
+    }
+  });
+});
+
+describe('ALL_TAGS', () => {
+  it('is non-empty', () => {
+    expect(ALL_TAGS.length).toBeGreaterThan(0);
+  });
+
+  it('contains tags from all categories', () => {
+    for (const cat of CATEGORIES) {
+      for (const tag of cat.tags) {
+        expect(ALL_TAGS).toContain(tag);
+      }
+    }
+  });
+});
+
+describe('getCategoryForTag', () => {
+  it('returns the correct category for a known tag', () => {
+    const cat = getCategoryForTag('musician');
+    expect(cat?.id).toBe('music');
+  });
+
+  it('returns undefined for an unknown tag', () => {
+    expect(getCategoryForTag('unknown-tag-xyz')).toBeUndefined();
+  });
+});
+
+describe('filterByCategory', () => {
+  const creators = [
+    { address: 'A', categoryId: 'music' },
+    { address: 'B', categoryId: 'art' },
+    { address: 'C', categoryId: 'music' },
+  ];
+
+  it('filters by category ID', () => {
+    const result = filterByCategory(creators, 'music');
+    expect(result).toHaveLength(2);
+    expect(result.every((c) => c.categoryId === 'music')).toBe(true);
+  });
+
+  it('returns all creators when categoryId is null', () => {
+    expect(filterByCategory(creators, null)).toHaveLength(3);
+  });
+
+  it('returns empty array when no match', () => {
+    expect(filterByCategory(creators, 'gaming')).toHaveLength(0);
+  });
+});
+
+describe('filterByTags', () => {
+  const creators = [
+    { address: 'A', tags: ['musician', 'producer'] },
+    { address: 'B', tags: ['illustrator', 'designer'] },
+    { address: 'C', tags: ['musician', 'blogger'] },
+  ];
+
+  it('filters by a single tag', () => {
+    const result = filterByTags(creators, ['musician']);
+    expect(result).toHaveLength(2);
+  });
+
+  it('uses OR logic for multiple tags', () => {
+    const result = filterByTags(creators, ['illustrator', 'blogger']);
+    expect(result).toHaveLength(2);
+  });
+
+  it('returns all creators when tags array is empty', () => {
+    expect(filterByTags(creators, [])).toHaveLength(3);
+  });
+});
+
+describe('isValidCategoryId', () => {
+  it('returns true for known category', () => {
+    expect(isValidCategoryId('music')).toBe(true);
+    expect(isValidCategoryId('tech')).toBe(true);
+  });
+
+  it('returns false for unknown category', () => {
+    expect(isValidCategoryId('unknown')).toBe(false);
+  });
+});
+
+describe('isValidTag', () => {
+  it('returns true for known tag', () => {
+    expect(isValidTag('musician')).toBe(true);
+    expect(isValidTag('open-source')).toBe(true);
+  });
+
+  it('returns false for unknown tag', () => {
+    expect(isValidTag('not-a-real-tag')).toBe(false);
+  });
+});

--- a/sdk/typescript/src/__tests__/validation.test.ts
+++ b/sdk/typescript/src/__tests__/validation.test.ts
@@ -1,0 +1,144 @@
+import {
+  validateAddress,
+  validateTipAmount,
+  validateMessage,
+  validateAssetCode,
+  validateTipForm,
+  validateBatchTip,
+  MAX_MESSAGE_LENGTH,
+  MAX_BATCH_SIZE,
+} from '../validation';
+
+describe('validateAddress', () => {
+  it('accepts a valid G-address', () => {
+    const result = validateAddress('GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWNA');
+    expect(result.valid).toBe(true);
+  });
+
+  it('accepts a valid C-address (contract)', () => {
+    const result = validateAddress('CAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWNA');
+    expect(result.valid).toBe(true);
+  });
+
+  it('rejects an empty string', () => {
+    const result = validateAddress('');
+    expect(result.valid).toBe(false);
+    expect(result.errors.length).toBeGreaterThan(0);
+  });
+
+  it('rejects a short address', () => {
+    const result = validateAddress('GABC123');
+    expect(result.valid).toBe(false);
+  });
+});
+
+describe('validateTipAmount', () => {
+  it('accepts a positive amount', () => {
+    expect(validateTipAmount(1n).valid).toBe(true);
+    expect(validateTipAmount(10_000_000n).valid).toBe(true);
+  });
+
+  it('rejects zero', () => {
+    const result = validateTipAmount(0n);
+    expect(result.valid).toBe(false);
+  });
+
+  it('rejects negative amounts', () => {
+    const result = validateTipAmount(-1n);
+    expect(result.valid).toBe(false);
+  });
+});
+
+describe('validateMessage', () => {
+  it('accepts an empty message', () => {
+    expect(validateMessage('').valid).toBe(true);
+  });
+
+  it('accepts a message at the limit', () => {
+    expect(validateMessage('a'.repeat(MAX_MESSAGE_LENGTH)).valid).toBe(true);
+  });
+
+  it('rejects a message over the limit', () => {
+    const result = validateMessage('a'.repeat(MAX_MESSAGE_LENGTH + 1));
+    expect(result.valid).toBe(false);
+    expect(result.errors[0]).toContain('280');
+  });
+});
+
+describe('validateAssetCode', () => {
+  it('accepts XLM', () => {
+    expect(validateAssetCode('XLM').valid).toBe(true);
+  });
+
+  it('accepts USDC', () => {
+    expect(validateAssetCode('USDC').valid).toBe(true);
+  });
+
+  it('rejects empty string', () => {
+    expect(validateAssetCode('').valid).toBe(false);
+  });
+
+  it('rejects code longer than 12 chars', () => {
+    expect(validateAssetCode('TOOLONGASSET1').valid).toBe(false);
+  });
+});
+
+describe('validateTipForm', () => {
+  const validCreator = 'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWNA';
+  const validTipper = 'GBVVJJWBKQZFKQZFKQZFKQZFKQZFKQZFKQZFKQZFKQZFKQZFKQZFKQZA';
+
+  it('passes with valid inputs', () => {
+    const result = validateTipForm({
+      creator: validCreator,
+      amount: 10_000_000n,
+      tipper: validTipper,
+    });
+    expect(result.valid).toBe(true);
+  });
+
+  it('fails with zero amount', () => {
+    const result = validateTipForm({ creator: validCreator, amount: 0n, tipper: validTipper });
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.includes('amount'))).toBe(true);
+  });
+
+  it('fails with invalid creator', () => {
+    const result = validateTipForm({ creator: 'bad', amount: 1n, tipper: validTipper });
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.includes('creator'))).toBe(true);
+  });
+
+  it('fails with message too long', () => {
+    const result = validateTipForm({
+      creator: validCreator,
+      amount: 1n,
+      tipper: validTipper,
+      message: 'x'.repeat(281),
+    });
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.includes('message'))).toBe(true);
+  });
+});
+
+describe('validateBatchTip', () => {
+  const validCreator = 'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWNA';
+
+  it('accepts a valid batch', () => {
+    const result = validateBatchTip([{ creator: validCreator, amount: 1n }]);
+    expect(result.valid).toBe(true);
+  });
+
+  it('rejects empty batch', () => {
+    expect(validateBatchTip([]).valid).toBe(false);
+  });
+
+  it('rejects batch over max size', () => {
+    const entries = Array.from({ length: MAX_BATCH_SIZE + 1 }, () => ({
+      creator: validCreator,
+      amount: 1n,
+    }));
+    const result = validateBatchTip(entries);
+    expect(result.valid).toBe(false);
+    expect(result.errors[0]).toContain('50');
+  });
+});

--- a/sdk/typescript/src/categories.ts
+++ b/sdk/typescript/src/categories.ts
@@ -1,0 +1,120 @@
+/**
+ * Creator category and tag definitions for the TipJar platform.
+ *
+ * Categories are broad groupings; tags are fine-grained labels within a category.
+ */
+
+export interface Category {
+  id: string;
+  label: string;
+  description: string;
+  tags: string[];
+}
+
+/** All supported creator categories. */
+export const CATEGORIES: Category[] = [
+  {
+    id: 'music',
+    label: 'Music',
+    description: 'Musicians, producers, DJs, and audio creators',
+    tags: ['musician', 'producer', 'dj', 'singer', 'songwriter', 'beatmaker', 'podcast'],
+  },
+  {
+    id: 'art',
+    label: 'Art & Design',
+    description: 'Visual artists, illustrators, designers, and photographers',
+    tags: ['illustrator', 'designer', 'photographer', 'painter', 'sculptor', 'digital-art', 'nft'],
+  },
+  {
+    id: 'writing',
+    label: 'Writing',
+    description: 'Writers, bloggers, journalists, and storytellers',
+    tags: ['blogger', 'journalist', 'novelist', 'poet', 'newsletter', 'technical-writer'],
+  },
+  {
+    id: 'gaming',
+    label: 'Gaming',
+    description: 'Streamers, game developers, and esports players',
+    tags: ['streamer', 'game-dev', 'esports', 'speedrunner', 'modder', 'reviewer'],
+  },
+  {
+    id: 'education',
+    label: 'Education',
+    description: 'Educators, tutors, and course creators',
+    tags: ['tutor', 'course-creator', 'researcher', 'science', 'math', 'language', 'coding'],
+  },
+  {
+    id: 'tech',
+    label: 'Technology',
+    description: 'Developers, open-source contributors, and tech creators',
+    tags: ['open-source', 'developer', 'blockchain', 'ai', 'security', 'devops'],
+  },
+  {
+    id: 'video',
+    label: 'Video',
+    description: 'Video creators, filmmakers, and animators',
+    tags: ['youtuber', 'filmmaker', 'animator', 'vlogger', 'documentary', 'short-film'],
+  },
+  {
+    id: 'wellness',
+    label: 'Wellness',
+    description: 'Fitness, mental health, and lifestyle creators',
+    tags: ['fitness', 'yoga', 'meditation', 'nutrition', 'mental-health', 'lifestyle'],
+  },
+];
+
+/** Map of category ID → Category for O(1) lookup. */
+export const CATEGORY_MAP: Record<string, Category> = Object.fromEntries(
+  CATEGORIES.map((c) => [c.id, c]),
+);
+
+/** All valid tag strings across all categories. */
+export const ALL_TAGS: string[] = CATEGORIES.flatMap((c) => c.tags);
+
+/**
+ * Find the category that contains a given tag.
+ * Returns undefined if the tag is not in any category.
+ */
+export function getCategoryForTag(tag: string): Category | undefined {
+  return CATEGORIES.find((c) => c.tags.includes(tag));
+}
+
+/**
+ * Filter creators by category ID.
+ * @param creators - Array of creator objects with a `categoryId` field.
+ * @param categoryId - Category ID to filter by. Pass `null` to return all.
+ */
+export function filterByCategory<T extends { categoryId?: string }>(
+  creators: T[],
+  categoryId: string | null,
+): T[] {
+  if (!categoryId) return creators;
+  return creators.filter((c) => c.categoryId === categoryId);
+}
+
+/**
+ * Filter creators by one or more tags (OR logic — matches any tag).
+ * @param creators - Array of creator objects with a `tags` field.
+ * @param tags - Tags to filter by. Empty array returns all creators.
+ */
+export function filterByTags<T extends { tags?: string[] }>(
+  creators: T[],
+  tags: string[],
+): T[] {
+  if (!tags.length) return creators;
+  return creators.filter((c) => c.tags?.some((t) => tags.includes(t)));
+}
+
+/**
+ * Validate that a category ID is known.
+ */
+export function isValidCategoryId(id: string): boolean {
+  return id in CATEGORY_MAP;
+}
+
+/**
+ * Validate that a tag string is known.
+ */
+export function isValidTag(tag: string): boolean {
+  return ALL_TAGS.includes(tag);
+}

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -5,3 +5,4 @@ export * from './utils';
 export * from './TipJarContract';
 export * from './client';
 export * from './validation';
+export * from './categories';

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -4,3 +4,4 @@ export * from './events';
 export * from './utils';
 export * from './TipJarContract';
 export * from './client';
+export * from './validation';

--- a/sdk/typescript/src/types.ts
+++ b/sdk/typescript/src/types.ts
@@ -34,3 +34,13 @@ export interface TipEvent {
 export interface WithdrawEvent {
   amount: bigint;
 }
+
+/** Creator profile with optional category and tags. */
+export interface CreatorProfile {
+  address: string;
+  username?: string;
+  categoryId?: string;
+  tags?: string[];
+  totalTips?: bigint;
+  withdrawableBalance?: bigint;
+}

--- a/sdk/typescript/src/validation.ts
+++ b/sdk/typescript/src/validation.ts
@@ -1,0 +1,151 @@
+/**
+ * Validation schemas and helpers for TipJar SDK inputs.
+ *
+ * Provides typed validation for tip parameters, creator addresses,
+ * and asset codes before they are submitted to the contract.
+ */
+
+export interface ValidationResult {
+  valid: boolean;
+  errors: string[];
+}
+
+/** Minimum tip amount in stroops (1 stroop). */
+export const MIN_TIP_AMOUNT = 1n;
+
+/** Maximum tip message length in characters. */
+export const MAX_MESSAGE_LENGTH = 280;
+
+/** Maximum tip batch size. */
+export const MAX_BATCH_SIZE = 50;
+
+/** Stellar public key regex (G... 56 chars). */
+const STELLAR_ADDRESS_RE = /^G[A-Z2-7]{55}$/;
+
+/** Stellar asset code regex (1–12 alphanumeric chars). */
+const ASSET_CODE_RE = /^[A-Za-z0-9]{1,12}$/;
+
+/**
+ * Validate a Stellar address (G... public key or contract address C...).
+ */
+export function validateAddress(address: string): ValidationResult {
+  const errors: string[] = [];
+  if (!address || typeof address !== 'string') {
+    errors.push('Address is required');
+  } else if (!/^[GC][A-Z2-7]{55}$/.test(address)) {
+    errors.push('Address must be a valid Stellar public key (G...) or contract address (C...)');
+  }
+  return { valid: errors.length === 0, errors };
+}
+
+/**
+ * Validate a tip amount.
+ * @param amount - Amount in stroops (bigint).
+ */
+export function validateTipAmount(amount: bigint): ValidationResult {
+  const errors: string[] = [];
+  if (typeof amount !== 'bigint') {
+    errors.push('Amount must be a bigint');
+  } else if (amount < MIN_TIP_AMOUNT) {
+    errors.push(`Amount must be at least ${MIN_TIP_AMOUNT} stroop`);
+  }
+  return { valid: errors.length === 0, errors };
+}
+
+/**
+ * Validate a tip message.
+ * @param message - Optional message string.
+ */
+export function validateMessage(message: string): ValidationResult {
+  const errors: string[] = [];
+  if (typeof message !== 'string') {
+    errors.push('Message must be a string');
+  } else if (message.length > MAX_MESSAGE_LENGTH) {
+    errors.push(`Message must not exceed ${MAX_MESSAGE_LENGTH} characters (got ${message.length})`);
+  }
+  return { valid: errors.length === 0, errors };
+}
+
+/**
+ * Validate a Stellar asset code.
+ * @param code - Asset code string (e.g. "XLM", "USDC").
+ */
+export function validateAssetCode(code: string): ValidationResult {
+  const errors: string[] = [];
+  if (!code || typeof code !== 'string') {
+    errors.push('Asset code is required');
+  } else if (!ASSET_CODE_RE.test(code)) {
+    errors.push('Asset code must be 1–12 alphanumeric characters');
+  }
+  return { valid: errors.length === 0, errors };
+}
+
+export interface TipFormValues {
+  creator: string;
+  amount: bigint;
+  tipper: string;
+  message?: string;
+}
+
+/**
+ * Validate all fields of a tip form submission.
+ * Returns a combined ValidationResult.
+ *
+ * @example
+ * const result = validateTipForm({ creator: 'G...', amount: 10_000_000n, tipper: 'G...' });
+ * if (!result.valid) console.error(result.errors);
+ */
+export function validateTipForm(values: TipFormValues): ValidationResult {
+  const errors: string[] = [];
+
+  const creatorResult = validateAddress(values.creator);
+  if (!creatorResult.valid) errors.push(...creatorResult.errors.map((e) => `creator: ${e}`));
+
+  const tipperResult = validateAddress(values.tipper);
+  if (!tipperResult.valid) errors.push(...tipperResult.errors.map((e) => `tipper: ${e}`));
+
+  const amountResult = validateTipAmount(values.amount);
+  if (!amountResult.valid) errors.push(...amountResult.errors.map((e) => `amount: ${e}`));
+
+  if (values.message !== undefined) {
+    const msgResult = validateMessage(values.message);
+    if (!msgResult.valid) errors.push(...msgResult.errors.map((e) => `message: ${e}`));
+  }
+
+  return { valid: errors.length === 0, errors };
+}
+
+export interface BatchTipEntry {
+  creator: string;
+  amount: bigint;
+}
+
+/**
+ * Validate a batch tip array.
+ * Checks batch size limit and validates each entry.
+ */
+export function validateBatchTip(entries: BatchTipEntry[]): ValidationResult {
+  const errors: string[] = [];
+
+  if (!Array.isArray(entries) || entries.length === 0) {
+    errors.push('Batch must contain at least one entry');
+    return { valid: false, errors };
+  }
+
+  if (entries.length > MAX_BATCH_SIZE) {
+    errors.push(`Batch size must not exceed ${MAX_BATCH_SIZE} (got ${entries.length})`);
+  }
+
+  entries.forEach((entry, i) => {
+    const creatorResult = validateAddress(entry.creator);
+    if (!creatorResult.valid) {
+      errors.push(...creatorResult.errors.map((e) => `entries[${i}].creator: ${e}`));
+    }
+    const amountResult = validateTipAmount(entry.amount);
+    if (!amountResult.valid) {
+      errors.push(...amountResult.errors.map((e) => `entries[${i}].amount: ${e}`));
+    }
+  });
+
+  return { valid: errors.length === 0, errors };
+}


### PR DESCRIPTION



## Summary

This PR implements four issues from the Stellar Wave program, covering developer documentation, a docs changelog, SDK input validation, and a creator category/tag system.

---

## Changes by Issue

### #41 — Comprehensive Developer Documentation

Added five new documentation files under `docs/`:

- **`docs/ARCHITECTURE.md`** — Full repository layout, request/data flow diagram (Frontend → SDK → RPC → Contract → Indexer), wallet interaction flow, and TypeScript SDK component hierarchy.
- **`docs/STATE_MANAGEMENT.md`** — On-chain storage model (instance vs. persistent storage), state transition diagrams for tip, withdraw, locked tip, and pause flows, plus the off-chain indexer DB schema.
- **`docs/WALLET_INTEGRATION.md`** — Integration patterns for Keypair (server/CLI), Freighter (browser), and WalletConnect. Includes the full authorization model table and network configuration reference.
- **`docs/CODE_STYLE.md`** — Rust and TypeScript formatting/linting rules, naming conventions, doc comment requirements, and Conventional Commits format.
- **`docs/CONTRIBUTING.md`** — Developer setup, branching strategy, PR checklist, and test requirements specific to the contracts repo.

---

### #42 — Docs Changelog

- **`docs/CHANGELOG.md`** — Lightweight changelog following [Keep a Changelog](https://keepachangelog.com/) format. Includes an `[Unreleased]` section for ongoing improvements and a `[1.0.0]` baseline entry cataloguing all previously existing documentation files.

---

### #43 — Form Validation Schemas and Helpers

Added `sdk/typescript/src/validation.ts` with typed, dependency-free validators:

| Export | Description |
|---|---|
| `validateAddress(address)` | Validates Stellar G.../C... public keys (56-char base32) |
| `validateTipAmount(amount)` | Ensures `bigint` amount ≥ 1 stroop |
| `validateMessage(message)` | Enforces ≤ 280 character limit |
| `validateAssetCode(code)` | Validates 1–12 alphanumeric asset codes |
| `validateTipForm(values)` | Composite validator for full tip form submissions |
| `validateBatchTip(entries)` | Validates batch arrays (≤ 50 entries, each entry valid) |

All validators return `{ valid: boolean, errors: string[] }` for easy integration with any form library. Exported from the SDK index. **21 unit tests** added covering happy paths and all error branches.

---

### #70 — Creator Categories and Tags

Added `sdk/typescript/src/categories.ts` with a full category/tag system:

**8 predefined categories:** Music, Art & Design, Writing, Gaming, Education, Technology, Video, Wellness — each with associated fine-grained tags (e.g. `musician`, `producer`, `open-source`, `blockchain`).

| Export | Description |
|---|---|
| `CATEGORIES` | Array of all `Category` objects |
| `CATEGORY_MAP` | O(1) lookup map by category ID |
| `ALL_TAGS` | Flat array of all valid tag strings |
| `getCategoryForTag(tag)` | Finds the parent category for a tag |
| `filterByCategory(creators, id)` | Filters creator list by category ID |
| `filterByTags(creators, tags)` | Filters creator list by tags (OR logic) |
| `isValidCategoryId(id)` | Validates a category ID string |
| `isValidTag(tag)` | Validates a tag string |

Added `CreatorProfile` interface to `types.ts` with `categoryId` and `tags` fields. Exported from the SDK index. **17 unit tests** added.

---

## Files Changed


docs/ARCHITECTURE.md          (new)
docs/STATE_MANAGEMENT.md      (new)
docs/WALLET_INTEGRATION.md    (new)
docs/CODE_STYLE.md            (new)
docs/CONTRIBUTING.md          (new)
docs/CHANGELOG.md             (new)
sdk/typescript/src/validation.ts              (new)
sdk/typescript/src/categories.ts              (new)
sdk/typescript/src/types.ts                   (modified — added CreatorProfile)
sdk/typescript/src/index.ts                   (modified — exports validation + categories)
sdk/typescript/src/__tests__/validation.test.ts  (new)
sdk/typescript/src/__tests__/categories.test.ts  (new)

## Test Plan

- `npx jest` in `sdk/typescript/` — all 38 new tests pass (21 validation + 17 categories)
- All existing SDK tests continue to pass

---

Closes #41
Closes #42
Closes #43
Closes #70

