### PR TITLE
feat: implement tip royalty system

### DIFF
--- a/contracts/tipjar/src/lib.rs
+++ b/contracts/tipjar/src/lib.rs
@@ -46,6 +46,9 @@ pub mod privacy_tip;
 // Options trading
 pub mod options;
 
+// Royalty system for derivative content
+pub mod royalty;
+
 /// A tip record that includes an optional memo and timestamp.
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -672,6 +675,14 @@ pub enum DataKey {
     BridgeEnabled,
     /// Bridge fee in basis points.
     BridgeFeeBps,
+    /// Royalty configuration for a creator's content.
+    RoyaltyConfig(Address),
+    /// Content lineage for a creator (parent link).
+    ContentLineage(Address),
+    /// Accumulated royalties for a creator per token.
+    RoyaltyBalance(Address, Address),
+    /// Subscription tier configuration keyed by tier.
+    TierConfig(SubscriptionTier),
 }
 
 #[contracterror]
@@ -850,6 +861,24 @@ pub enum TipJarError {
     OptionNotExpired = 96,
     /// Invalid bridge fee.
     InvalidBridgeFee = 97,
+    /// Royalty rate exceeds maximum allowed (3000 bps).
+    RoyaltyRateTooHigh = 98,
+    /// No royalties available to withdraw.
+    NoRoyaltiesToWithdraw = 99,
+    /// Royalty config not found for creator.
+    RoyaltyConfigNotFound = 100,
+    /// Vesting duration must be greater than zero.
+    InvalidVestingDuration = 101,
+    /// Cliff duration exceeds vesting duration.
+    CliffExceedsVesting = 102,
+    /// Vesting schedule ID is invalid (zero).
+    InvalidVestingId = 103,
+    /// Vesting schedule not found.
+    VestingScheduleNotFound = 104,
+    /// No vested amount available to withdraw.
+    NoVestedAmount = 105,
+    /// Subscription tier is not configured.
+    TierNotConfigured = 106,
 }
 
 #[contract]
@@ -5612,5 +5641,138 @@ impl TipJarContract {
         );
 
         expired_count
