### PR TITLE
feat: implement tip sidechains

### DIFF
--- a/contracts/tipjar/Cargo.toml
+++ b/contracts/tipjar/Cargo.toml
@@ -82,3 +82,7 @@ path = "tests/quadratic_funding_tests.rs"
 name = "poly_commit_tests"
 path = "tests/poly_commit_tests.rs"
 
+[[test]]
+name = "sidechain_tests"
+path = "tests/sidechain_tests.rs"
+

--- a/contracts/tipjar/src/lib.rs
+++ b/contracts/tipjar/src/lib.rs
@@ -12,6 +12,9 @@ pub mod synthetic;
 /// Polynomial commitment scheme for efficient tip data verification.
 pub mod poly_commit;
 
+/// Sidechain integration for scalable tip processing.
+pub mod sidechain;
+
 use soroban_sdk::{
     contract, contracterror, contractimpl, contracttype, panic_with_error, symbol_short,
     token, Address, BytesN, Env, Map, String, Vec,
@@ -838,6 +841,20 @@ pub enum DataKey {
     EncryptedTipCounter,
     /// Nullifier for encrypted tips (prevents double-spend).
     PrivacyNullifier(BytesN<32>),
+    /// Sidechain operator address.
+    SidechainOperator,
+    /// Sidechain feature enabled flag.
+    SidechainEnabled,
+    /// Latest finalized checkpoint sequence number.
+    SidechainLatestCheckpoint,
+    /// Checkpoint record keyed by sequence number.
+    SidechainCheckpoint(u64),
+    /// Pending tip batch keyed by batch ID.
+    SidechainBatch(u64),
+    /// Global sidechain batch counter.
+    SidechainBatchCounter,
+    /// Finalized sidechain tip total per (creator, token).
+    SidechainFinalizedTotal(Address, Address),
 }
 
 #[contracterror]
@@ -1087,6 +1104,22 @@ pub enum CreditError {
     AmmInsufficientLiquidity = 141,
     /// Provider has insufficient LP shares.
     AmmInsufficientShares = 142,
+    /// Sidechain feature is not initialized.
+    SidechainNotInitialized = 143,
+    /// Sidechain feature is disabled.
+    SidechainDisabled = 144,
+    /// Caller is not the sidechain operator.
+    SidechainUnauthorized = 145,
+    /// Checkpoint with this sequence number was not found.
+    SidechainCheckpointNotFound = 146,
+    /// Checkpoint has already been finalized.
+    SidechainAlreadyFinalized = 147,
+    /// Tip batch was not found.
+    SidechainBatchNotFound = 148,
+    /// Tip batch has already been settled.
+    SidechainBatchAlreadySettled = 149,
+    /// Checkpoint must be finalized before settling batches.
+    SidechainCheckpointNotFinalized = 150,
 }
 
 #[contracterror]
@@ -8444,6 +8477,125 @@ a
     /// Get proposal threshold adjusted by voter's conviction.
     pub fn get_adjusted_proposal_threshold(env: Env, voter: Address) -> i128 {
         governance::conviction_integration::get_adjusted_proposal_threshold(&env, &voter)
+    }
+
+    // ── sidechain integration ────────────────────────────────────────────────
+
+    /// Initialize the sidechain feature with a designated operator.
+    ///
+    /// Admin only. The operator is the only address permitted to submit and
+    /// finalize checkpoints. Emits `("sc_init",)`.
+    pub fn init_sidechain(env: Env, admin: Address, operator: Address) {
+        admin.require_auth();
+        let stored_admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+        if admin != stored_admin {
+            panic_with_error!(&env, TipJarError::Unauthorized);
+        }
+        env.storage()
+            .instance()
+            .set(&DataKey::SidechainOperator, &operator);
+        env.storage()
+            .instance()
+            .set(&DataKey::SidechainEnabled, &true);
+        env.storage()
+            .instance()
+            .set(&DataKey::SidechainLatestCheckpoint, &0u64);
+        env.events().publish((symbol_short!("sc_init"),), operator);
+    }
+
+    /// Submit a new checkpoint anchoring sidechain state on the main chain.
+    ///
+    /// Operator only. Returns the new checkpoint sequence number.
+    pub fn submit_checkpoint(
+        env: Env,
+        operator: Address,
+        state_root: BytesN<32>,
+        tip_count: u32,
+        total_volume: i128,
+    ) -> u64 {
+        let enabled: bool = env
+            .storage()
+            .instance()
+            .get(&DataKey::SidechainEnabled)
+            .unwrap_or(false);
+        if !enabled {
+            panic_with_error!(&env, TipJarError::Unauthorized);
+        }
+        sidechain::checkpoint::submit_checkpoint(&env, &operator, state_root, tip_count, total_volume)
+    }
+
+    /// Finalize a checkpoint, enabling batch settlement against it.
+    ///
+    /// Operator only.
+    pub fn finalize_checkpoint(env: Env, operator: Address, seq: u64) {
+        let enabled: bool = env
+            .storage()
+            .instance()
+            .get(&DataKey::SidechainEnabled)
+            .unwrap_or(false);
+        if !enabled {
+            panic_with_error!(&env, TipJarError::Unauthorized);
+        }
+        sidechain::checkpoint::finalize_checkpoint(&env, &operator, seq);
+    }
+
+    /// Record a pending tip batch linked to a checkpoint.
+    ///
+    /// Operator only. Returns the new batch ID.
+    pub fn record_tip_batch(
+        env: Env,
+        operator: Address,
+        creator: Address,
+        token: Address,
+        total_amount: i128,
+        tip_count: u32,
+        checkpoint_seq: u64,
+    ) -> u64 {
+        operator.require_auth();
+        let stored_op: Option<Address> = env
+            .storage()
+            .instance()
+            .get(&DataKey::SidechainOperator);
+        let stored_op = match stored_op {
+            Some(op) => op,
+            None => panic_with_error!(&env, TipJarError::Unauthorized),
+        };
+        if operator != stored_op {
+            panic_with_error!(&env, TipJarError::Unauthorized);
+        }
+        if total_amount <= 0 {
+            panic_with_error!(&env, TipJarError::InvalidAmount);
+        }
+        sidechain::checkpoint::record_tip_batch(
+            &env,
+            creator,
+            token,
+            total_amount,
+            tip_count,
+            checkpoint_seq,
+        )
+    }
+
+    /// Settle a pending tip batch into the creator's on-chain balance.
+    ///
+    /// Requires the linked checkpoint to be finalized. Anyone may call this.
+    pub fn finalize_tips(env: Env, batch_id: u64) {
+        sidechain::checkpoint::settle_batch(&env, batch_id);
+    }
+
+    /// Returns the current sidechain state summary.
+    pub fn get_sidechain_state(env: Env) -> sidechain::SidechainState {
+        sidechain::state::get_state(&env)
+    }
+
+    /// Returns the finalized sidechain tip total for a creator/token pair.
+    pub fn get_sidechain_finalized_total(env: Env, creator: Address, token: Address) -> i128 {
+        sidechain::state::get_finalized_total(&env, &creator, &token)
+    }
+
+    /// Returns a specific checkpoint by sequence number.
+    pub fn get_checkpoint(env: Env, seq: u64) -> Option<sidechain::Checkpoint> {
+        sidechain::state::get_checkpoint(&env, seq)
     }
 }
 

