### PR TITLE
feat: implement tip payment channels

### DIFF
--- a/contracts/tipjar/Cargo.toml
+++ b/contracts/tipjar/Cargo.toml
@@ -82,3 +82,7 @@ path = "tests/quadratic_funding_tests.rs"
 name = "poly_commit_tests"
 path = "tests/poly_commit_tests.rs"
 
+[[test]]
+name = "payment_channel_tests"
+path = "tests/payment_channel_tests.rs"
+

--- a/contracts/tipjar/src/lib.rs
+++ b/contracts/tipjar/src/lib.rs
@@ -76,6 +76,9 @@ pub mod quadratic_funding;
 // TWAP oracle
 pub mod twap_oracle;
 
+// Tip payment channels
+pub mod payment_channel;
+
 /// A tip record that includes an optional memo and timestamp.
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -838,6 +841,10 @@ pub enum DataKey {
     EncryptedTipCounter,
     /// Nullifier for encrypted tips (prevents double-spend).
     PrivacyNullifier(BytesN<32>),
+    /// Payment channel record keyed by (party_a, party_b, token).
+    PaymentChannel(Address, Address, Address),
+    /// Global counter for payment channel IDs.
+    ChannelCounter,
 }
 
 #[contracterror]
@@ -1099,6 +1106,30 @@ pub enum OtherError {
     ActiveLoanExists = 110,
     InsufficientLendingLiquidity = 111,
     NoActiveCredit = 112,
+}
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum ChannelError {
+    /// No channel exists for the given parties and token.
+    ChannelNotFound = 200,
+    /// Channel is not in the Open state.
+    ChannelNotOpen = 201,
+    /// Provided nonce is not strictly greater than the current nonce.
+    StaleNonce = 202,
+    /// Caller is not a party to this channel.
+    NotChannelParty = 203,
+    /// Channel is not in the Disputed state.
+    ChannelNotDisputed = 204,
+    /// Dispute window has not yet elapsed.
+    DisputeWindowActive = 205,
+    /// Proposed balance exceeds total channel deposit.
+    InvalidChannelBalance = 206,
+    /// Deposit amount must be greater than zero.
+    InvalidDeposit = 207,
+    /// Dispute window must be greater than zero.
+    InvalidDisputeWindow = 208,
 }
 
 
