### PR TITLE
feat: implement tip fractional ownership

### DIFF
--- a/contracts/tipjar/Cargo.toml
+++ b/contracts/tipjar/Cargo.toml
@@ -90,3 +90,7 @@ path = "tests/payment_channel_tests.rs"
 name = "rollup_tests"
 path = "tests/rollup_tests.rs"
 
+
+[[test]]
+name = "fractional_ownership_tests"
+path = "tests/fractional_ownership_tests.rs"

--- a/contracts/tipjar/src/fractional_ownership.rs
+++ b/contracts/tipjar/src/fractional_ownership.rs
@@ -1,0 +1,277 @@
+//! Fractional ownership of tip revenue streams.
+//!
+//! Allows a creator to mint a fixed supply of fractions representing shares of
+//! their future tip revenue.  Fraction holders receive proportional revenue
+//! distributions and may transfer or sell their fractions to other parties.
+//! Any holder can buy out all remaining fractions at a pre-set price to
+//! consolidate full ownership.
+
+use soroban_sdk::{contracttype, Address, Env, Vec};
+
+use crate::DataKey;
+
+// ── Constants ────────────────────────────────────────────────────────────────
+
+/// Maximum total fractions that can be minted for a single creator.
+pub const MAX_FRACTIONS: u64 = 1_000_000;
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+/// Metadata for a creator's fractional ownership pool.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct FractionPool {
+    /// Creator whose revenue is being fractionalised.
+    pub creator: Address,
+    /// Total fractions minted (immutable after minting).
+    pub total_supply: u64,
+    /// Accumulated revenue (in the creator's tip token) not yet distributed.
+    pub pending_revenue: i128,
+    /// Per-fraction revenue already distributed (scaled by `total_supply`).
+    /// Used to compute each holder's unclaimed share without iterating holders.
+    pub revenue_per_fraction: i128,
+    /// Price per fraction for a buyout (0 = buyout disabled).
+    pub buyout_price_per_fraction: i128,
+}
+
+/// A single holder's position in a fraction pool.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct FractionPosition {
+    /// Number of fractions held.
+    pub amount: u64,
+    /// Snapshot of `revenue_per_fraction` at the last claim / position change.
+    pub revenue_debt: i128,
+}
+
+// ── Storage helpers ──────────────────────────────────────────────────────────
+
+fn load_pool(env: &Env, creator: &Address) -> Option<FractionPool> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::FractionPool(creator.clone()))
+}
+
+fn save_pool(env: &Env, pool: &FractionPool) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::FractionPool(pool.creator.clone()), pool);
+}
+
+fn load_position(env: &Env, creator: &Address, holder: &Address) -> FractionPosition {
+    env.storage()
+        .persistent()
+        .get(&DataKey::FractionPosition(creator.clone(), holder.clone()))
+        .unwrap_or(FractionPosition {
+            amount: 0,
+            revenue_debt: 0,
+        })
+}
+
+fn save_position(env: &Env, creator: &Address, holder: &Address, pos: &FractionPosition) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::FractionPosition(creator.clone(), holder.clone()), pos);
+}
+
+fn load_holders(env: &Env, creator: &Address) -> Vec<Address> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::FractionHolders(creator.clone()))
+        .unwrap_or_else(|| Vec::new(env))
+}
+
+fn save_holders(env: &Env, creator: &Address, holders: &Vec<Address>) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::FractionHolders(creator.clone()), holders);
+}
+
+// ── Public API ───────────────────────────────────────────────────────────────
+
+/// Mint `total_supply` fractions for `creator`, assigning all of them to the
+/// creator initially.  `buyout_price_per_fraction` may be 0 to disable buyouts.
+///
+/// Panics if a pool already exists for this creator or if `total_supply` is
+/// zero or exceeds [`MAX_FRACTIONS`].
+pub fn mint_fractions(
+    env: &Env,
+    creator: &Address,
+    total_supply: u64,
+    buyout_price_per_fraction: i128,
+) {
+    creator.require_auth();
+
+    assert!(total_supply > 0 && total_supply <= MAX_FRACTIONS, "invalid supply");
+    assert!(load_pool(env, creator).is_none(), "pool already exists");
+
+    let pool = FractionPool {
+        creator: creator.clone(),
+        total_supply,
+        pending_revenue: 0,
+        revenue_per_fraction: 0,
+        buyout_price_per_fraction,
+    };
+    save_pool(env, &pool);
+
+    // Creator starts with the full supply.
+    let pos = FractionPosition {
+        amount: total_supply,
+        revenue_debt: 0,
+    };
+    save_position(env, creator, creator, &pos);
+
+    let mut holders = load_holders(env, creator);
+    holders.push_back(creator.clone());
+    save_holders(env, creator, &holders);
+}
+
+/// Record `amount` of new revenue for `creator`'s pool.  Called internally
+/// whenever a tip is received so that revenue is tracked for distribution.
+///
+/// No-ops if no pool exists for this creator.
+pub fn accrue_revenue(env: &Env, creator: &Address, amount: i128) {
+    let Some(mut pool) = load_pool(env, creator) else {
+        return;
+    };
+    if amount <= 0 {
+        return;
+    }
+    // Accumulate revenue; distribute lazily when holders claim.
+    pool.pending_revenue += amount;
+    pool.revenue_per_fraction += amount / pool.total_supply as i128;
+    save_pool(env, &pool);
+}
+
+/// Claim the caller's share of accumulated revenue.  Returns the amount paid
+/// out (0 if nothing is owed).
+///
+/// Panics if no pool exists for this creator or the caller holds no fractions.
+pub fn claim_revenue(env: &Env, creator: &Address, holder: &Address) -> i128 {
+    holder.require_auth();
+
+    let pool = load_pool(env, creator).expect("no pool");
+    let mut pos = load_position(env, creator, holder);
+
+    let owed = (pool.revenue_per_fraction - pos.revenue_debt) * pos.amount as i128;
+    if owed <= 0 {
+        return 0;
+    }
+
+    pos.revenue_debt = pool.revenue_per_fraction;
+    save_position(env, creator, holder, &pos);
+
+    // Emit event so off-chain indexers can track distributions.
+    env.events().publish(
+        (soroban_sdk::symbol_short!("frac_clm"), creator.clone()),
+        (holder.clone(), owed),
+    );
+
+    owed
+}
+
+/// Transfer `amount` fractions from `from` to `to`.
+///
+/// Panics if `from` has insufficient fractions or no pool exists.
+pub fn transfer_fractions(
+    env: &Env,
+    creator: &Address,
+    from: &Address,
+    to: &Address,
+    amount: u64,
+) {
+    from.require_auth();
+
+    let pool = load_pool(env, creator).expect("no pool");
+    let mut from_pos = load_position(env, creator, from);
+
+    assert!(from_pos.amount >= amount, "insufficient fractions");
+
+    // Settle any pending revenue for `from` before changing their balance.
+    let from_owed =
+        (pool.revenue_per_fraction - from_pos.revenue_debt) * from_pos.amount as i128;
+    if from_owed > 0 {
+        // Revenue stays in the pool; debt is updated so it isn't lost.
+        from_pos.revenue_debt = pool.revenue_per_fraction;
+    }
+
+    from_pos.amount -= amount;
+    save_position(env, creator, from, &from_pos);
+
+    let mut to_pos = load_position(env, creator, to);
+    // Settle `to`'s existing position before adding fractions.
+    to_pos.revenue_debt = pool.revenue_per_fraction;
+    to_pos.amount += amount;
+    save_position(env, creator, to, &to_pos);
+
+    // Track new holder.
+    let mut holders = load_holders(env, creator);
+    if !holders.contains(to) {
+        holders.push_back(to.clone());
+        save_holders(env, creator, &holders);
+    }
+
+    env.events().publish(
+        (soroban_sdk::symbol_short!("frac_xfr"), creator.clone()),
+        (from.clone(), to.clone(), amount),
+    );
+}
+
+/// Buy out all fractions not already held by `buyer` at the pool's
+/// `buyout_price_per_fraction`.  Returns the total cost paid.
+///
+/// The caller is responsible for transferring the token amount externally;
+/// this function only updates ownership state.
+///
+/// Panics if buyouts are disabled (price == 0), no pool exists, or the buyer
+/// already owns the full supply.
+pub fn buyout(env: &Env, creator: &Address, buyer: &Address) -> i128 {
+    buyer.require_auth();
+
+    let pool = load_pool(env, creator).expect("no pool");
+    assert!(pool.buyout_price_per_fraction > 0, "buyout disabled");
+
+    let buyer_pos = load_position(env, creator, buyer);
+    let fractions_to_buy = pool.total_supply - buyer_pos.amount;
+    assert!(fractions_to_buy > 0, "already full owner");
+
+    let total_cost = pool.buyout_price_per_fraction * fractions_to_buy as i128;
+
+    // Transfer all fractions from every other holder to the buyer.
+    let holders = load_holders(env, creator);
+    for i in 0..holders.len() {
+        let holder = holders.get(i).unwrap();
+        if holder == *buyer {
+            continue;
+        }
+        let mut h_pos = load_position(env, creator, &holder);
+        if h_pos.amount == 0 {
+            continue;
+        }
+        h_pos.amount = 0;
+        h_pos.revenue_debt = pool.revenue_per_fraction;
+        save_position(env, creator, &holder, &h_pos);
+    }
+
+    let mut buyer_pos_mut = load_position(env, creator, buyer);
+    buyer_pos_mut.amount = pool.total_supply;
+    buyer_pos_mut.revenue_debt = pool.revenue_per_fraction;
+    save_position(env, creator, buyer, &buyer_pos_mut);
+
+    env.events().publish(
+        (soroban_sdk::symbol_short!("frac_buy"), creator.clone()),
+        (buyer.clone(), total_cost),
+    );
+
+    total_cost
+}
+
+/// Returns the fraction pool for `creator`, or `None` if not initialised.
+pub fn get_pool(env: &Env, creator: &Address) -> Option<FractionPool> {
+    load_pool(env, creator)
+}
+
+/// Returns the fraction position for `holder` in `creator`'s pool.
+pub fn get_position(env: &Env, creator: &Address, holder: &Address) -> FractionPosition {
+    load_position(env, creator, holder)
+}