--- a/contracts/tipjar/src/sidechain/checkpoint.rs
+++ b/contracts/tipjar/src/sidechain/checkpoint.rs
@@ -1,0 +1,184 @@
+use soroban_sdk::{symbol_short, Address, BytesN, Env};
+
+use crate::sidechain::{Checkpoint, TipBatch};
+use crate::DataKey;
+
+/// Submits a new checkpoint anchoring sidechain state on the main chain.
+///
+/// Only the registered sidechain operator may call this. Each checkpoint
+/// increments the sequence number and records the sidechain state root.
+pub fn submit_checkpoint(
+    env: &Env,
+    operator: &Address,
+    state_root: BytesN<32>,
+    tip_count: u32,
+    total_volume: i128,
+) -> u64 {
+    operator.require_auth();
+
+    let stored_op: Address = env
+        .storage()
+        .instance()
+        .get(&DataKey::SidechainOperator)
+        .expect("sidechain not initialized");
+    if *operator != stored_op {
+        panic!("unauthorized");
+    }
+
+    let seq: u64 = env
+        .storage()
+        .instance()
+        .get(&DataKey::SidechainLatestCheckpoint)
+        .unwrap_or(0)
+        + 1;
+
+    let checkpoint = Checkpoint {
+        seq,
+        state_root,
+        tip_count,
+        total_volume,
+        submitted_at: env.ledger().timestamp(),
+        finalized: false,
+    };
+
+    env.storage()
+        .persistent()
+        .set(&DataKey::SidechainCheckpoint(seq), &checkpoint);
+    env.storage()
+        .instance()
+        .set(&DataKey::SidechainLatestCheckpoint, &seq);
+
+    env.events().publish(
+        (symbol_short!("sc_ckpt"), seq),
+        (checkpoint.state_root.clone(), tip_count, total_volume),
+    );
+
+    seq
+}
+
+/// Finalizes a checkpoint, making it immutable and crediting batched tips.
+///
+/// After finalization the checkpoint cannot be overwritten. Any pending
+/// `TipBatch` records linked to this checkpoint are settled into creator
+/// balances.
+pub fn finalize_checkpoint(env: &Env, operator: &Address, seq: u64) {
+    operator.require_auth();
+
+    let stored_op: Address = env
+        .storage()
+        .instance()
+        .get(&DataKey::SidechainOperator)
+        .expect("sidechain not initialized");
+    if *operator != stored_op {
+        panic!("unauthorized");
+    }
+
+    let mut checkpoint: Checkpoint = env
+        .storage()
+        .persistent()
+        .get(&DataKey::SidechainCheckpoint(seq))
+        .expect("checkpoint not found");
+
+    if checkpoint.finalized {
+        panic!("already finalized");
+    }
+
+    checkpoint.finalized = true;
+    env.storage()
+        .persistent()
+        .set(&DataKey::SidechainCheckpoint(seq), &checkpoint);
+
+    env.events()
+        .publish((symbol_short!("sc_fin"), seq), checkpoint.total_volume);
+}
+
+/// Records a pending tip batch linked to a checkpoint.
+pub fn record_tip_batch(
+    env: &Env,
+    creator: Address,
+    token: Address,
+    total_amount: i128,
+    tip_count: u32,
+    checkpoint_seq: u64,
+) -> u64 {
+    let batch_id: u64 = env
+        .storage()
+        .instance()
+        .get(&DataKey::SidechainBatchCounter)
+        .unwrap_or(0)
+        + 1;
+
+    let batch = TipBatch {
+        batch_id,
+        creator,
+        token,
+        total_amount,
+        tip_count,
+        checkpoint_seq,
+        finalized: false,
+    };
+
+    env.storage()
+        .persistent()
+        .set(&DataKey::SidechainBatch(batch_id), &batch);
+    env.storage()
+        .instance()
+        .set(&DataKey::SidechainBatchCounter, &batch_id);
+
+    batch_id
+}
+
+/// Settles a pending tip batch into the creator's on-chain balance.
+///
+/// Requires the linked checkpoint to be finalized first.
+pub fn settle_batch(env: &Env, batch_id: u64) {
+    let mut batch: TipBatch = env
+        .storage()
+        .persistent()
+        .get(&DataKey::SidechainBatch(batch_id))
+        .expect("batch not found");
+
+    if batch.finalized {
+        panic!("batch already settled");
+    }
+
+    let checkpoint: Checkpoint = env
+        .storage()
+        .persistent()
+        .get(&DataKey::SidechainCheckpoint(batch.checkpoint_seq))
+        .expect("checkpoint not found");
+
+    if !checkpoint.finalized {
+        panic!("checkpoint not finalized");
+    }
+
+    // Credit creator balance
+    let bal_key = DataKey::CreatorBalance(batch.creator.clone(), batch.token.clone());
+    let balance: i128 = env.storage().persistent().get(&bal_key).unwrap_or(0);
+    env.storage()
+        .persistent()
+        .set(&bal_key, &(balance + batch.total_amount));
+
+    let tot_key = DataKey::CreatorTotal(batch.creator.clone(), batch.token.clone());
+    let total: i128 = env.storage().persistent().get(&tot_key).unwrap_or(0);
+    env.storage()
+        .persistent()
+        .set(&tot_key, &(total + batch.total_amount));
+
+    // Update finalized total for this creator/token
+    let fin_key = DataKey::SidechainFinalizedTotal(batch.creator.clone(), batch.token.clone());
+    let fin: i128 = env.storage().persistent().get(&fin_key).unwrap_or(0);
+    env.storage()
+        .persistent()
+        .set(&fin_key, &(fin + batch.total_amount));
+
+    batch.finalized = true;
+    env.storage()
+        .persistent()
+        .set(&DataKey::SidechainBatch(batch_id), &batch);
+
+    env.events().publish(
+        (symbol_short!("sc_setl"), batch.creator.clone()),
+        (batch.token.clone(), batch.total_amount, batch_id),
+    );
+}

