### PR TITLE
feat(contract): implement partial withdrawal functionality

### DIFF
--- a/contracts/tipjar/src/lib.rs
+++ b/contracts/tipjar/src/lib.rs
@@ -840,6 +840,8 @@ pub enum TipJarError {
     InvalidGoalAmount = 8,
     Unauthorized = 9,
     RoleNotFound = 10,
+    InsufficientBalance = 11,
+    AmountTooSmall = 12,
 }
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
@@ -1986,6 +1988,37 @@ impl TipJarContract {
         }
         Self::check_and_update_withdrawal_limits(&env, &creator, amount);
         env.storage().persistent().set(&bal_key, &0i128);
+        token::Client::new(&env, &token).transfer(&env.current_contract_address(), &creator, &amount);
+        events::emit_withdraw_event(&env, &creator, amount, &token);
+    }
+
+    /// Withdraws a specific amount from the escrowed balance for `creator` in `token`.
+    ///
+    /// Validates amount is at least the minimum (1 token = 1_0000000 stroops) and does not exceed available balance.
+    /// Enforces per-creator (or default) daily limits and cooldown periods.
+    /// Emits `("withdraw", creator)` with data `amount`.
+    pub fn withdraw_amount(env: Env, creator: Address, token: Address, amount: i128) {
+        Self::require_not_paused(&env);
+        creator.require_auth();
+
+        const MIN_WITHDRAWAL: i128 = 1_0000000;
+        if amount < MIN_WITHDRAWAL {
+            panic_with_error!(&env, TipJarError::AmountTooSmall);
+        }
+
+        let bal_key = DataKey::CreatorBalance(creator.clone(), token.clone());
+        let current_balance: i128 = env.storage().persistent().get(&bal_key)
+            .unwrap_or_else(|| env.storage().instance().get(&bal_key).unwrap_or(0));
+
+        if amount > current_balance {
+            panic_with_error!(&env, TipJarError::InsufficientBalance);
+        }
+
+        Self::check_and_update_withdrawal_limits(&env, &creator, amount);
+
+        let new_balance = current_balance - amount;
+        env.storage().persistent().set(&bal_key, &new_balance);
+
         token::Client::new(&env, &token).transfer(&env.current_contract_address(), &creator, &amount);
         events::emit_withdraw_event(&env, &creator, amount, &token);
     }


### PR DESCRIPTION
## Summary
Allows creators to withdraw a specific amount instead of requiring full balance withdrawal, providing more flexibility in fund management.
## Changes
- Added withdraw_amount function to TipJarContract with amount parameter
- Added new error codes InsufficientBalance (11) and AmountTooSmall (12) to TipJarError
## Implementation Details
- Minimum withdrawal: 1 token (1_0000000 stroops) to prevent dust amounts
- Balance validation: Ensures withdrawal amount doesn't exceed available balance
- Balance update: Updates storage with remaining balance after partial withdrawal
- Events: Emits withdraw event with withdrawn amount using existing event system
- Rate limiting: Applies existing withdrawal limits (daily limits and cooldown periods)
- Backward compatibility: Existing withdraw() function remains unchanged for full balance withdrawal
## Test Cases Covered
- Partial withdrawal with valid amount
- Balance updates correctly after withdrawal
- Withdrawal of exact balance
- Insufficient balance error handling
- Minimum amount validation (AmountTooSmall error)
- Multiple partial withdrawals

Closes #104