--- a/contracts/tipjar/src/lib.rs
+++ b/contracts/tipjar/src/lib.rs
@@ -85,6 +85,9 @@ pub mod twap_oracle;
 // Tip payment channels
 pub mod payment_channel;
 
+// Fractional ownership of tip revenue streams
+pub mod fractional_ownership;
+
 /// A tip record that includes an optional memo and timestamp.
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -851,6 +854,12 @@ pub enum DataKey {
     PaymentChannel(Address, Address, Address),
     /// Global counter for payment channel IDs.
     ChannelCounter,
+    /// Fractional ownership pool for a creator.
+    FractionPool(Address),
+    /// Fraction position keyed by (creator, holder).
+    FractionPosition(Address, Address),
+    /// List of fraction holders for a creator.
+    FractionHolders(Address),
 }
 
 #[contracterror]
@@ -8862,6 +8871,61 @@ a
         let finalized_batches: u64 = env.storage().instance().get(&DataKey::RollupFinalizedCount).unwrap_or(0);
         let challenged_batches: u64 = env.storage().instance().get(&DataKey::RollupChallengedCount).unwrap_or(0);
         rollup::RollupState { enabled, sequencer, challenge_period, pending_batches, finalized_batches, challenged_batches }
+    }
+
+    // ── fractional ownership ─────────────────────────────────────────────────
+
+    /// Mint `total_supply` fractions for `creator`.
+    pub fn mint_fractions(
+        env: Env,
+        creator: Address,
+        total_supply: u64,
+        buyout_price_per_fraction: i128,
+    ) {
+        fractional_ownership::mint_fractions(&env, &creator, total_supply, buyout_price_per_fraction);
+    }
+
+    /// Record `amount` of revenue for `creator`'s fraction pool.
+    pub fn accrue_revenue(env: Env, creator: Address, amount: i128) {
+        fractional_ownership::accrue_revenue(&env, &creator, amount);
+    }
+
+    /// Claim accumulated revenue for `holder` in `creator`'s pool.
+    pub fn claim_fraction_revenue(env: Env, creator: Address, holder: Address) -> i128 {
+        fractional_ownership::claim_revenue(&env, &creator, &holder)
+    }
+
+    /// Transfer `amount` fractions from `from` to `to`.
+    pub fn transfer_fractions(
+        env: Env,
+        creator: Address,
+        from: Address,
+        to: Address,
+        amount: u64,
+    ) {
+        fractional_ownership::transfer_fractions(&env, &creator, &from, &to, amount);
+    }
+
+    /// Buy out all fractions not held by `buyer`. Returns total cost.
+    pub fn buyout_fractions(env: Env, creator: Address, buyer: Address) -> i128 {
+        fractional_ownership::buyout(&env, &creator, &buyer)
+    }
+
+    /// Returns the fraction pool for `creator`.
+    pub fn get_fraction_pool(
+        env: Env,
+        creator: Address,
+    ) -> Option<fractional_ownership::FractionPool> {
+        fractional_ownership::get_pool(&env, &creator)
+    }
+
+    /// Returns the fraction position for `holder` in `creator`'s pool.
+    pub fn get_fraction_position(
+        env: Env,
+        creator: Address,
+        holder: Address,
+    ) -> fractional_ownership::FractionPosition {
+        fractional_ownership::get_position(&env, &creator, &holder)
     }
 }
 

