### PR TITLE
feat: implement tip subscription tiers

### DIFF
--- a/contracts/tipjar/Cargo.toml
+++ b/contracts/tipjar/Cargo.toml
@@ -52,3 +52,7 @@ path = "tests/multisig_withdrawal_tests.rs"
 [[test]]
 name = "multi_token_tests"
 path = "tests/multi_token_tests.rs"
+
+[[test]]
+name = "subscription_tiers"
+path = "tests/subscription_tiers.rs"

--- a/contracts/tipjar/src/lib.rs
+++ b/contracts/tipjar/src/lib.rs
@@ -277,6 +277,25 @@ pub enum SubscriptionStatus {
     Cancelled,
 }
 
+/// Subscription tier level.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum SubscriptionTier {
+    Bronze,
+    Silver,
+    Gold,
+}
+
+/// Configuration for a subscription tier set by admin.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TierConfig {
+    /// Price per payment interval in token units.
+    pub price: i128,
+    /// Human-readable description of benefits for this tier.
+    pub benefits: String,
+}
+
 /// A recurring tip subscription from a subscriber to a creator.
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -290,6 +309,10 @@ pub struct Subscription {
     pub last_payment: u64,
     pub next_payment: u64,
     pub status: SubscriptionStatus,
+    /// The tier this subscription is on.
+    pub tier: SubscriptionTier,
+    /// Pending tier change to apply at next payment cycle (None = no pending change).
+    pub pending_tier: Option<SubscriptionTier>,
 }
 
 /// A time-locked tip that can only be withdrawn after `unlock_time`.
@@ -478,6 +501,8 @@ pub enum DataKey {
     PrivateTipCounter,
     /// Revealed amount for a private tip keyed by tip_id.
     PrivateTipAmount(u64),
+    /// Tier configuration keyed by SubscriptionTier.
+    TierConfig(SubscriptionTier),
 }
 
 #[contracterror]
@@ -568,6 +593,8 @@ pub enum TipJarError {
     PrivateTipNotFound = 52,
     /// Invalid reveal - hash mismatch.
     InvalidReveal = 53,
+    /// Tier configuration not found.
+    TierNotConfigured = 54,
 }
 
 #[contract]
@@ -1448,8 +1475,52 @@ impl TipJarContract {
         upgrade::get_version(&env)
     }
 
-    /// Creates a recurring tip subscription from `subscriber` to `creator`.
+    /// Sets the configuration for a subscription tier. Admin only.
     ///
+    /// `price` is the amount charged per payment interval.
+    /// `benefits` is a human-readable description of what the tier provides.
+    /// Emits `("tier_set",)` with data `(tier, price)`.
+    pub fn set_tier_config(
+        env: Env,
+        admin: Address,
+        tier: SubscriptionTier,
+        price: i128,
+        benefits: String,
+    ) {
+        admin.require_auth();
+        let stored_admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+        if admin != stored_admin {
+            panic_with_error!(&env, TipJarError::Unauthorized);
+        }
+        if price <= 0 {
+            panic_with_error!(&env, TipJarError::InvalidAmount);
+        }
+        let config = TierConfig { price, benefits };
+        env.storage()
+            .persistent()
+            .set(&DataKey::TierConfig(tier.clone()), &config);
+        env.events()
+            .publish((symbol_short!("tier_set"),), (tier, price));
+    }
+
+    /// Returns the configuration for a tier, or `None` if not configured.
+    pub fn get_tier_config(env: Env, tier: SubscriptionTier) -> Option<TierConfig> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::TierConfig(tier))
+    }
+
+    /// Returns the benefits description for a tier, or `None` if not configured.
+    pub fn get_tier_benefits(env: Env, tier: SubscriptionTier) -> Option<String> {
+        env.storage()
+            .persistent()
+            .get::<DataKey, TierConfig>(&DataKey::TierConfig(tier))
+            .map(|c| c.benefits)
+    }
+
+    /// Creates a recurring tip subscription from `subscriber` to `creator` at the given tier.
+    ///
+    /// The tier must be configured via `set_tier_config` first.
     /// The first payment becomes due immediately (at creation time).
     /// Minimum interval is 1 day (86 400 seconds).
     ///
@@ -1481,6 +1552,8 @@ impl TipJarContract {
             last_payment: 0,
             next_payment: now,
             status: SubscriptionStatus::Active,
+            tier: SubscriptionTier::Bronze,
+            pending_tier: None,
         };
         env.storage()
             .persistent()