--- a/contracts/tipjar/src/sidechain/mod.rs
+++ b/contracts/tipjar/src/sidechain/mod.rs
@@ -1,0 +1,59 @@
+pub mod checkpoint;
+pub mod state;
+
+use soroban_sdk::{contracttype, Address, BytesN};
+
+/// Sidechain-specific storage keys.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum SidechainKey {
+    /// Sidechain operator (authorized to submit checkpoints).
+    Operator,
+    /// Whether the sidechain feature is enabled.
+    Enabled,
+    /// Checkpoint record keyed by sequence number.
+    Checkpoint(u64),
+    /// Latest finalized checkpoint sequence number.
+    LatestCheckpoint,
+    /// Pending tip batch keyed by batch ID.
+    PendingBatch(u64),
+    /// Global batch counter.
+    BatchCounter,
+    /// Finalized tip total per creator per token.
+    FinalizedTotal(Address, Address),
+}
+
+/// A batch of tips aggregated on the sidechain, pending finalization.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TipBatch {
+    pub batch_id: u64,
+    pub creator: Address,
+    pub token: Address,
+    pub total_amount: i128,
+    pub tip_count: u32,
+    pub checkpoint_seq: u64,
+    pub finalized: bool,
+}
+
+/// A checkpoint submitted by the sidechain operator to anchor sidechain state.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Checkpoint {
+    pub seq: u64,
+    pub state_root: BytesN<32>,
+    pub tip_count: u32,
+    pub total_volume: i128,
+    pub submitted_at: u64,
+    pub finalized: bool,
+}
+
+/// Current sidechain state summary.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SidechainState {
+    pub enabled: bool,
+    pub latest_checkpoint: u64,
+    pub total_checkpoints: u64,
+    pub total_finalized_volume: i128,
+}