+    }
+
+    // ── royalty system ───────────────────────────────────────────────────────
+
+    /// Registers a royalty configuration for derivative content.
+    ///
+    /// `creator` is the derivative content creator; `original_creator` receives
+    /// `rate_bps` basis points of every tip sent to `creator`.
+    /// `max_depth` caps multi-level traversal (1–5; 0 defaults to 5).
+    ///
+    /// Emits `("roy_reg",)` with data `(creator, original_creator, rate_bps)`.
+    pub fn register_royalty(
+        env: Env,
+        creator: Address,
+        original_creator: Address,
+        rate_bps: u32,
+        max_depth: u32,
+    ) {
+        Self::require_not_paused(&env);
+        creator.require_auth();
+        if rate_bps == 0 || rate_bps > royalty::MAX_ROYALTY_BPS {
+            panic_with_error!(&env, TipJarError::RoyaltyRateTooHigh);
+        }
+        royalty::register_royalty(&env, &creator, &original_creator, rate_bps, max_depth);
+        env.events().publish(
+            (symbol_short!("roy_reg"),),
+            (creator, original_creator, rate_bps),
+        );
+    }
+
+    /// Sends a tip to `creator` and automatically distributes royalties up the
+    /// content lineage chain before crediting the creator's balance.
+    ///
+    /// Emits `("tip", creator)` with data `(sender, net_amount)` and
+    /// `("royalty",)` for each royalty payment.
+    pub fn tip_with_royalty(
+        env: Env,
+        sender: Address,
+        creator: Address,
+        token: Address,
+        amount: i128,
+    ) -> u64 {
+        Self::require_not_paused(&env);
+        sender.require_auth();
+        if amount <= 0 {
+            panic_with_error!(&env, TipJarError::InvalidAmount);
+        }
+        let whitelisted: bool = env
+            .storage()
+            .instance()
+            .get(&DataKey::TokenWhitelist(token.clone()))
+            .unwrap_or(false);
+        if !whitelisted {
+            panic_with_error!(&env, TipJarError::TokenNotWhitelisted);
+        }
+
+        let fee_bp: u32 = env.storage().instance().get(&DataKey::FeeBasisPoints).unwrap_or(0);
+        let fee: i128 = (amount * fee_bp as i128) / 10_000;
+        let after_fee = amount - fee;
+
+        // Distribute royalties; returns net amount for creator.
+        let net = royalty::distribute_royalties(&env, &creator, &token, after_fee);
+
+        if fee > 0 {
+            let fee_key = DataKey::PlatformFeeBalance(token.clone());
+            let current_fee: i128 = env.storage().instance().get(&fee_key).unwrap_or(0);
+            env.storage().instance().set(&fee_key, &(current_fee + fee));
+        }
+
+        let bal_key = DataKey::CreatorBalance(creator.clone(), token.clone());
+        let existing_bal: i128 = env.storage().persistent().get(&bal_key).unwrap_or(0);
+        env.storage().persistent().set(&bal_key, &(existing_bal + net));
+
+        let tot_key = DataKey::CreatorTotal(creator.clone(), token.clone());
+        let existing_tot: i128 = env.storage().persistent().get(&tot_key).unwrap_or(0);
+        env.storage().persistent().set(&tot_key, &(existing_tot + net));
+
+        let tip_id: u64 = env.storage().instance().get(&DataKey::TipCounter).unwrap_or(0);
+        env.storage().instance().set(&DataKey::TipCounter, &(tip_id + 1));
+
+        Self::update_leaderboard_stats(&env, &sender, &creator, net);
+        Self::track_creator_token(&env, &creator, &token);
+
+        token::Client::new(&env, &token).transfer(&sender, &env.current_contract_address(), &amount);
+
+        env.events().publish((symbol_short!("tip"), creator.clone()), (sender, net));
+        tip_id
+    }
+
+    /// Withdraws accumulated royalties for `creator` in `token`.
+    ///
+    /// Emits `("roy_wdr",)` with data `(creator, token, amount)`.
+    pub fn withdraw_royalties(env: Env, creator: Address, token: Address) -> i128 {
+        Self::require_not_paused(&env);
+        creator.require_auth();
+        let bal_key = DataKey::RoyaltyBalance(creator.clone(), token.clone());
+        let amount: i128 = env.storage().persistent().get(&bal_key).unwrap_or(0);
+        if amount == 0 {
+            panic_with_error!(&env, TipJarError::NoRoyaltiesToWithdraw);
+        }
+        env.storage().persistent().set(&bal_key, &0i128);
+        token::Client::new(&env, &token).transfer(
+            &env.current_contract_address(),
+            &creator,
+            &amount,
+        );
+        env.events().publish(
+            (symbol_short!("roy_wdr"),),
+            (creator, token, amount),
+        );
+        amount
+    }
+
+    /// Returns the accumulated royalty balance for `creator` in `token`.
+    pub fn get_royalty_balance(env: Env, creator: Address, token: Address) -> i128 {
+        env.storage()
+            .persistent()
+            .get(&DataKey::RoyaltyBalance(creator, token))
+            .unwrap_or(0)
+    }
+
+    /// Returns the royalty configuration for `creator`, if registered.
+    pub fn get_royalty_config(env: Env, creator: Address) -> Option<royalty::RoyaltyConfig> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::RoyaltyConfig(creator))
+    }
+
+    /// Returns the content lineage for `creator`, if registered.
+    pub fn get_content_lineage(env: Env, creator: Address) -> Option<royalty::ContentLineage> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::ContentLineage(creator))
     }
 }

