### PR TITLE
feat: implement tip index funds

### DIFF
--- a/contracts/tipjar/src/index_fund/composition.rs
+++ b/contracts/tipjar/src/index_fund/composition.rs
@@ -1,0 +1,84 @@
+//! Index composition management — define and validate creator baskets.
+
+use soroban_sdk::{Address, Env, String, Vec};
+
+use super::{next_fund_id, save_fund, IndexComponent, IndexFund};
+
+/// Validate that component weights sum to exactly 10_000 bps.
+pub fn validate_weights(components: &Vec<IndexComponent>) -> bool {
+    if components.is_empty() {
+        return false;
+    }
+    let sum: u32 = components.iter().map(|c| c.weight_bps).sum();
+    sum == 10_000
+}
+
+/// Create a new index fund with the given composition.
+/// Panics if weights don't sum to 10_000 or if fewer than 2 creators are provided.
+pub fn create_index_fund(
+    env: &Env,
+    manager: &Address,
+    token: &Address,
+    name: String,
+    components: Vec<IndexComponent>,
+) -> u64 {
+    if components.len() < 2 {
+        panic!("Index fund requires at least 2 creators");
+    }
+    if !validate_weights(&components) {
+        panic!("Component weights must sum to 10000 bps");
+    }
+
+    let id = next_fund_id(env);
+    let now = env.ledger().timestamp();
+
+    let fund = IndexFund {
+        id,
+        name,
+        manager: manager.clone(),
+        token: token.clone(),
+        components,
+        total_shares: 0,
+        total_value: 0,
+        created_at: now,
+        last_rebalanced: now,
+        active: true,
+    };
+
+    save_fund(env, &fund);
+    id
+}
+
+/// Update the composition of an existing fund (manager only).
+/// Resets allocations proportionally based on new weights.
+pub fn update_composition(
+    env: &Env,
+    fund_id: u64,
+    caller: &Address,
+    new_components: Vec<IndexComponent>,
+) {
+    let mut fund = super::get_fund(env, fund_id).expect("Fund not found");
+
+    if fund.manager != *caller {
+        panic!("Only the fund manager can update composition");
+    }
+    if new_components.len() < 2 {
+        panic!("Index fund requires at least 2 creators");
+    }
+    if !validate_weights(&new_components) {
+        panic!("Component weights must sum to 10000 bps");
+    }
+
+    fund.components = new_components;
+    save_fund(env, &fund);
+}
+
+/// Get the list of creators in a fund.
+pub fn get_creators(env: &Env, fund_id: u64) -> Vec<Address> {
+    let fund = super::get_fund(env, fund_id).expect("Fund not found");
+    let mut creators = Vec::new(env);
+    for c in fund.components.iter() {
+        creators.push_back(c.creator.clone());
+    }
+    creators
+}