@@ -1491,9 +1564,149 @@ impl TipJarContract {
         );
     }
 
+    /// Creates a tiered subscription from `subscriber` to `creator`.
+    ///
+    /// The tier must be configured via `set_tier_config`. The price from the tier
+    /// config is used as the payment amount.
+    /// Minimum interval is 1 day (86 400 seconds).
+    ///
+    /// Emits `("sub_new", creator)` with data `(subscriber, amount, interval_seconds)`.
+    pub fn create_tiered_subscription(
+        env: Env,
+        subscriber: Address,
+        creator: Address,
+        token: Address,
+        tier: SubscriptionTier,
+        interval_seconds: u64,
+    ) {
+        Self::require_not_paused(&env);
+        subscriber.require_auth();
+        let config: TierConfig = env
+            .storage()
+            .persistent()
+            .get(&DataKey::TierConfig(tier.clone()))
+            .unwrap_or_else(|| panic_with_error!(&env, TipJarError::TierNotConfigured));
+        const MIN_INTERVAL: u64 = 86_400;
+        if interval_seconds < MIN_INTERVAL {
+            panic_with_error!(&env, TipJarError::InvalidInterval);
+        }
+        let now = env.ledger().timestamp();
+        let amount = config.price;
+        let sub = Subscription {
+            subscriber: subscriber.clone(),
+            creator: creator.clone(),
+            token,
+            amount,
+            interval_seconds,
+            last_payment: 0,
+            next_payment: now,
+            status: SubscriptionStatus::Active,
+            tier: tier.clone(),
+            pending_tier: None,
+        };
+        env.storage()
+            .persistent()
+            .set(&DataKey::Subscription(subscriber.clone(), creator.clone()), &sub);
+        env.events().publish(
+            (symbol_short!("sub_new"), creator),
+            (subscriber, amount, interval_seconds),
+        );
+    }
+
+    /// Upgrades an active subscription to a higher tier immediately.
+    ///
+    /// Executes an immediate payment at the new tier's price and updates the
+    /// subscription amount for future payments.
+    /// Emits `("sub_upgr", creator)` with data `(subscriber, new_tier_price)`.
+    pub fn upgrade_subscription(
+        env: Env,
+        subscriber: Address,
+        creator: Address,
+        new_tier: SubscriptionTier,
+    ) {
+        Self::require_not_paused(&env);
+        subscriber.require_auth();
+        let key = DataKey::Subscription(subscriber.clone(), creator.clone());
+        let mut sub: Subscription = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .unwrap_or_else(|| panic_with_error!(&env, TipJarError::SubscriptionNotFound));
+        if sub.status != SubscriptionStatus::Active {
+            panic_with_error!(&env, TipJarError::SubscriptionNotActive);
+        }
+        let config: TierConfig = env
+            .storage()
+            .persistent()
+            .get(&DataKey::TierConfig(new_tier.clone()))
+            .unwrap_or_else(|| panic_with_error!(&env, TipJarError::TierNotConfigured));
+
+        // Execute immediate payment at new tier price.
+        token::Client::new(&env, &sub.token).transfer(
+            &subscriber,
+            &env.current_contract_address(),
+            &config.price,
+        );
+        let bal_key = DataKey::CreatorBalance(creator.clone(), sub.token.clone());
+        let bal: i128 = env.storage().persistent().get(&bal_key).unwrap_or(0);
+        env.storage().persistent().set(&bal_key, &(bal + config.price));
+        let tot_key = DataKey::CreatorTotal(creator.clone(), sub.token.clone());
+        let tot: i128 = env.storage().persistent().get(&tot_key).unwrap_or(0);
+        env.storage().persistent().set(&tot_key, &(tot + config.price));
+
+        let now = env.ledger().timestamp();
+        sub.tier = new_tier;
+        sub.amount = config.price;
+        sub.last_payment = now;
+        sub.next_payment = now + sub.interval_seconds;
+        sub.pending_tier = None;
+        env.storage().persistent().set(&key, &sub);
+        env.events().publish(
+            (symbol_short!("sub_upgr"), creator),
+            (subscriber, config.price),
+        );
+    }
+
+    /// Schedules a downgrade to a lower tier, effective at the next payment cycle.
+    ///
+    /// The current tier and amount remain active until `execute_subscription_payment`
+    /// is called, at which point the pending tier is applied.
+    /// Emits `("sub_dngr", creator)` with data `(subscriber, new_tier_price)`.
+    pub fn downgrade_subscription(
+        env: Env,
+        subscriber: Address,
+        creator: Address,
+        new_tier: SubscriptionTier,
+    ) {
+        Self::require_not_paused(&env);
+        subscriber.require_auth();
+        let key = DataKey::Subscription(subscriber.clone(), creator.clone());
+        let mut sub: Subscription = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .unwrap_or_else(|| panic_with_error!(&env, TipJarError::SubscriptionNotFound));
+        if sub.status != SubscriptionStatus::Active {
+            panic_with_error!(&env, TipJarError::SubscriptionNotActive);
+        }
+        // Validate the target tier is configured.
+        let config: TierConfig = env
+            .storage()
+            .persistent()
+            .get(&DataKey::TierConfig(new_tier.clone()))
+            .unwrap_or_else(|| panic_with_error!(&env, TipJarError::TierNotConfigured));
+        sub.pending_tier = Some(new_tier);
+        env.storage().persistent().set(&key, &sub);
+        env.events().publish(
+            (symbol_short!("sub_dngr"), creator),
+            (subscriber, config.price),
+        );
+    }
+
     /// Executes a due subscription payment, transferring tokens from subscriber
     /// into escrow for the creator.
     ///