--- a/contracts/tipjar/src/royalty/mod.rs
+++ b/contracts/tipjar/src/royalty/mod.rs
@@ -1,0 +1,114 @@
+//! Royalty system for derivative content tips.
+//!
+//! Tracks content lineage and automatically distributes a percentage of tips
+//! to original creators when derivative content receives tips.
+
+use soroban_sdk::{contracttype, symbol_short, Address, Env};
+
+use crate::DataKey;
+
+/// Royalty configuration for a piece of content.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RoyaltyConfig {
+    /// The original creator who receives royalties.
+    pub original_creator: Address,
+    /// Royalty rate in basis points (e.g. 500 = 5%).
+    pub rate_bps: u32,
+    /// Maximum depth of lineage to traverse (capped at MAX_DEPTH).
+    pub max_depth: u32,
+}
+
+/// A content lineage record linking derivative to original.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ContentLineage {
+    /// The derivative content creator.
+    pub creator: Address,
+    /// The parent content creator (one level up).
+    pub parent_creator: Address,
+    /// Royalty config for this lineage link.
+    pub royalty_config: RoyaltyConfig,
+}
+
+/// Maximum lineage depth to prevent unbounded loops.
+pub const MAX_DEPTH: u32 = 5;
+/// Maximum royalty rate: 30%.
+pub const MAX_ROYALTY_BPS: u32 = 3_000;
+
+/// Register a royalty configuration for a creator's content.
+pub fn register_royalty(env: &Env, creator: &Address, original_creator: &Address, rate_bps: u32, max_depth: u32) {
+    let depth = if max_depth == 0 { MAX_DEPTH } else { max_depth.min(MAX_DEPTH) };
+    let config = RoyaltyConfig {
+        original_creator: original_creator.clone(),
+        rate_bps,
+        max_depth: depth,
+    };
+    env.storage().persistent().set(&DataKey::RoyaltyConfig(creator.clone()), &config);
+
+    let lineage = ContentLineage {
+        creator: creator.clone(),
+        parent_creator: original_creator.clone(),
+        royalty_config: config,
+    };
+    env.storage().persistent().set(&DataKey::ContentLineage(creator.clone()), &lineage);
+}
+
+/// Calculate and distribute royalties for a tip to `creator`.
+///
+/// Traverses the lineage chain up to `max_depth` levels, crediting royalties
+/// to each ancestor's `RoyaltyBalance`. Returns the net amount after royalties.
+pub fn distribute_royalties(
+    env: &Env,
+    creator: &Address,
+    token_addr: &Address,
+    tip_amount: i128,
+) -> i128 {
+    let mut remaining = tip_amount;
+    let mut current = creator.clone();
+    let mut depth = 0u32;
+
+    loop {
+        let lineage: Option<ContentLineage> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::ContentLineage(current.clone()));
+
+        let lineage = match lineage {
+            Some(l) => l,
+            None => break,
+        };
+
+        if depth >= lineage.royalty_config.max_depth {
+            break;
+        }
+
+        let royalty = (remaining * lineage.royalty_config.rate_bps as i128) / 10_000;
+        if royalty <= 0 {
+            break;
+        }
+
+        let bal_key = DataKey::RoyaltyBalance(
+            lineage.royalty_config.original_creator.clone(),
+            token_addr.clone(),
+        );
+        let current_bal: i128 = env.storage().persistent().get(&bal_key).unwrap_or(0);
+        env.storage().persistent().set(&bal_key, &(current_bal + royalty));
+
+        env.events().publish(
+            (symbol_short!("royalty"),),
+            (
+                lineage.royalty_config.original_creator.clone(),
+                creator.clone(),
+                royalty,
+                depth,
+            ),
+        );
+
+        remaining -= royalty;
+        current = lineage.royalty_config.original_creator.clone();
+        depth += 1;
+    }
+
+    remaining
+}


### PR DESCRIPTION
- Add royalty/ module with RoyaltyConfig and ContentLineage types
- Track content lineage up to 5 levels deep
- Distribute royalties automatically on tip_with_royalty
- Support multi-level royalty splits (up to MAX_DEPTH=5)
- Add register_royalty, tip_with_royalty, withdraw_royalties contract fns
- Add RoyaltyConfig, ContentLineage, RoyaltyBalance DataKey variants
- Add TierConfig DataKey variant and missing vesting/tier error variants

Closes #178 