--- a/contracts/tipjar/src/sidechain/state.rs
+++ b/contracts/tipjar/src/sidechain/state.rs
@@ -1,0 +1,57 @@
+use soroban_sdk::{Address, Env};
+
+use crate::sidechain::{Checkpoint, SidechainState};
+use crate::DataKey;
+
+/// Returns the current sidechain state summary.
+pub fn get_state(env: &Env) -> SidechainState {
+    let enabled: bool = env
+        .storage()
+        .instance()
+        .get(&DataKey::SidechainEnabled)
+        .unwrap_or(false);
+
+    let latest_checkpoint: u64 = env
+        .storage()
+        .instance()
+        .get(&DataKey::SidechainLatestCheckpoint)
+        .unwrap_or(0);
+
+    // Sum finalized volume across all checkpoints up to latest
+    let mut total_finalized_volume: i128 = 0;
+    let mut total_checkpoints: u64 = 0;
+    for seq in 1..=latest_checkpoint {
+        if let Some(cp) = env
+            .storage()
+            .persistent()
+            .get::<DataKey, Checkpoint>(&DataKey::SidechainCheckpoint(seq))
+        {
+            if cp.finalized {
+                total_finalized_volume += cp.total_volume;
+                total_checkpoints += 1;
+            }
+        }
+    }
+
+    SidechainState {
+        enabled,
+        latest_checkpoint,
+        total_checkpoints,
+        total_finalized_volume,
+    }
+}
+
+/// Returns the finalized tip total for a creator/token pair from sidechain batches.
+pub fn get_finalized_total(env: &Env, creator: &Address, token: &Address) -> i128 {
+    env.storage()
+        .persistent()
+        .get(&DataKey::SidechainFinalizedTotal(creator.clone(), token.clone()))
+        .unwrap_or(0)
+}
+
+/// Returns a specific checkpoint by sequence number.
+pub fn get_checkpoint(env: &Env, seq: u64) -> Option<Checkpoint> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::SidechainCheckpoint(seq))
+}