--- a/contracts/tipjar/src/index_fund/mod.rs
+++ b/contracts/tipjar/src/index_fund/mod.rs
@@ -1,0 +1,154 @@
+//! Tip Index Funds
+//!
+//! Allows users to deposit into diversified baskets of creators.
+//! The fund tracks a weighted composition of creators, supports rebalancing,
+//! calculates NAV (net asset value), and issues/redeems fund shares.
+
+pub mod composition;
+pub mod rebalance;
+pub mod shares;
+
+use soroban_sdk::{contracttype, Address, Env, Vec};
+
+/// A single creator entry in the index with its weight.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct IndexComponent {
+    /// Creator address included in the index.
+    pub creator: Address,
+    /// Weight in basis points (sum of all components must equal 10_000).
+    pub weight_bps: u32,
+}
+
+/// Index fund configuration and aggregate state.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct IndexFund {
+    /// Unique fund identifier.
+    pub id: u64,
+    /// Human-readable name.
+    pub name: soroban_sdk::String,
+    /// Address of the manager who can rebalance.
+    pub manager: Address,
+    /// Token used for deposits/withdrawals.
+    pub token: Address,
+    /// Ordered list of creator components.
+    pub components: Vec<IndexComponent>,
+    /// Total fund shares outstanding.
+    pub total_shares: i128,
+    /// Total token value held by the fund (sum of all creator allocations).
+    pub total_value: i128,
+    /// Creation timestamp.
+    pub created_at: u64,
+    /// Last rebalance timestamp.
+    pub last_rebalanced: u64,
+    /// Whether the fund is active.
+    pub active: bool,
+}
+
+/// A user's share position in a fund.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct FundShare {
+    /// Fund this position belongs to.
+    pub fund_id: u64,
+    /// Holder address.
+    pub holder: Address,
+    /// Number of shares held.
+    pub shares: i128,
+    /// Cumulative amount deposited (for reference).
+    pub deposited: i128,
+}
+
+/// Storage keys for index funds.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum DataKey {
+    /// Fund record by ID.
+    Fund(u64),
+    /// Global fund counter.
+    FundCounter,
+    /// User share position keyed by (fund_id, holder).
+    FundShare(u64, Address),
+    /// Creator allocation within a fund keyed by (fund_id, creator).
+    CreatorAlloc(u64, Address),
+}
+
+/// Minimum deposit amount (1 token unit).
+pub const MIN_DEPOSIT: i128 = 1;
+/// Initial share price denominator (1 share = 1 token on first deposit).
+pub const INITIAL_SHARE_PRICE: i128 = 1_000_000; // 6 decimal precision
+
+// ── storage helpers ──────────────────────────────────────────────────────────
+
+/// Get a fund by ID.
+pub fn get_fund(env: &Env, fund_id: u64) -> Option<IndexFund> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::Fund(fund_id))
+}
+
+/// Persist a fund record.
+pub fn save_fund(env: &Env, fund: &IndexFund) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::Fund(fund.id), fund);
+}
+
+/// Get the next fund ID and increment the counter.
+pub fn next_fund_id(env: &Env) -> u64 {
+    let id: u64 = env
+        .storage()
+        .persistent()
+        .get(&DataKey::FundCounter)
+        .unwrap_or(0)
+        + 1;
+    env.storage()
+        .persistent()
+        .set(&DataKey::FundCounter, &id);
+    id
+}
+
+/// Get a user's share position.
+pub fn get_share(env: &Env, fund_id: u64, holder: &Address) -> FundShare {
+    env.storage()
+        .persistent()
+        .get(&DataKey::FundShare(fund_id, holder.clone()))
+        .unwrap_or(FundShare {
+            fund_id,
+            holder: holder.clone(),
+            shares: 0,
+            deposited: 0,
+        })
+}
+
+/// Persist a user's share position.
+pub fn save_share(env: &Env, share: &FundShare) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::FundShare(share.fund_id, share.holder.clone()), share);
+}
+
+/// Get creator allocation within a fund (token amount allocated to that creator).
+pub fn get_creator_alloc(env: &Env, fund_id: u64, creator: &Address) -> i128 {
+    env.storage()
+        .persistent()
+        .get(&DataKey::CreatorAlloc(fund_id, creator.clone()))
+        .unwrap_or(0)
+}
+
+/// Set creator allocation within a fund.
+pub fn set_creator_alloc(env: &Env, fund_id: u64, creator: &Address, amount: i128) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::CreatorAlloc(fund_id, creator.clone()), &amount);
+}
+
+/// Calculate the current NAV per share (scaled by INITIAL_SHARE_PRICE).
+/// Returns 0 if no shares are outstanding.
+pub fn nav_per_share(fund: &IndexFund) -> i128 {
+    if fund.total_shares == 0 {
+        return INITIAL_SHARE_PRICE;
+    }
+    fund.total_value * INITIAL_SHARE_PRICE / fund.total_shares
+}

