### PR TITLE
feat: implement tip escrow with conditions

### DIFF
--- a/contracts/tipjar/src/escrow/mod.rs
+++ b/contracts/tipjar/src/escrow/mod.rs
@@ -1,0 +1,246 @@
+//! Conditional escrow system for tips.
+//!
+//! Tips are held in escrow and released only when all attached conditions
+//! are fulfilled. Supports oracle integration and dispute resolution.
+
+use soroban_sdk::{contracttype, symbol_short, token, Address, Env, String, Vec};
+
+use crate::{conditions::types::Condition, DataKey};
+
+/// Status of a conditional escrow.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum EscrowStatus {
+    /// Funds are held, conditions not yet evaluated.
+    Pending,
+    /// All conditions passed; funds released to creator.
+    Released,
+    /// Conditions failed or dispute resolved against creator; funds refunded.
+    Refunded,
+    /// Under dispute review.
+    Disputed,
+}
+
+/// A conditional escrow record.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ConditionalEscrow {
+    pub id: u64,
+    pub sender: Address,
+    pub creator: Address,
+    pub token: Address,
+    pub amount: i128,
+    pub conditions: Vec<Condition>,
+    pub status: EscrowStatus,
+    pub created_at: u64,
+    /// Optional deadline after which the sender can reclaim funds.
+    pub deadline: Option<u64>,
+    pub description: String,
+}
+
+/// Create a new conditional escrow.
+///
+/// Transfers `amount` from `sender` into contract escrow.
+/// Returns the escrow ID.
+pub fn create_escrow(
+    env: &Env,
+    sender: &Address,
+    creator: &Address,
+    token_addr: &Address,
+    amount: i128,
+    conditions: Vec<Condition>,
+    deadline: Option<u64>,
+    description: String,
+) -> u64 {
+    let id: u64 = env
+        .storage()
+        .instance()
+        .get(&DataKey::EscrowCounter)
+        .unwrap_or(0);
+    env.storage().instance().set(&DataKey::EscrowCounter, &(id + 1));
+
+    let escrow = ConditionalEscrow {
+        id,
+        sender: sender.clone(),
+        creator: creator.clone(),
+        token: token_addr.clone(),
+        amount,
+        conditions,
+        status: EscrowStatus::Pending,
+        created_at: env.ledger().timestamp(),
+        deadline,
+        description,
+    };
+
+    env.storage().persistent().set(&DataKey::Escrow(id), &escrow);
+
+    // Track escrow IDs per creator and sender.
+    let mut creator_escrows: Vec<u64> = env
+        .storage()
+        .persistent()
+        .get(&DataKey::CreatorEscrows(creator.clone()))
+        .unwrap_or_else(|| Vec::new(env));
+    creator_escrows.push_back(id);
+    env.storage()
+        .persistent()
+        .set(&DataKey::CreatorEscrows(creator.clone()), &creator_escrows);
+
+    token::Client::new(env, token_addr).transfer(
+        sender,
+        &env.current_contract_address(),
+        &amount,
+    );
+
+    env.events().publish(
+        (symbol_short!("esc_crt"),),
+        (id, sender.clone(), creator.clone(), amount),
+    );
+
+    id
+}
+
+/// Attempt to release escrow funds to the creator.
+///
+/// Evaluates all conditions; releases if all pass, otherwise panics.
+pub fn release_escrow(env: &Env, caller: &Address, escrow_id: u64) {
+    let mut escrow: ConditionalEscrow = env
+        .storage()
+        .persistent()
+        .get(&DataKey::Escrow(escrow_id))
+        .expect("Escrow not found");
+
+    assert!(escrow.status == EscrowStatus::Pending, "Escrow not pending");
+    // Only creator or sender may trigger release.
+    assert!(
+        caller == &escrow.creator || caller == &escrow.sender,
+        "Unauthorized"
+    );
+
+    let all_pass = crate::conditions::evaluator::evaluate_all(env, &escrow.conditions);
+    assert!(all_pass, "Conditions not met");
+
+    escrow.status = EscrowStatus::Released;
+    env.storage().persistent().set(&DataKey::Escrow(escrow_id), &escrow);
+
+    token::Client::new(env, &escrow.token).transfer(
+        &env.current_contract_address(),
+        &escrow.creator,
+        &escrow.amount,
+    );
+
+    env.events().publish(
+        (symbol_short!("esc_rel"),),
+        (escrow_id, escrow.creator.clone(), escrow.amount),
+    );
+}
+
+/// Refund escrow to sender.
+///
+/// Allowed when: deadline has passed, or conditions explicitly fail and
+/// caller is the sender.
+pub fn refund_escrow(env: &Env, caller: &Address, escrow_id: u64) {
+    let mut escrow: ConditionalEscrow = env
+        .storage()
+        .persistent()
+        .get(&DataKey::Escrow(escrow_id))
+        .expect("Escrow not found");
+
+    assert!(
+        escrow.status == EscrowStatus::Pending || escrow.status == EscrowStatus::Disputed,
+        "Escrow not refundable"
+    );
+    assert!(caller == &escrow.sender, "Only sender can refund");
+
+    // Allow refund if deadline passed or conditions explicitly fail.
+    let now = env.ledger().timestamp();
+    let deadline_passed = escrow.deadline.map(|d| now >= d).unwrap_or(false);
+    let conditions_fail = !crate::conditions::evaluator::evaluate_all(env, &escrow.conditions);
+
+    assert!(deadline_passed || conditions_fail, "Cannot refund yet");
+
+    escrow.status = EscrowStatus::Refunded;
+    env.storage().persistent().set(&DataKey::Escrow(escrow_id), &escrow);
+
+    token::Client::new(env, &escrow.token).transfer(
+        &env.current_contract_address(),
+        &escrow.sender,
+        &escrow.amount,
+    );
+
+    env.events().publish(
+        (symbol_short!("esc_ref"),),
+        (escrow_id, escrow.sender.clone(), escrow.amount),
+    );
+}
+
+/// Mark an escrow as disputed. Only sender or creator may dispute.
+pub fn dispute_escrow(env: &Env, caller: &Address, escrow_id: u64) {
+    let mut escrow: ConditionalEscrow = env
+        .storage()
+        .persistent()
+        .get(&DataKey::Escrow(escrow_id))
+        .expect("Escrow not found");
+
+    assert!(escrow.status == EscrowStatus::Pending, "Escrow not pending");
+    assert!(
+        caller == &escrow.creator || caller == &escrow.sender,
+        "Unauthorized"
+    );
+
+    escrow.status = EscrowStatus::Disputed;
+    env.storage().persistent().set(&DataKey::Escrow(escrow_id), &escrow);
+
+    env.events().publish(
+        (symbol_short!("esc_dis"),),
+        (escrow_id, caller.clone()),
+    );
+}
+
+/// Resolve a disputed escrow. Admin only — releases to creator or refunds sender.
+pub fn resolve_escrow_dispute(
+    env: &Env,
+    escrow_id: u64,
+    release_to_creator: bool,
+) {
+    let mut escrow: ConditionalEscrow = env
+        .storage()
+        .persistent()
+        .get(&DataKey::Escrow(escrow_id))
+        .expect("Escrow not found");
+
+    assert!(escrow.status == EscrowStatus::Disputed, "Escrow not disputed");
+
+    let recipient = if release_to_creator {
+        escrow.status = EscrowStatus::Released;
+        escrow.creator.clone()
+    } else {
+        escrow.status = EscrowStatus::Refunded;
+        escrow.sender.clone()
+    };
+
+    env.storage().persistent().set(&DataKey::Escrow(escrow_id), &escrow);
+
+    token::Client::new(env, &escrow.token).transfer(
+        &env.current_contract_address(),
+        &recipient,
+        &escrow.amount,
+    );
+
+    env.events().publish(
+        (symbol_short!("esc_rsl"),),
+        (escrow_id, recipient, release_to_creator),
+    );
+}
+
+/// Get an escrow record by ID.
+pub fn get_escrow(env: &Env, escrow_id: u64) -> Option<ConditionalEscrow> {
+    env.storage().persistent().get(&DataKey::Escrow(escrow_id))
+}
+
+/// Get all escrow IDs for a creator.
+pub fn get_creator_escrows(env: &Env, creator: &Address) -> Vec<u64> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::CreatorEscrows(creator.clone()))
+        .unwrap_or_else(|| Vec::new(env))
+}