@@ -8444,6 +8475,273 @@ a
     /// Get proposal threshold adjusted by voter's conviction.
     pub fn get_adjusted_proposal_threshold(env: Env, voter: Address) -> i128 {
         governance::conviction_integration::get_adjusted_proposal_threshold(&env, &voter)
+    }
+
+    // ── payment channels ─────────────────────────────────────────────────────
+
+    /// Opens a bidirectional payment channel between `party_a` and `party_b`.
+    ///
+    /// Both parties' deposits are transferred into contract escrow immediately.
+    /// `dispute_window` is the seconds a counterparty has to submit a newer state
+    /// during a unilateral close.
+    ///
+    /// Emits `("ch_open",)` with data `(party_a, party_b, token, total_deposit)`.
+    pub fn open_channel(
+        env: Env,
+        party_a: Address,
+        party_b: Address,
+        token: Address,
+        deposit_a: i128,
+        deposit_b: i128,
+        dispute_window: u64,
+    ) {
+        Self::require_not_paused(&env);
+        party_a.require_auth();
+        party_b.require_auth();
+
+        if deposit_a <= 0 || deposit_b <= 0 {
+            panic_with_error!(&env, ChannelError::InvalidDeposit);
+        }
+        if dispute_window == 0 {
+            panic_with_error!(&env, ChannelError::InvalidDisputeWindow);
+        }
+
+        let whitelisted: bool = env
+            .storage()
+            .instance()
+            .get(&DataKey::TokenWhitelist(token.clone()))
+            .unwrap_or(false);
+        if !whitelisted {
+            panic_with_error!(&env, TipJarError::TokenNotWhitelisted);
+        }
+
+        let key = DataKey::PaymentChannel(party_a.clone(), party_b.clone(), token.clone());
+        if env.storage().persistent().has(&key) {
+            panic_with_error!(&env, ChannelError::ChannelNotOpen);
+        }
+
+        let channel = payment_channel::open(
+            &env, &party_a, &party_b, &token, deposit_a, deposit_b, dispute_window,
+        );
+
+        // CEI: state before external calls
+        env.storage().persistent().set(&key, &channel);
+
+        let tok = token::Client::new(&env, &token);
+        tok.transfer(&party_a, &env.current_contract_address(), &deposit_a);
+        tok.transfer(&party_b, &env.current_contract_address(), &deposit_b);
+
+        env.events().publish(
+            (symbol_short!("ch_open"),),
+            (party_a, party_b, token, deposit_a + deposit_b),
+        );
+    }
+
+    /// Updates the channel's latest agreed balance state.
+    ///
+    /// Both parties must authorise. `new_balance_a` is party_a's new balance;
+    /// `nonce` must be strictly greater than the current nonce.
+    ///
+    /// Emits `("ch_upd",)` with data `(party_a, party_b, token, new_balance_a, nonce)`.
+    pub fn update_channel_state(
+        env: Env,
+        party_a: Address,
+        party_b: Address,
+        token: Address,
+        new_balance_a: i128,
+        nonce: u64,
+    ) {
+        Self::require_not_paused(&env);
+        party_a.require_auth();
+        party_b.require_auth();
+
+        let key = DataKey::PaymentChannel(party_a.clone(), party_b.clone(), token.clone());
+        let mut channel: payment_channel::PaymentChannel = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .unwrap_or_else(|| panic_with_error!(&env, ChannelError::ChannelNotFound));
+
+        if channel.status != payment_channel::ChannelStatus::Open {
+            panic_with_error!(&env, ChannelError::ChannelNotOpen);
+        }
+        if nonce <= channel.nonce {
+            panic_with_error!(&env, ChannelError::StaleNonce);
+        }
+        if new_balance_a < 0 || new_balance_a > channel.total_deposit {
+            panic_with_error!(&env, ChannelError::InvalidChannelBalance);
+        }
+
+        channel.balance_a = new_balance_a;
+        channel.nonce = nonce;
+        env.storage().persistent().set(&key, &channel);
+
+        env.events().publish(
+            (symbol_short!("ch_upd"),),
+            (party_a, party_b, token, new_balance_a, nonce),
+        );
+    }
+
+    /// Cooperatively closes a channel. Both parties must authorise.
+    ///
+    /// Distributes funds according to the latest agreed state and marks the channel closed.
+    /// Emits `("ch_coop",)` with data `(party_a, party_b, token, balance_a, balance_b)`.
+    pub fn cooperative_close(
+        env: Env,
+        party_a: Address,
+        party_b: Address,
+        token: Address,
+    ) {
+        Self::require_not_paused(&env);
+        party_a.require_auth();
+        party_b.require_auth();
+
+        let key = DataKey::PaymentChannel(party_a.clone(), party_b.clone(), token.clone());
+        let mut channel: payment_channel::PaymentChannel = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .unwrap_or_else(|| panic_with_error!(&env, ChannelError::ChannelNotFound));
+
+        if channel.status != payment_channel::ChannelStatus::Open {
+            panic_with_error!(&env, ChannelError::ChannelNotOpen);
+        }
+
+        let bal_a = channel.balance_a;
+        let bal_b = payment_channel::balance_b(&channel);
+
+        channel.status = payment_channel::ChannelStatus::Closed;
+        env.storage().persistent().set(&key, &channel);
+
+        let tok = token::Client::new(&env, &token);
+        if bal_a > 0 {
+            tok.transfer(&env.current_contract_address(), &party_a, &bal_a);
+        }
+        if bal_b > 0 {
+            tok.transfer(&env.current_contract_address(), &party_b, &bal_b);
+        }
+
+        env.events().publish(
+            (symbol_short!("ch_coop"),),
+            (party_a, party_b, token, bal_a, bal_b),
+        );
+    }
+
+    /// Initiates or finalises a unilateral (dispute) close.
+    ///
+    /// **First call** (by either party): sets status to `Disputed` and starts the
+    /// dispute window using the caller's proposed `balance_a` / `nonce`.
+    ///
+    /// **Second call** (by the counterparty, within the window): if the submitted
+    /// `nonce` is strictly higher, the newer state is applied before closing.
+    ///
+    /// **After the window**: anyone may call to finalise the close with the last
+    /// submitted state.
+    ///
+    /// Emits `("ch_disp",)` on initiation and `("ch_fin",)` on finalisation.
+    pub fn dispute_close(
+        env: Env,
+        caller: Address,
+        party_a: Address,
+        party_b: Address,
+        token: Address,
+        claimed_balance_a: i128,
+        nonce: u64,
+    ) {
+        Self::require_not_paused(&env);
+        caller.require_auth();
+
+        let key = DataKey::PaymentChannel(party_a.clone(), party_b.clone(), token.clone());
+        let mut channel: payment_channel::PaymentChannel = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .unwrap_or_else(|| panic_with_error!(&env, ChannelError::ChannelNotFound));
+
+        if caller != channel.party_a && caller != channel.party_b {
+            panic_with_error!(&env, ChannelError::NotChannelParty);
+        }
+
+        let now = env.ledger().timestamp();
+
+        match channel.status {
+            payment_channel::ChannelStatus::Open => {
+                // Initiate dispute
+                if claimed_balance_a < 0 || claimed_balance_a > channel.total_deposit {
+                    panic_with_error!(&env, ChannelError::InvalidChannelBalance);
+                }
+                if nonce < channel.nonce {
+                    panic_with_error!(&env, ChannelError::StaleNonce);
+                }
+                channel.status = payment_channel::ChannelStatus::Disputed;
+                channel.dispute_started_at = now;
+                channel.disputer = Some(caller.clone());
+                channel.balance_a = claimed_balance_a;
+                channel.nonce = nonce;
+                env.storage().persistent().set(&key, &channel);
+
+                env.events().publish(
+                    (symbol_short!("ch_disp"),),
+                    (caller, party_a, party_b, token, claimed_balance_a, nonce),
+                );
+            }
+            payment_channel::ChannelStatus::Disputed => {
+                let window_end = channel.dispute_started_at + channel.dispute_window;
+
+                if now < window_end {
+                    // Counterparty submitting a newer state
+                    if nonce <= channel.nonce {
+                        panic_with_error!(&env, ChannelError::StaleNonce);
+                    }
+                    if claimed_balance_a < 0 || claimed_balance_a > channel.total_deposit {
+                        panic_with_error!(&env, ChannelError::InvalidChannelBalance);
+                    }
+                    channel.balance_a = claimed_balance_a;
+                    channel.nonce = nonce;
+                    env.storage().persistent().set(&key, &channel);
+
+                    env.events().publish(
+                        (symbol_short!("ch_disp"),),
+                        (caller, party_a, party_b, token, claimed_balance_a, nonce),
+                    );
+                } else {
+                    // Window elapsed — finalise
+                    let bal_a = channel.balance_a;
+                    let bal_b = payment_channel::balance_b(&channel);
+
+                    channel.status = payment_channel::ChannelStatus::Closed;
+                    env.storage().persistent().set(&key, &channel);
+
+                    let tok = token::Client::new(&env, &token);
+                    if bal_a > 0 {
+                        tok.transfer(&env.current_contract_address(), &party_a, &bal_a);
+                    }
+                    if bal_b > 0 {
+                        tok.transfer(&env.current_contract_address(), &party_b, &bal_b);
+                    }
+
+                    env.events().publish(
+                        (symbol_short!("ch_fin"),),
+                        (party_a, party_b, token, bal_a, bal_b),
+                    );
+                }
+            }
+            payment_channel::ChannelStatus::Closed => {
+                panic_with_error!(&env, ChannelError::ChannelNotOpen);
+            }
+        }
+    }
+
+    /// Returns the payment channel between `party_a`, `party_b`, and `token`.
+    pub fn get_channel(
+        env: Env,
+        party_a: Address,
+        party_b: Address,
+        token: Address,
+    ) -> Option<payment_channel::PaymentChannel> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::PaymentChannel(party_a, party_b, token))
     }
 }
 