--- a/contracts/tipjar/src/index_fund/rebalance.rs
+++ b/contracts/tipjar/src/index_fund/rebalance.rs
@@ -1,0 +1,46 @@
+//! Rebalancing logic — redistribute fund value according to target weights.
+
+use soroban_sdk::Env;
+
+use super::{get_creator_alloc, save_fund, set_creator_alloc};
+
+/// Rebalance a fund: recalculate each creator's allocation based on current
+/// total_value and target weights. Does not move tokens — just updates the
+/// on-chain allocation records so deposits/withdrawals use the new targets.
+///
+/// Only the fund manager may call this.
+pub fn rebalance(env: &Env, fund_id: u64, caller: &soroban_sdk::Address) {
+    let mut fund = super::get_fund(env, fund_id).expect("Fund not found");
+
+    if fund.manager != *caller {
+        panic!("Only the fund manager can rebalance");
+    }
+    if !fund.active {
+        panic!("Fund is not active");
+    }
+
+    let total_value = fund.total_value;
+
+    // Recompute each creator's target allocation.
+    for component in fund.components.iter() {
+        let target = total_value * (component.weight_bps as i128) / 10_000;
+        set_creator_alloc(env, fund_id, &component.creator, target);
+    }
+
+    fund.last_rebalanced = env.ledger().timestamp();
+    save_fund(env, &fund);
+}
+
+/// Return the current allocation for each creator as a Vec of (creator, amount) pairs.
+pub fn get_allocations(
+    env: &Env,
+    fund_id: u64,
+) -> soroban_sdk::Vec<(soroban_sdk::Address, i128)> {
+    let fund = super::get_fund(env, fund_id).expect("Fund not found");
+    let mut result = soroban_sdk::Vec::new(env);
+    for component in fund.components.iter() {
+        let alloc = get_creator_alloc(env, fund_id, &component.creator);
+        result.push_back((component.creator.clone(), alloc));
+    }
+    result
+}

--- a/contracts/tipjar/src/index_fund/shares.rs
+++ b/contracts/tipjar/src/index_fund/shares.rs
@@ -1,0 +1,121 @@
+//! Fund share issuance and redemption — deposits and withdrawals.
+
+use soroban_sdk::{token, Address, Env};
+
+use super::{
+    get_share, nav_per_share, save_fund, save_share, set_creator_alloc, get_creator_alloc,
+    INITIAL_SHARE_PRICE, MIN_DEPOSIT,
+};
+
+/// Deposit `amount` tokens into the fund and mint shares to `depositor`.
+///
+/// Shares minted = amount * INITIAL_SHARE_PRICE / nav_per_share
+/// Creator allocations are updated proportionally.
+pub fn deposit(env: &Env, fund_id: u64, depositor: &Address, amount: i128) -> i128 {
+    depositor.require_auth();
+
+    if amount < MIN_DEPOSIT {
+        panic!("Deposit amount too small");
+    }
+
+    let mut fund = super::get_fund(env, fund_id).expect("Fund not found");
+    if !fund.active {
+        panic!("Fund is not active");
+    }
+
+    // Transfer tokens from depositor to this contract.
+    let token_client = token::Client::new(env, &fund.token);
+    token_client.transfer(depositor, &env.current_contract_address(), &amount);
+
+    // Calculate shares to mint.
+    let nav = nav_per_share(&fund);
+    let shares_minted = amount * INITIAL_SHARE_PRICE / nav;
+
+    // Update creator allocations based on deposit.
+    for component in fund.components.iter() {
+        let creator_amount = amount * (component.weight_bps as i128) / 10_000;
+        let current = get_creator_alloc(env, fund_id, &component.creator);
+        set_creator_alloc(env, fund_id, &component.creator, current + creator_amount);
+    }
+
+    // Update fund state.
+    fund.total_value += amount;
+    fund.total_shares += shares_minted;
+    save_fund(env, &fund);
+
+    // Update depositor's share position.
+    let mut share = get_share(env, fund_id, depositor);
+    share.shares += shares_minted;
+    share.deposited += amount;
+    save_share(env, &share);
+
+    shares_minted
+}
+
+/// Withdraw by redeeming `shares` from the fund.
+///
+/// Token amount returned = shares * nav_per_share / INITIAL_SHARE_PRICE
+/// Creator allocations are reduced proportionally.
+pub fn withdraw(env: &Env, fund_id: u64, holder: &Address, shares: i128) -> i128 {
+    holder.require_auth();
+
+    if shares <= 0 {
+        panic!("Shares must be positive");
+    }
+
+    let mut fund = super::get_fund(env, fund_id).expect("Fund not found");
+    if !fund.active {
+        panic!("Fund is not active");
+    }
+
+    let mut share_pos = get_share(env, fund_id, holder);
+    if share_pos.shares < shares {
+        panic!("Insufficient shares");
+    }
+
+    // Calculate token amount to return.
+    let nav = nav_per_share(&fund);
+    let amount_out = shares * nav / INITIAL_SHARE_PRICE;
+
+    if amount_out > fund.total_value {
+        panic!("Insufficient fund reserves");
+    }
+
+    // Reduce creator allocations proportionally.
+    for component in fund.components.iter() {
+        let creator_reduction = amount_out * (component.weight_bps as i128) / 10_000;
+        let current = get_creator_alloc(env, fund_id, &component.creator);
+        let new_alloc = if current > creator_reduction {
+            current - creator_reduction
+        } else {
+            0
+        };
+        set_creator_alloc(env, fund_id, &component.creator, new_alloc);
+    }
+
+    // Update fund state.
+    fund.total_value -= amount_out;
+    fund.total_shares -= shares;
+    save_fund(env, &fund);
+
+    // Update holder's share position.
+    share_pos.shares -= shares;
+    save_share(env, &share_pos);
+
+    // Transfer tokens back to holder.
+    let token_client = token::Client::new(env, &fund.token);
+    token_client.transfer(&env.current_contract_address(), holder, &amount_out);
+
+    amount_out
+}
+
+/// Return the current NAV per share for a fund.
+pub fn get_nav(env: &Env, fund_id: u64) -> i128 {
+    let fund = super::get_fund(env, fund_id).expect("Fund not found");
+    nav_per_share(&fund)
+}
+
+/// Return the share balance for a holder.
+pub fn get_shares(env: &Env, fund_id: u64, holder: &Address) -> i128 {
+    get_share(env, fund_id, holder).shares
+}