--- a/contracts/tipjar/src/lib.rs
+++ b/contracts/tipjar/src/lib.rs
@@ -46,6 +46,9 @@ pub mod privacy_tip;
 // Options trading
 pub mod options;
 
+// Conditional escrow system
+pub mod escrow;
+
 /// A tip record that includes an optional memo and timestamp.
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -672,6 +675,14 @@ pub enum DataKey {
     BridgeEnabled,
     /// Bridge fee in basis points.
     BridgeFeeBps,
+    /// Subscription tier configuration keyed by tier.
+    TierConfig(SubscriptionTier),
+    /// Conditional escrow record keyed by escrow ID.
+    Escrow(u64),
+    /// Global counter for escrow IDs.
+    EscrowCounter,
+    /// List of escrow IDs for a creator.
+    CreatorEscrows(Address),
 }
 
 #[contracterror]
@@ -850,6 +861,28 @@ pub enum TipJarError {
     OptionNotExpired = 96,
     /// Invalid bridge fee.
     InvalidBridgeFee = 97,
+    /// Vesting duration must be greater than zero.
+    InvalidVestingDuration = 101,
+    /// Cliff duration exceeds vesting duration.
+    CliffExceedsVesting = 102,
+    /// Vesting schedule ID is invalid (zero).
+    InvalidVestingId = 103,
+    /// Vesting schedule not found.
+    VestingScheduleNotFound = 104,
+    /// No vested amount available to withdraw.
+    NoVestedAmount = 105,
+    /// Subscription tier is not configured.
+    TierNotConfigured = 106,
+    /// Conditional escrow not found.
+    EscrowNotFound = 107,
+    /// Escrow is not in a pending state.
+    EscrowNotPending = 108,
+    /// Escrow conditions have not been met.
+    EscrowConditionsNotMet = 109,
+    /// Escrow deadline has not passed and conditions are not failing.
+    EscrowCannotRefund = 110,
+    /// Escrow is not in a disputed state.
+    EscrowNotDisputed = 111,
 }
 
 #[contract]