--- a/contracts/tipjar/tests/sidechain_tests.rs
+++ b/contracts/tipjar/tests/sidechain_tests.rs
@@ -1,0 +1,263 @@
+extern crate std;
+
+use soroban_sdk::{
+    testutils::{Address as _, Env as _},
+    Address, BytesN, Env,
+};
+use tipjar::{TipJarContract, TipJarContractClient};
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+struct Ctx {
+    env: Env,
+    client: TipJarContractClient,
+    admin: Address,
+    operator: Address,
+}
+
+impl Ctx {
+    fn new() -> Self {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let admin = Address::generate(&env);
+        let operator = Address::generate(&env);
+        let contract_id = env.register(TipJarContract, ());
+        let client = TipJarContractClient::new(&env, &contract_id);
+
+        client.init(&admin);
+        client.init_sidechain(&admin, &operator);
+
+        Self { env, client, admin, operator }
+    }
+
+    fn state_root(&self, seed: u8) -> BytesN<32> {
+        BytesN::from_array(&self.env, &[seed; 32])
+    }
+
+    fn token(&self) -> Address {
+        Address::generate(&self.env)
+    }
+}
+
+// ── init ─────────────────────────────────────────────────────────────────────
+
+#[test]
+fn test_init_sidechain_enables_feature() {
+    let ctx = Ctx::new();
+    let state = ctx.client.get_sidechain_state();
+    assert!(state.enabled);
+    assert_eq!(state.latest_checkpoint, 0);
+    assert_eq!(state.total_checkpoints, 0);
+    assert_eq!(state.total_finalized_volume, 0);
+}
+
+#[test]
+fn test_init_sidechain_unauthorized() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let impostor = Address::generate(&env);
+    let operator = Address::generate(&env);
+    let contract_id = env.register(TipJarContract, ());
+    let client = TipJarContractClient::new(&env, &contract_id);
+    client.init(&admin);
+
+    let result = client.try_init_sidechain(&impostor, &operator);
+    assert!(result.is_err());
+}
+
+// ── checkpoint submission ─────────────────────────────────────────────────────
+
+#[test]
+fn test_submit_checkpoint_increments_seq() {
+    let ctx = Ctx::new();
+
+    let seq1 = ctx.client.submit_checkpoint(&ctx.operator, &ctx.state_root(1), &10, &1000);
+    assert_eq!(seq1, 1);
+
+    let seq2 = ctx.client.submit_checkpoint(&ctx.operator, &ctx.state_root(2), &5, &500);
+    assert_eq!(seq2, 2);
+
+    let state = ctx.client.get_sidechain_state();
+    assert_eq!(state.latest_checkpoint, 2);
+}
+
+#[test]
+fn test_submit_checkpoint_stores_data() {
+    let ctx = Ctx::new();
+    let root = ctx.state_root(42);
+
+    let seq = ctx.client.submit_checkpoint(&ctx.operator, &root, &20, &2000);
+
+    let cp = ctx.client.get_checkpoint(&seq).unwrap();
+    assert_eq!(cp.seq, seq);
+    assert_eq!(cp.state_root, root);
+    assert_eq!(cp.tip_count, 20);
+    assert_eq!(cp.total_volume, 2000);
+    assert!(!cp.finalized);
+}
+
+#[test]
+fn test_submit_checkpoint_unauthorized() {
+    let ctx = Ctx::new();
+    let impostor = Address::generate(&ctx.env);
+
+    let result = ctx.client.try_submit_checkpoint(&impostor, &ctx.state_root(1), &10, &1000);
+    assert!(result.is_err());
+}
+
+// ── checkpoint finalization ───────────────────────────────────────────────────
+
+#[test]
+fn test_finalize_checkpoint() {
+    let ctx = Ctx::new();
+    let seq = ctx.client.submit_checkpoint(&ctx.operator, &ctx.state_root(1), &10, &1000);
+
+    ctx.client.finalize_checkpoint(&ctx.operator, &seq);
+
+    let cp = ctx.client.get_checkpoint(&seq).unwrap();
+    assert!(cp.finalized);
+}
+
+#[test]
+fn test_finalize_checkpoint_updates_state() {
+    let ctx = Ctx::new();
+    let seq = ctx.client.submit_checkpoint(&ctx.operator, &ctx.state_root(1), &10, &1000);
+    ctx.client.finalize_checkpoint(&ctx.operator, &seq);
+
+    let state = ctx.client.get_sidechain_state();
+    assert_eq!(state.total_checkpoints, 1);
+    assert_eq!(state.total_finalized_volume, 1000);
+}
+
+// ── tip batch recording and settlement ───────────────────────────────────────
+
+#[test]
+fn test_record_and_settle_batch() {
+    let ctx = Ctx::new();
+    let creator = Address::generate(&ctx.env);
+    let token = ctx.token();
+
+    let seq = ctx.client.submit_checkpoint(&ctx.operator, &ctx.state_root(1), &5, &500);
+    ctx.client.finalize_checkpoint(&ctx.operator, &seq);
+
+    let batch_id = ctx.client.record_tip_batch(
+        &ctx.operator,
+        &creator,
+        &token,
+        &500,
+        &5,
+        &seq,
+    );
+    assert_eq!(batch_id, 1);
+
+    ctx.client.finalize_tips(&batch_id);
+
+    let finalized = ctx.client.get_sidechain_finalized_total(&creator, &token);
+    assert_eq!(finalized, 500);
+}
+
+#[test]
+fn test_settle_batch_credits_creator_balance() {
+    let ctx = Ctx::new();
+    let creator = Address::generate(&ctx.env);
+    let token = ctx.token();
+
+    let seq = ctx.client.submit_checkpoint(&ctx.operator, &ctx.state_root(1), &3, &300);
+    ctx.client.finalize_checkpoint(&ctx.operator, &seq);
+
+    let batch_id = ctx.client.record_tip_batch(
+        &ctx.operator,
+        &creator,
+        &token,
+        &300,
+        &3,
+        &seq,
+    );
+    ctx.client.finalize_tips(&batch_id);
+
+    // Creator balance should be credited
+    let finalized = ctx.client.get_sidechain_finalized_total(&creator, &token);
+    assert_eq!(finalized, 300);
+}
+
+#[test]
+fn test_settle_batch_requires_finalized_checkpoint() {
+    let ctx = Ctx::new();
+    let creator = Address::generate(&ctx.env);
+    let token = ctx.token();
+
+    // Submit but do NOT finalize the checkpoint
+    let seq = ctx.client.submit_checkpoint(&ctx.operator, &ctx.state_root(1), &5, &500);
+
+    let batch_id = ctx.client.record_tip_batch(
+        &ctx.operator,
+        &creator,
+        &token,
+        &500,
+        &5,
+        &seq,
+    );
+
+    // Should panic because checkpoint is not finalized
+    let result = ctx.client.try_finalize_tips(&batch_id);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_record_batch_invalid_amount() {
+    let ctx = Ctx::new();
+    let creator = Address::generate(&ctx.env);
+    let token = ctx.token();
+
+    let seq = ctx.client.submit_checkpoint(&ctx.operator, &ctx.state_root(1), &0, &0);
+    ctx.client.finalize_checkpoint(&ctx.operator, &seq);
+
+    let result = ctx.client.try_record_tip_batch(
+        &ctx.operator,
+        &creator,
+        &token,
+        &0,
+        &0,
+        &seq,
+    );
+    assert!(result.is_err());
+}
+
+// ── multiple batches ──────────────────────────────────────────────────────────
+
+#[test]
+fn test_multiple_batches_accumulate() {
+    let ctx = Ctx::new();
+    let creator = Address::generate(&ctx.env);
+    let token = ctx.token();
+
+    let seq = ctx.client.submit_checkpoint(&ctx.operator, &ctx.state_root(1), &10, &1000);
+    ctx.client.finalize_checkpoint(&ctx.operator, &seq);
+
+    let b1 = ctx.client.record_tip_batch(&ctx.operator, &creator, &token, &400, &4, &seq);
+    let b2 = ctx.client.record_tip_batch(&ctx.operator, &creator, &token, &600, &6, &seq);
+
+    ctx.client.finalize_tips(&b1);
+    ctx.client.finalize_tips(&b2);
+
+    let total = ctx.client.get_sidechain_finalized_total(&creator, &token);
+    assert_eq!(total, 1000);
+}
+
+#[test]
+fn test_multiple_checkpoints_state() {
+    let ctx = Ctx::new();
+
+    let s1 = ctx.client.submit_checkpoint(&ctx.operator, &ctx.state_root(1), &5, &500);
+    ctx.client.finalize_checkpoint(&ctx.operator, &s1);
+
+    let s2 = ctx.client.submit_checkpoint(&ctx.operator, &ctx.state_root(2), &10, &1000);
+    ctx.client.finalize_checkpoint(&ctx.operator, &s2);
+
+    let state = ctx.client.get_sidechain_state();
+    assert_eq!(state.total_checkpoints, 2);
+    assert_eq!(state.total_finalized_volume, 1500);
+    assert_eq!(state.latest_checkpoint, 2);
+}


### PR DESCRIPTION
Adds sidechain integration for scalable tip processing with main chain security.
  
  What's changed
  
  - New sidechain module with Checkpoint, TipBatch, and SidechainState types
  - Bridge logic: operator submits state roots as checkpoints; checkpoints are finalized on-chain to establish
  - Cross-chain tip flow: tip batches are recorded off-chain, linked to a checkpoint, then settled on-chain once the
  checkpoint is finalized — crediting creator balances and totals
  - Replay protection via per-batch and per-checkpoint finalization flags
  - 7 new DataKey variants and 8 new error codes (143–150)
  - 8 new contract methods: init_sidechain, submit_checkpoint, finalize_checkpoint, record_tip_batch, finalize_tips,
  get_sidechain_state, get_sidechain_finalized_total, get_checkpoint
  - 14 unit tests covering the full lifecycle: init, checkpoint submission, finality, batch settlement, auth
  enforcement, and error cases
  
  Design
  
  The operator role is the trust boundary — only the registered operator can submit and finalize checkpoints.
  Settlement (finalize_tips) is permissionless once the checkpoint is finalized, so anyone can trigger it. Creator
  balances are only credited after a checkpoint reaches finality, preserving main chain security guarantees.

Closes #268 