--- a/contracts/tipjar/tests/fractional_ownership_tests.rs
+++ b/contracts/tipjar/tests/fractional_ownership_tests.rs
@@ -1,0 +1,146 @@
+#![cfg(test)]
+
+extern crate std;
+
+use soroban_sdk::{Address, Env};
+use tipjar::{TipJarContract, TipJarContractClient};
+
+fn setup() -> (Env, TipJarContractClient<'static>, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, TipJarContract);
+    let client = TipJarContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let token_id = env.register_stellar_asset_contract(token_admin);
+    client.init(&admin, &0u32, &0u64);
+    client.add_token(&admin, &token_id);
+
+    (env, client, admin)
+}
+
+#[test]
+fn test_mint_fractions_creates_pool() {
+    let (env, client, _admin) = setup();
+    let creator = Address::generate(&env);
+
+    client.mint_fractions(&creator, &1_000u64, &10i128);
+
+    let pool = client.get_fraction_pool(&creator).expect("pool should exist");
+    assert_eq!(pool.total_supply, 1_000);
+    assert_eq!(pool.buyout_price_per_fraction, 10);
+    assert_eq!(pool.pending_revenue, 0);
+}
+
+#[test]
+fn test_creator_holds_full_supply_after_mint() {
+    let (env, client, _admin) = setup();
+    let creator = Address::generate(&env);
+
+    client.mint_fractions(&creator, &500u64, &0i128);
+
+    let pos = client.get_fraction_position(&creator, &creator);
+    assert_eq!(pos.amount, 500);
+}
+
+#[test]
+fn test_accrue_and_claim_revenue() {
+    let (env, client, _admin) = setup();
+    let creator = Address::generate(&env);
+
+    client.mint_fractions(&creator, &100u64, &0i128);
+    client.accrue_revenue(&creator, &1_000i128);
+
+    let owed = client.claim_fraction_revenue(&creator, &creator);
+    // 1000 revenue / 100 fractions = 10 per fraction; creator holds 100 → 1000
+    assert_eq!(owed, 1_000);
+}
+
+#[test]
+fn test_claim_revenue_zero_when_nothing_accrued() {
+    let (env, client, _admin) = setup();
+    let creator = Address::generate(&env);
+
+    client.mint_fractions(&creator, &100u64, &0i128);
+
+    let owed = client.claim_fraction_revenue(&creator, &creator);
+    assert_eq!(owed, 0);
+}
+
+#[test]
+fn test_transfer_fractions_splits_ownership() {
+    let (env, client, _admin) = setup();
+    let creator = Address::generate(&env);
+    let holder = Address::generate(&env);
+
+    client.mint_fractions(&creator, &100u64, &0i128);
+    client.transfer_fractions(&creator, &creator, &holder, &40u64);
+
+    let creator_pos = client.get_fraction_position(&creator, &creator);
+    let holder_pos = client.get_fraction_position(&creator, &holder);
+
+    assert_eq!(creator_pos.amount, 60);
+    assert_eq!(holder_pos.amount, 40);
+}
+
+#[test]
+fn test_revenue_split_proportional_after_transfer() {
+    let (env, client, _admin) = setup();
+    let creator = Address::generate(&env);
+    let holder = Address::generate(&env);
+
+    client.mint_fractions(&creator, &100u64, &0i128);
+    client.transfer_fractions(&creator, &creator, &holder, &40u64);
+
+    // Accrue 100 units: creator (60%) → 60, holder (40%) → 40
+    client.accrue_revenue(&creator, &100i128);
+
+    let creator_owed = client.claim_fraction_revenue(&creator, &creator);
+    let holder_owed = client.claim_fraction_revenue(&creator, &holder);
+
+    assert_eq!(creator_owed, 60);
+    assert_eq!(holder_owed, 40);
+}
+
+#[test]
+fn test_buyout_consolidates_ownership() {
+    let (env, client, _admin) = setup();
+    let creator = Address::generate(&env);
+    let buyer = Address::generate(&env);
+
+    client.mint_fractions(&creator, &100u64, &5i128);
+    client.transfer_fractions(&creator, &creator, &buyer, &30u64);
+
+    // buyer holds 30, creator holds 70 → buyer buys remaining 70 at 5 each
+    let cost = client.buyout_fractions(&creator, &buyer);
+    assert_eq!(cost, 70 * 5);
+
+    let buyer_pos = client.get_fraction_position(&creator, &buyer);
+    assert_eq!(buyer_pos.amount, 100);
+
+    let creator_pos = client.get_fraction_position(&creator, &creator);
+    assert_eq!(creator_pos.amount, 0);
+}
+
+#[test]
+fn test_no_pool_returns_none() {
+    let (env, client, _admin) = setup();
+    let creator = Address::generate(&env);
+
+    assert!(client.get_fraction_pool(&creator).is_none());
+}
+
+#[test]
+fn test_double_claim_returns_zero() {
+    let (env, client, _admin) = setup();
+    let creator = Address::generate(&env);
+
+    client.mint_fractions(&creator, &100u64, &0i128);
+    client.accrue_revenue(&creator, &500i128);
+
+    client.claim_fraction_revenue(&creator, &creator);
+    let second = client.claim_fraction_revenue(&creator, &creator);
+    assert_eq!(second, 0);
+}


### PR DESCRIPTION
- Add fractional_ownership module with FractionPool and FractionPosition types
- Implement mint_fractions: creator mints a fixed supply of revenue-share fractions
- Implement accrue_revenue: records incoming tip revenue for proportional distribution
- Implement claim_revenue: holder claims their share of accumulated revenue
- Implement transfer_fractions: peer-to-peer fraction transfers with revenue settlement
- Implement buyout: consolidate full ownership by purchasing all outstanding fractions
- Add DataKey variants: FractionPool, FractionPosition, FractionHolders
- Add 9 unit tests covering all five features

Closes #251 