### PR TITLE
ci: add continuous integration for contract testing

### DIFF
--- a/.github/workflows/contract-ci.yml
+++ b/.github/workflows/contract-ci.yml
@@ -1,0 +1,61 @@
+name: Contract CI
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main, develop]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32v1-none
+          components: rustfmt, clippy
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+
+      - name: Check formatting
+        run: cargo fmt -- --check
+
+      - name: Run clippy
+        run: cargo clippy --all-targets -- -D warnings
+
+      - name: Run tests
+        run: cargo test -p tipjar
+
+      - name: Build WASM
+        run: cargo build -p tipjar --target wasm32v1-none --release
+
+      - name: Generate coverage
+        run: |
+          cargo install cargo-tarpaulin --locked
+          cargo tarpaulin -p tipjar --out Xml --output-dir coverage/ --timeout 120
+
+      - name: Upload coverage
+        uses: codecov/codecov-action@v4
+        with:
+          files: coverage/cobertura.xml
+          fail_ci_if_error: false
+
+  security:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+
+      - name: Security audit
+        run: |
+          cargo install cargo-audit --locked
+          cargo audit

--- a/.github/workflows/deploy-testnet.yml
+++ b/.github/workflows/deploy-testnet.yml
@@ -1,0 +1,47 @@
+name: Deploy to Testnet
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  deploy-testnet:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32v1-none
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+
+      - name: Run tests before deploy
+        run: cargo test -p tipjar
+
+      - name: Build WASM
+        run: cargo build -p tipjar --target wasm32v1-none --release
+
+      - name: Install Stellar CLI
+        run: cargo install --locked stellar-cli
+
+      - name: Deploy to testnet
+        env:
+          DEPLOYER_SECRET: ${{ secrets.DEPLOYER_SECRET }}
+        run: bash scripts/deploy_testnet.sh
+
+      - name: Upload WASM artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: tipjar-wasm-${{ github.sha }}
+          path: target/wasm32v1-none/release/tipjar.wasm
+
+      - name: Report deployment result
+        if: always()
+        run: |
+          echo "Deployment status: ${{ job.status }}"
+          echo "Commit: ${{ github.sha }}"
+          echo "Branch: ${{ github.ref_name }}"


### PR DESCRIPTION
- Add contract-ci.yml: runs on push/PR to main and develop
  - rustfmt check
  - clippy with -D warnings
  - cargo test -p tipjar
  - WASM build (wasm32v1-none)
  - cargo-tarpaulin coverage with Codecov upload
  - cargo-audit security scanning
- Add deploy-testnet.yml: deploys on push to main
  - Runs tests before deploying
  - Builds WASM artifact
  - Deploys via scripts/deploy_testnet.sh
  - Uploads WASM artifact for traceability
  - Reports deployment result

Closes #131 