--- a/contracts/tipjar/src/lib.rs
+++ b/contracts/tipjar/src/lib.rs
@@ -46,6 +46,9 @@ pub mod privacy_tip;
 // Options trading
 pub mod options;
 
+// Tip Index Funds
+pub mod index_fund;
+
 /// A tip record that includes an optional memo and timestamp.
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -672,6 +675,14 @@ pub enum DataKey {
     BridgeEnabled,
     /// Bridge fee in basis points.
     BridgeFeeBps,
+    /// Index fund record by ID.
+    IndexFund(u64),
+    /// Global index fund counter.
+    IndexFundCounter,
+    /// User share position in a fund keyed by (fund_id, holder).
+    IndexFundShare(u64, Address),
+    /// Creator allocation within a fund keyed by (fund_id, creator).
+    IndexCreatorAlloc(u64, Address),
 }
 
 #[contracterror]
@@ -850,6 +861,18 @@ pub enum TipJarError {
     OptionNotExpired = 96,
     /// Invalid bridge fee.
     InvalidBridgeFee = 97,
+    /// Index fund not found.
+    IndexFundNotFound = 98,
+    /// Index fund is not active.
+    IndexFundNotActive = 99,
+    /// Component weights do not sum to 10000 bps.
+    InvalidIndexWeights = 100,
+    /// Index fund requires at least 2 creators.
+    IndexFundTooFewCreators = 101,
+    /// Insufficient fund shares for withdrawal.
+    InsufficientFundShares = 102,
+    /// Deposit amount is below the minimum.
+    IndexDepositTooSmall = 103,
 }
 
 #[contract]
@@ -5612,5 +5635,142 @@ impl TipJarContract {
         );
 
         expired_count