+    /// Applies any pending tier downgrade before charging.
     /// Anyone may call this; the subscriber's auth is pulled via `transfer`.
     /// Emits `("sub_pay", creator)` with data `(subscriber, amount)`.
     pub fn execute_subscription_payment(env: Env, subscriber: Address, creator: Address) {
@@ -1511,6 +1724,19 @@ impl TipJarContract {
         let now = env.ledger().timestamp();
         if now < sub.next_payment {
             panic_with_error!(&env, TipJarError::PaymentNotDue);
+        }
+
+        // Apply pending downgrade if present.
+        if let Some(pending) = sub.pending_tier.clone() {
+            if let Some(config) = env
+                .storage()
+                .persistent()
+                .get::<DataKey, TierConfig>(&DataKey::TierConfig(pending.clone()))
+            {
+                sub.tier = pending;
+                sub.amount = config.price;
+            }
+            sub.pending_tier = None;
         }
 
         token::Client::new(&env, &sub.token).transfer(

--- a/contracts/tipjar/tests/subscription_tiers.rs
+++ b/contracts/tipjar/tests/subscription_tiers.rs
@@ -1,0 +1,431 @@
+#![cfg(test)]
+
+extern crate std;
+
+use soroban_sdk::{
+    testutils::{Address as _, Ledger as _},
+    token, Address, Env, String,
+};
+use tipjar::{
+    Subscription, SubscriptionStatus, SubscriptionTier, TierConfig, TipJarContract,
+    TipJarContractClient, TipJarError,
+};
+
+const ONE_MONTH: u64 = 2_592_000;
+
+// ── setup ─────────────────────────────────────────────────────────────────────
+
+fn setup() -> (Env, TipJarContractClient<'static>, Address, Address, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let token_admin = Address::generate(&env);
+    let token = env.register_stellar_asset_contract_v2(token_admin.clone()).address();
+
+    let admin = Address::generate(&env);
+    let contract_id = env.register(TipJarContract, ());
+    let client = TipJarContractClient::new(&env, &contract_id);
+
+    client.init(&admin);
+    client.add_token(&admin, &token);
+
+    (env, client, admin, token, token_admin)
+}
+
+fn mint(env: &Env, token_admin: &Address, token: &Address, user: &Address, amount: i128) {
+    token::StellarAssetClient::new(env, token).mint(user, &amount);
+}
+
+fn balance(env: &Env, token: &Address, user: &Address) -> i128 {
+    token::Client::new(env, token).balance(user)
+}
+
+// ── tier config ───────────────────────────────────────────────────────────────
+
+#[test]
+fn test_set_and_get_tier_config() {
+    let (env, client, admin, _token, _ta) = setup();
+    client.set_tier_config(
+        &admin,
+        &SubscriptionTier::Silver,
+        &500,
+        &String::from_str(&env, "Silver benefits"),
+    );
+    let cfg: TierConfig = client.get_tier_config(&SubscriptionTier::Silver).unwrap();
+    assert_eq!(cfg.price, 500);
+    assert_eq!(cfg.benefits, String::from_str(&env, "Silver benefits"));
+}
+
+#[test]
+fn test_get_tier_config_returns_none_when_not_set() {
+    let (_env, client, _admin, _token, _ta) = setup();
+    assert!(client.get_tier_config(&SubscriptionTier::Gold).is_none());
+}
+
+#[test]
+fn test_set_tier_config_unauthorized() {
+    let (env, client, _admin, _token, _ta) = setup();
+    let not_admin = Address::generate(&env);
+    let result = client.try_set_tier_config(
+        &not_admin,
+        &SubscriptionTier::Bronze,
+        &100,
+        &String::from_str(&env, "Bronze"),
+    );
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_set_tier_config_rejects_zero_price() {
+    let (env, client, admin, _token, _ta) = setup();
+    let result = client.try_set_tier_config(
+        &admin,
+        &SubscriptionTier::Bronze,
+        &0,
+        &String::from_str(&env, "Bronze"),
+    );
+    assert!(result.is_err());
+}
+
+// ── get_tier_benefits ─────────────────────────────────────────────────────────
+
+#[test]
+fn test_get_tier_benefits_returns_description() {
+    let (env, client, admin, _token, _ta) = setup();
+    client.set_tier_config(
+        &admin,
+        &SubscriptionTier::Gold,
+        &1000,
+        &String::from_str(&env, "Gold: exclusive access"),
+    );
+    let benefits = client.get_tier_benefits(&SubscriptionTier::Gold).unwrap();
+    assert_eq!(benefits, String::from_str(&env, "Gold: exclusive access"));
+}
+
+#[test]
+fn test_get_tier_benefits_returns_none_when_not_configured() {
+    let (_env, client, _admin, _token, _ta) = setup();
+    assert!(client.get_tier_benefits(&SubscriptionTier::Silver).is_none());
+}
+
+// ── create_tiered_subscription ────────────────────────────────────────────────
+
+#[test]
+fn test_create_tiered_subscription_uses_tier_price() {
+    let (env, client, admin, token, ta) = setup();
+    client.set_tier_config(
+        &admin,
+        &SubscriptionTier::Silver,
+        &300,
+        &String::from_str(&env, "Silver"),
+    );
+    let subscriber = Address::generate(&env);
+    let creator = Address::generate(&env);
+    mint(&env, &ta, &token, &subscriber, 10_000);
+
+    client.create_tiered_subscription(
+        &subscriber,
+        &creator,
+        &token,
+        &SubscriptionTier::Silver,
+        &ONE_MONTH,
+    );
+
+    let sub: Subscription = client.get_subscription(&subscriber, &creator).unwrap();
+    assert_eq!(sub.amount, 300);
+    assert_eq!(sub.status, SubscriptionStatus::Active);
+    assert_eq!(sub.tier, SubscriptionTier::Silver);
+    assert!(sub.pending_tier.is_none());
+}
+
+#[test]
+fn test_create_tiered_subscription_fails_when_tier_not_configured() {
+    let (env, client, _admin, token, ta) = setup();
+    let subscriber = Address::generate(&env);
+    let creator = Address::generate(&env);
+    mint(&env, &ta, &token, &subscriber, 10_000);
+
+    let result = client.try_create_tiered_subscription(
+        &subscriber,
+        &creator,
+        &token,
+        &SubscriptionTier::Gold,
+        &ONE_MONTH,
+    );
+    assert!(result.is_err());
+}
+
+// ── upgrade_subscription ──────────────────────────────────────────────────────
+
+#[test]
+fn test_upgrade_executes_immediate_payment_at_new_price() {
+    let (env, client, admin, token, ta) = setup();
+    client.set_tier_config(
+        &admin,
+        &SubscriptionTier::Bronze,
+        &100,
+        &String::from_str(&env, "Bronze"),
+    );
+    client.set_tier_config(
+        &admin,
+        &SubscriptionTier::Gold,
+        &500,
+        &String::from_str(&env, "Gold"),
+    );
+    let subscriber = Address::generate(&env);
+    let creator = Address::generate(&env);
+    mint(&env, &ta, &token, &subscriber, 10_000);
+
+    client.create_tiered_subscription(
+        &subscriber,
+        &creator,
+        &token,
+        &SubscriptionTier::Bronze,
+        &ONE_MONTH,
+    );
+
+    client.upgrade_subscription(&subscriber, &creator, &SubscriptionTier::Gold);
+
+    // Subscriber paid 500 immediately.
+    assert_eq!(balance(&env, &token, &subscriber), 9_500);
+
+    let sub: Subscription = client.get_subscription(&subscriber, &creator).unwrap();
+    assert_eq!(sub.tier, SubscriptionTier::Gold);
+    assert_eq!(sub.amount, 500);
+    assert!(sub.pending_tier.is_none());
+}
+
+#[test]
+fn test_upgrade_fails_when_tier_not_configured() {
+    let (env, client, admin, token, ta) = setup();
+    client.set_tier_config(
+        &admin,
+        &SubscriptionTier::Bronze,
+        &100,
+        &String::from_str(&env, "Bronze"),
+    );
+    let subscriber = Address::generate(&env);
+    let creator = Address::generate(&env);
+    mint(&env, &ta, &token, &subscriber, 10_000);
+
+    client.create_tiered_subscription(
+        &subscriber,
+        &creator,
+        &token,
+        &SubscriptionTier::Bronze,
+        &ONE_MONTH,
+    );
+
+    let result =
+        client.try_upgrade_subscription(&subscriber, &creator, &SubscriptionTier::Gold);
+    assert!(result.is_err());
+}
+
+// ── downgrade_subscription ────────────────────────────────────────────────────
+
+#[test]
+fn test_downgrade_schedules_pending_tier() {
+    let (env, client, admin, token, ta) = setup();
+    client.set_tier_config(
+        &admin,
+        &SubscriptionTier::Gold,
+        &500,
+        &String::from_str(&env, "Gold"),
+    );
+    client.set_tier_config(
+        &admin,
+        &SubscriptionTier::Bronze,
+        &100,
+        &String::from_str(&env, "Bronze"),
+    );
+    let subscriber = Address::generate(&env);
+    let creator = Address::generate(&env);
+    mint(&env, &ta, &token, &subscriber, 10_000);
+
+    client.create_tiered_subscription(
+        &subscriber,
+        &creator,
+        &token,
+        &SubscriptionTier::Gold,
+        &ONE_MONTH,
+    );
+
+    client.downgrade_subscription(&subscriber, &creator, &SubscriptionTier::Bronze);
+
+    let sub: Subscription = client.get_subscription(&subscriber, &creator).unwrap();
+    // Current tier unchanged until next payment.
+    assert_eq!(sub.tier, SubscriptionTier::Gold);
+    assert_eq!(sub.amount, 500);
+    assert_eq!(sub.pending_tier, Some(SubscriptionTier::Bronze));
+}
+
+#[test]
+fn test_downgrade_applied_at_next_payment() {
+    let (env, client, admin, token, ta) = setup();
+    client.set_tier_config(
+        &admin,
+        &SubscriptionTier::Gold,
+        &500,
+        &String::from_str(&env, "Gold"),
+    );
+    client.set_tier_config(
+        &admin,
+        &SubscriptionTier::Bronze,
+        &100,
+        &String::from_str(&env, "Bronze"),
+    );
+    let subscriber = Address::generate(&env);
+    let creator = Address::generate(&env);
+    mint(&env, &ta, &token, &subscriber, 10_000);
+
+    client.create_tiered_subscription(
+        &subscriber,
+        &creator,
+        &token,
+        &SubscriptionTier::Gold,
+        &ONE_MONTH,
+    );
+
+    // Execute first payment at Gold price.
+    client.execute_subscription_payment(&subscriber, &creator);
+    assert_eq!(balance(&env, &token, &subscriber), 9_500);
+
+    // Schedule downgrade.
+    client.downgrade_subscription(&subscriber, &creator, &SubscriptionTier::Bronze);
+
+    // Advance time and execute second payment — should apply Bronze price.
+    env.ledger().with_mut(|li| li.timestamp += ONE_MONTH);
+    client.execute_subscription_payment(&subscriber, &creator);
+
+    // Second payment was 100 (Bronze), not 500 (Gold).
+    assert_eq!(balance(&env, &token, &subscriber), 9_400);
+
+    let sub: Subscription = client.get_subscription(&subscriber, &creator).unwrap();
+    assert_eq!(sub.tier, SubscriptionTier::Bronze);
+    assert_eq!(sub.amount, 100);
+    assert!(sub.pending_tier.is_none());
+}
+
+#[test]
+fn test_downgrade_fails_when_tier_not_configured() {
+    let (env, client, admin, token, ta) = setup();
+    client.set_tier_config(
+        &admin,
+        &SubscriptionTier::Gold,
+        &500,
+        &String::from_str(&env, "Gold"),
+    );
+    let subscriber = Address::generate(&env);
+    let creator = Address::generate(&env);
+    mint(&env, &ta, &token, &subscriber, 10_000);
+
+    client.create_tiered_subscription(
+        &subscriber,
+        &creator,
+        &token,
+        &SubscriptionTier::Gold,
+        &ONE_MONTH,
+    );
+
+    let result =
+        client.try_downgrade_subscription(&subscriber, &creator, &SubscriptionTier::Bronze);
+    assert!(result.is_err());
+}
+
+// ── status tracking ───────────────────────────────────────────────────────────
+
+#[test]
+fn test_tiered_subscription_pause_resume_cancel() {
+    let (env, client, admin, token, ta) = setup();
+    client.set_tier_config(
+        &admin,
+        &SubscriptionTier::Silver,
+        &200,
+        &String::from_str(&env, "Silver"),
+    );
+    let subscriber = Address::generate(&env);
+    let creator = Address::generate(&env);
+    mint(&env, &ta, &token, &subscriber, 10_000);
+
+    client.create_tiered_subscription(
+        &subscriber,
+        &creator,
+        &token,
+        &SubscriptionTier::Silver,
+        &ONE_MONTH,
+    );
+
+    client.pause_subscription(&subscriber, &creator);
+    let sub: Subscription = client.get_subscription(&subscriber, &creator).unwrap();
+    assert_eq!(sub.status, SubscriptionStatus::Paused);
+
+    client.resume_subscription(&subscriber, &creator);
+    let sub: Subscription = client.get_subscription(&subscriber, &creator).unwrap();
+    assert_eq!(sub.status, SubscriptionStatus::Active);
+
+    client.cancel_subscription(&subscriber, &creator);
+    let sub: Subscription = client.get_subscription(&subscriber, &creator).unwrap();
+    assert_eq!(sub.status, SubscriptionStatus::Cancelled);
+}
+
+// ── recurring payments ────────────────────────────────────────────────────────
+
+#[test]
+fn test_recurring_payments_at_tier_price() {
+    let (env, client, admin, token, ta) = setup();
+    client.set_tier_config(
+        &admin,
+        &SubscriptionTier::Silver,
+        &250,
+        &String::from_str(&env, "Silver"),
+    );
+    let subscriber = Address::generate(&env);
+    let creator = Address::generate(&env);
+    mint(&env, &ta, &token, &subscriber, 10_000);
+
+    client.create_tiered_subscription(
+        &subscriber,
+        &creator,
+        &token,
+        &SubscriptionTier::Silver,
+        &ONE_MONTH,
+    );
+
+    // First payment.
+    client.execute_subscription_payment(&subscriber, &creator);
+    assert_eq!(balance(&env, &token, &subscriber), 9_750);
+
+    // Second payment after interval.
+    env.ledger().with_mut(|li| li.timestamp += ONE_MONTH);
+    client.execute_subscription_payment(&subscriber, &creator);
+    assert_eq!(balance(&env, &token, &subscriber), 9_500);
+}
+
+#[test]
+fn test_payment_not_due_before_interval() {
+    let (env, client, admin, token, ta) = setup();
+    client.set_tier_config(
+        &admin,
+        &SubscriptionTier::Bronze,
+        &100,
+        &String::from_str(&env, "Bronze"),
+    );
+    let subscriber = Address::generate(&env);
+    let creator = Address::generate(&env);
+    mint(&env, &ta, &token, &subscriber, 10_000);
+
+    client.create_tiered_subscription(
+        &subscriber,
+        &creator,
+        &token,
+        &SubscriptionTier::Bronze,
+        &ONE_MONTH,
+    );
+
+    client.execute_subscription_payment(&subscriber, &creator);
+
+    // Advance less than the full interval.
+    env.ledger().with_mut(|li| li.timestamp += ONE_MONTH - 1);
+    let result = client.try_execute_subscription_payment(&subscriber, &creator);
+    assert!(result.is_err());
+}


### PR DESCRIPTION
closes #180 
closes #181 
closes #182 
closes #183 

- Add SubscriptionTier enum (Bronze/Silver/Gold) and TierConfig struct with price and benefits fields
- Update Subscription struct with tier and pending_tier fields
- Add DataKey::TierConfig for per-tier storage
- Add TierNotConfigured error code (54)
- Add set_tier_config / get_tier_config / get_tier_benefits (admin-managed)
- Add create_tiered_subscription using tier price as payment amount
- Add upgrade_subscription: immediate payment at new tier price
- Add downgrade_subscription: schedules pending tier for next cycle
- Update execute_subscription_payment to apply pending downgrades
- Keep backward-compatible create_subscription (defaults to Bronze tier)
- Add subscription_tiers test suite (15 tests)