--- a/contracts/tipjar/src/payment_channel.rs
+++ b/contracts/tipjar/src/payment_channel.rs
@@ -1,0 +1,77 @@
+/// Bidirectional payment channel for instant tip settlements.
+///
+/// Lifecycle:
+///   open_channel → update_channel_state (off-chain, many times) → cooperative_close
+///                                                                 → dispute_close (unilateral)
+use soroban_sdk::{contracttype, Address, Env};
+
+/// Status of a payment channel.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum ChannelStatus {
+    /// Channel is open and accepting state updates.
+    Open,
+    /// A unilateral close has been initiated; waiting for dispute window.
+    Disputed,
+    /// Channel is closed; funds have been distributed.
+    Closed,
+}
+
+/// On-chain record for a payment channel between two parties.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PaymentChannel {
+    /// First party (channel opener).
+    pub party_a: Address,
+    /// Second party (counterparty).
+    pub party_b: Address,
+    /// Token used in this channel.
+    pub token: Address,
+    /// Total collateral locked in the channel (party_a + party_b deposits).
+    pub total_deposit: i128,
+    /// Latest agreed balance for party_a (party_b gets total_deposit - balance_a).
+    pub balance_a: i128,
+    /// Monotonically increasing state version; prevents replay of stale states.
+    pub nonce: u64,
+    /// Current channel status.
+    pub status: ChannelStatus,
+    /// Ledger timestamp when the channel was opened.
+    pub opened_at: u64,
+    /// When a dispute was initiated (0 if none).
+    pub dispute_started_at: u64,
+    /// Seconds the counterparty has to submit a newer state during a dispute.
+    pub dispute_window: u64,
+    /// Address that initiated the current dispute (if any).
+    pub disputer: Option<Address>,
+}
+
+/// Opens a channel, transferring `deposit_a` from party_a and `deposit_b` from party_b.
+pub fn open(
+    env: &Env,
+    party_a: &Address,
+    party_b: &Address,
+    token: &Address,
+    deposit_a: i128,
+    deposit_b: i128,
+    dispute_window: u64,
+) -> PaymentChannel {
+    let total = deposit_a + deposit_b;
+    PaymentChannel {
+        party_a: party_a.clone(),
+        party_b: party_b.clone(),
+        token: token.clone(),
+        total_deposit: total,
+        balance_a: deposit_a, // initial split: each party owns their deposit
+        nonce: 0,
+        status: ChannelStatus::Open,
+        opened_at: env.ledger().timestamp(),
+        dispute_started_at: 0,
+        dispute_window,
+        disputer: None,
+    }
+}
+
+/// Returns the balance owed to party_b given the current channel state.
+pub fn balance_b(channel: &PaymentChannel) -> i128 {
+    channel.total_deposit - channel.balance_a
+}