+    }
+
+    // ── index funds ──────────────────────────────────────────────────────────
+
+    /// Create a new tip index fund with a basket of creators.
+    /// `components` must have at least 2 entries and weights must sum to 10_000 bps.
+    pub fn create_index_fund(
+        env: Env,
+        manager: Address,
+        token: Address,
+        name: String,
+        components: Vec<index_fund::IndexComponent>,
+    ) -> u64 {
+        manager.require_auth();
+        Self::require_not_paused(&env);
+
+        if components.len() < 2 {
+            panic_with_error!(&env, TipJarError::IndexFundTooFewCreators);
+        }
+        if !index_fund::composition::validate_weights(&components) {
+            panic_with_error!(&env, TipJarError::InvalidIndexWeights);
+        }
+
+        let fund_id = index_fund::composition::create_index_fund(
+            &env, &manager, &token, name, components,
+        );
+
+        env.events().publish(
+            (symbol_short!("idx_new"),),
+            (manager, fund_id),
+        );
+
+        fund_id
+    }
+
+    /// Update the composition of an existing index fund (manager only).
+    pub fn update_index_composition(
+        env: Env,
+        caller: Address,
+        fund_id: u64,
+        new_components: Vec<index_fund::IndexComponent>,
+    ) {
+        caller.require_auth();
+        Self::require_not_paused(&env);
+
+        if new_components.len() < 2 {
+            panic_with_error!(&env, TipJarError::IndexFundTooFewCreators);
+        }
+        if !index_fund::composition::validate_weights(&new_components) {
+            panic_with_error!(&env, TipJarError::InvalidIndexWeights);
+        }
+
+        index_fund::composition::update_composition(&env, fund_id, &caller, new_components);
+
+        env.events().publish(
+            (symbol_short!("idx_upd"),),
+            (caller, fund_id),
+        );
+    }
+
+    /// Rebalance a fund's creator allocations to match current target weights.
+    pub fn rebalance_index_fund(env: Env, caller: Address, fund_id: u64) {
+        caller.require_auth();
+        Self::require_not_paused(&env);
+
+        index_fund::rebalance::rebalance(&env, fund_id, &caller);
+
+        env.events().publish(
+            (symbol_short!("idx_reb"),),
+            (caller, fund_id),
+        );
+    }
+
+    /// Deposit tokens into an index fund and receive shares.
+    /// Returns the number of shares minted.
+    pub fn deposit_index_fund(
+        env: Env,
+        depositor: Address,
+        fund_id: u64,
+        amount: i128,
+    ) -> i128 {
+        Self::require_not_paused(&env);
+
+        if amount < index_fund::MIN_DEPOSIT {
+            panic_with_error!(&env, TipJarError::IndexDepositTooSmall);
+        }
+
+        let shares = index_fund::shares::deposit(&env, fund_id, &depositor, amount);
+
+        env.events().publish(
+            (symbol_short!("idx_dep"),),
+            (depositor, fund_id, amount, shares),
+        );
+
+        shares
+    }
+
+    /// Withdraw from an index fund by redeeming shares.
+    /// Returns the token amount returned to the holder.
+    pub fn withdraw_index_fund(
+        env: Env,
+        holder: Address,
+        fund_id: u64,
+        shares: i128,
+    ) -> i128 {
+        Self::require_not_paused(&env);
+
+        if shares <= 0 {
+            panic_with_error!(&env, TipJarError::InvalidAmount);
+        }
+
+        let amount_out = index_fund::shares::withdraw(&env, fund_id, &holder, shares);
+
+        env.events().publish(
+            (symbol_short!("idx_wdr"),),
+            (holder, fund_id, shares, amount_out),
+        );
+
+        amount_out
+    }
+
+    /// Get the current NAV (net asset value) per share for a fund.
+    pub fn get_index_fund_nav(env: Env, fund_id: u64) -> i128 {
+        index_fund::shares::get_nav(&env, fund_id)
+    }
+
+    /// Get the share balance of a holder in a fund.
+    pub fn get_index_fund_shares(env: Env, fund_id: u64, holder: Address) -> i128 {
+        index_fund::shares::get_shares(&env, fund_id, &holder)
+    }
+
+    /// Get the current creator allocations for a fund.
+    pub fn get_index_fund_allocations(
+        env: Env,
+        fund_id: u64,
+    ) -> Vec<(Address, i128)> {
+        index_fund::rebalance::get_allocations(&env, fund_id)
     }
 }


### PR DESCRIPTION
Closes #206

- Add index_fund module with composition, rebalance, and shares submodules
- IndexFund struct tracks creator basket with weighted components (bps)
- IndexComponent defines per-creator weight in the fund
- FundShare tracks user positions (shares held, deposited amount)
- composition: create/update fund with weight validation (must sum to 10_000)
- rebalance: redistribute allocations to match target weights (manager only)
- shares: deposit mints shares at current NAV; withdraw redeems shares for tokens
- NAV per share calculated with 6-decimal precision (INITIAL_SHARE_PRICE = 1_000_000)
- New DataKey variants: IndexFund, IndexFundCounter, IndexFundShare, IndexCreatorAlloc
- New TipJarError codes 98-103 for index fund error cases
- Contract methods: create_index_fund, update_index_composition, rebalance_index_fund, deposit_index_fund, withdraw_index_fund, get_index_fund_nav, get_index_fund_shares, get_index_fund_allocations
- Events emitted: idx_new, idx_upd, idx_reb, idx_dep, idx_wdr