@@ -5612,5 +5645,142 @@ impl TipJarContract {
         );
 
         expired_count
+    }
+
+    // ── conditional escrow ───────────────────────────────────────────────────
+
+    /// Creates a conditional escrow: `sender` deposits `amount` of `token` for
+    /// `creator`, to be released only when all `conditions` evaluate to true.
+    ///
+    /// `deadline` is an optional Unix timestamp after which the sender may
+    /// reclaim funds if conditions have not been met.
+    ///
+    /// Returns the escrow ID.
+    /// Emits `("esc_crt",)` with data `(id, sender, creator, amount)`.
+    pub fn create_escrow(
+        env: Env,
+        sender: Address,
+        creator: Address,
+        token: Address,
+        amount: i128,
+        conditions: Vec<conditions::types::Condition>,
+        deadline: Option<u64>,
+        description: String,
+    ) -> u64 {
+        Self::require_not_paused(&env);
+        sender.require_auth();
+        if amount <= 0 {
+            panic_with_error!(&env, TipJarError::InvalidAmount);
+        }
+        let whitelisted: bool = env
+            .storage()
+            .instance()
+            .get(&DataKey::TokenWhitelist(token.clone()))
+            .unwrap_or(false);
+        if !whitelisted {
+            panic_with_error!(&env, TipJarError::TokenNotWhitelisted);
+        }
+        escrow::create_escrow(&env, &sender, &creator, &token, amount, conditions, deadline, description)
+    }
+
+    /// Releases escrow funds to the creator if all conditions pass.
+    ///
+    /// Caller must be the creator or sender.
+    /// Emits `("esc_rel",)` with data `(escrow_id, creator, amount)`.
+    pub fn release_escrow(env: Env, caller: Address, escrow_id: u64) {
+        Self::require_not_paused(&env);
+        caller.require_auth();
+        let esc: escrow::ConditionalEscrow = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Escrow(escrow_id))
+            .unwrap_or_else(|| panic_with_error!(&env, TipJarError::EscrowNotFound));
+        if esc.status != escrow::EscrowStatus::Pending {
+            panic_with_error!(&env, TipJarError::EscrowNotPending);
+        }
+        if !conditions::evaluator::evaluate_all(&env, &esc.conditions) {
+            panic_with_error!(&env, TipJarError::EscrowConditionsNotMet);
+        }
+        escrow::release_escrow(&env, &caller, escrow_id);
+    }
+
+    /// Refunds escrow to sender when deadline has passed or conditions fail.
+    ///
+    /// Only the original sender may call this.
+    /// Emits `("esc_ref",)` with data `(escrow_id, sender, amount)`.
+    pub fn refund_escrow(env: Env, sender: Address, escrow_id: u64) {
+        Self::require_not_paused(&env);
+        sender.require_auth();
+        let esc: escrow::ConditionalEscrow = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Escrow(escrow_id))
+            .unwrap_or_else(|| panic_with_error!(&env, TipJarError::EscrowNotFound));
+        if esc.status != escrow::EscrowStatus::Pending && esc.status != escrow::EscrowStatus::Disputed {
+            panic_with_error!(&env, TipJarError::EscrowNotPending);
+        }
+        let now = env.ledger().timestamp();
+        let deadline_passed = esc.deadline.map(|d| now >= d).unwrap_or(false);
+        let conditions_fail = !conditions::evaluator::evaluate_all(&env, &esc.conditions);
+        if !deadline_passed && !conditions_fail {
+            panic_with_error!(&env, TipJarError::EscrowCannotRefund);
+        }
+        escrow::refund_escrow(&env, &sender, escrow_id);
+    }
+
+    /// Marks an escrow as disputed. Sender or creator may dispute.
+    ///
+    /// Emits `("esc_dis",)` with data `(escrow_id, caller)`.
+    pub fn dispute_escrow(env: Env, caller: Address, escrow_id: u64) {
+        Self::require_not_paused(&env);
+        caller.require_auth();
+        let esc: escrow::ConditionalEscrow = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Escrow(escrow_id))
+            .unwrap_or_else(|| panic_with_error!(&env, TipJarError::EscrowNotFound));
+        if esc.status != escrow::EscrowStatus::Pending {
+            panic_with_error!(&env, TipJarError::EscrowNotPending);
+        }
+        escrow::dispute_escrow(&env, &caller, escrow_id);
+    }
+
+    /// Resolves a disputed escrow. Admin only.
+    ///
+    /// `release_to_creator = true` releases funds to creator; `false` refunds sender.
+    /// Emits `("esc_rsl",)` with data `(escrow_id, recipient, release_to_creator)`.
+    pub fn resolve_escrow_dispute(
+        env: Env,
+        admin: Address,
+        escrow_id: u64,
+        release_to_creator: bool,
+    ) {
+        admin.require_auth();
+        let stored_admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+        if admin != stored_admin {
+            panic_with_error!(&env, TipJarError::Unauthorized);
+        }
+        let esc: escrow::ConditionalEscrow = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Escrow(escrow_id))
+            .unwrap_or_else(|| panic_with_error!(&env, TipJarError::EscrowNotFound));
+        if esc.status != escrow::EscrowStatus::Disputed {
+            panic_with_error!(&env, TipJarError::EscrowNotDisputed);
+        }
+        escrow::resolve_escrow_dispute(&env, escrow_id, release_to_creator);
+    }
+
+    /// Returns the escrow record for `escrow_id`, if it exists.
+    pub fn get_escrow(env: Env, escrow_id: u64) -> Option<escrow::ConditionalEscrow> {
+        env.storage().persistent().get(&DataKey::Escrow(escrow_id))
+    }
+
+    /// Returns all escrow IDs for `creator`.
+    pub fn get_creator_escrows(env: Env, creator: Address) -> Vec<u64> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::CreatorEscrows(creator))
+            .unwrap_or_else(|| Vec::new(&env))
     }
 }


### PR DESCRIPTION
- Add escrow/ module with ConditionalEscrow type and EscrowStatus enum
- Implement escrow creation with condition list and optional deadline
- Add condition verification via existing conditions::evaluator
- Support oracle integration through OffchainApproved conditions
- Handle condition fulfillment with release_escrow
- Add dispute resolution: dispute_escrow, resolve_escrow_dispute
- Add refund path when deadline passes or conditions fail
- Add DataKey variants: Escrow, EscrowCounter, CreatorEscrows
- Add error variants: EscrowNotFound, EscrowNotPending, EscrowConditionsNotMet, EscrowCannotRefund, EscrowNotDisputed
- Add TierConfig DataKey and missing vesting/tier error variants

Closes #179 