--- a/contracts/tipjar/tests/payment_channel_tests.rs
+++ b/contracts/tipjar/tests/payment_channel_tests.rs
@@ -1,0 +1,163 @@
+#![cfg(test)]
+
+extern crate std;
+
+use soroban_sdk::{
+    testutils::{Address as _, Ledger},
+    Address, Env,
+};
+use tipjar::{
+    payment_channel::{ChannelStatus, PaymentChannel},
+    ChannelError, DataKey, TipJarContract, TipJarContractClient, TipJarError,
+};
+
+fn setup() -> (Env, TipJarContractClient<'static>, Address, Address, Address, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, TipJarContract);
+    let client = TipJarContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let token_id = env.register_stellar_asset_contract(token_admin.clone());
+
+    client.init(&admin, &0u32, &0u64);
+    client.add_token(&admin, &token_id);
+
+    let party_a = Address::generate(&env);
+    let party_b = Address::generate(&env);
+
+    let tok = soroban_sdk::token::StellarAssetClient::new(&env, &token_id);
+    tok.mint(&party_a, &1_000i128);
+    tok.mint(&party_b, &1_000i128);
+
+    (env, client, admin, party_a, party_b, token_id)
+}
+
+#[test]
+fn test_open_channel() {
+    let (env, client, _admin, party_a, party_b, token) = setup();
+
+    client.open_channel(&party_a, &party_b, &token, &500i128, &500i128, &3600u64);
+
+    let ch = client.get_channel(&party_a, &party_b, &token).unwrap();
+    assert_eq!(ch.total_deposit, 1_000);
+    assert_eq!(ch.balance_a, 500);
+    assert_eq!(ch.nonce, 0);
+    assert_eq!(ch.status, ChannelStatus::Open);
+    assert_eq!(ch.dispute_window, 3600);
+}
+
+#[test]
+fn test_update_channel_state() {
+    let (env, client, _admin, party_a, party_b, token) = setup();
+
+    client.open_channel(&party_a, &party_b, &token, &500i128, &500i128, &3600u64);
+    client.update_channel_state(&party_a, &party_b, &token, &700i128, &1u64);
+
+    let ch = client.get_channel(&party_a, &party_b, &token).unwrap();
+    assert_eq!(ch.balance_a, 700);
+    assert_eq!(ch.nonce, 1);
+}
+
+#[test]
+fn test_update_stale_nonce_rejected() {
+    let (env, client, _admin, party_a, party_b, token) = setup();
+
+    client.open_channel(&party_a, &party_b, &token, &500i128, &500i128, &3600u64);
+    client.update_channel_state(&party_a, &party_b, &token, &700i128, &5u64);
+
+    let result = client.try_update_channel_state(&party_a, &party_b, &token, &600i128, &3u64);
+    assert_eq!(result, Err(Ok(ChannelError::StaleNonce)));
+}
+
+#[test]
+fn test_cooperative_close() {
+    let (env, client, _admin, party_a, party_b, token) = setup();
+
+    client.open_channel(&party_a, &party_b, &token, &500i128, &500i128, &3600u64);
+    client.update_channel_state(&party_a, &party_b, &token, &300i128, &1u64);
+    client.cooperative_close(&party_a, &party_b, &token);
+
+    let ch = client.get_channel(&party_a, &party_b, &token).unwrap();
+    assert_eq!(ch.status, ChannelStatus::Closed);
+
+    // Verify token balances: party_a gets 300, party_b gets 700
+    let tok = soroban_sdk::token::Client::new(&env, &token);
+    assert_eq!(tok.balance(&party_a), 800); // started with 1000, deposited 500, got back 300
+    assert_eq!(tok.balance(&party_b), 1200); // started with 1000, deposited 500, got back 700
+}
+
+#[test]
+fn test_cooperative_close_already_closed() {
+    let (env, client, _admin, party_a, party_b, token) = setup();
+
+    client.open_channel(&party_a, &party_b, &token, &500i128, &500i128, &3600u64);
+    client.cooperative_close(&party_a, &party_b, &token);
+
+    let result = client.try_cooperative_close(&party_a, &party_b, &token);
+    assert_eq!(result, Err(Ok(ChannelError::ChannelNotOpen)));
+}
+
+#[test]
+fn test_dispute_close_initiate_and_finalise() {
+    let (env, client, _admin, party_a, party_b, token) = setup();
+
+    client.open_channel(&party_a, &party_b, &token, &500i128, &500i128, &3600u64);
+    client.update_channel_state(&party_a, &party_b, &token, &800i128, &1u64);
+
+    // party_a initiates dispute with latest state
+    client.dispute_close(&party_a, &party_a, &party_b, &token, &800i128, &1u64);
+
+    let ch = client.get_channel(&party_a, &party_b, &token).unwrap();
+    assert_eq!(ch.status, ChannelStatus::Disputed);
+
+    // Advance time past dispute window
+    env.ledger().with_mut(|l| l.timestamp += 3601);
+
+    // Anyone can finalise after window
+    client.dispute_close(&party_b, &party_a, &party_b, &token, &800i128, &1u64);
+
+    let ch = client.get_channel(&party_a, &party_b, &token).unwrap();
+    assert_eq!(ch.status, ChannelStatus::Closed);
+
+    let tok = soroban_sdk::token::Client::new(&env, &token);
+    assert_eq!(tok.balance(&party_a), 1300); // 1000 - 500 + 800
+    assert_eq!(tok.balance(&party_b), 700);  // 1000 - 500 + 200
+}
+
+#[test]
+fn test_dispute_counterparty_submits_newer_state() {
+    let (env, client, _admin, party_a, party_b, token) = setup();
+
+    client.open_channel(&party_a, &party_b, &token, &500i128, &500i128, &3600u64);
+    client.update_channel_state(&party_a, &party_b, &token, &800i128, &2u64);
+
+    // party_a tries to cheat with an old state (nonce=1, balance_a=900)
+    client.dispute_close(&party_a, &party_a, &party_b, &token, &900i128, &1u64);
+
+    // party_b counters with the real latest state (nonce=2)
+    client.dispute_close(&party_b, &party_a, &party_b, &token, &800i128, &2u64);
+
+    let ch = client.get_channel(&party_a, &party_b, &token).unwrap();
+    assert_eq!(ch.balance_a, 800);
+    assert_eq!(ch.nonce, 2);
+}
+
+#[test]
+fn test_non_party_cannot_dispute() {
+    let (env, client, _admin, party_a, party_b, token) = setup();
+    let stranger = Address::generate(&env);
+
+    client.open_channel(&party_a, &party_b, &token, &500i128, &500i128, &3600u64);
+
+    let result = client.try_dispute_close(&stranger, &party_a, &party_b, &token, &500i128, &0u64);
+    assert_eq!(result, Err(Ok(ChannelError::NotChannelParty)));
+}
+
+#[test]
+fn test_get_channel_not_found() {
+    let (_env, client, _admin, party_a, party_b, token) = setup();
+    assert!(client.get_channel(&party_a, &party_b, &token).is_none());
+}


### PR DESCRIPTION
- Add payment_channel module with PaymentChannel struct and ChannelStatus enum
- Add DataKey::PaymentChannel variant for persistent storage
- Add ChannelError enum with 9 error variants
- Implement open_channel, update_channel_state, cooperative_close, dispute_close, and get_channel contract methods
- Add payment_channel_tests.rs with 9 test cases covering open, update, cooperative close, dispute flow, and auth checks

Closes #266