### PR TITLE
feat: implement streaming vesting, Merkle distributor, soulbound tokens, dynamic NFTs (#247-250)

### DIFF
--- a/contracts/tipjar/src/dynamic_nft.rs
+++ b/contracts/tipjar/src/dynamic_nft.rs
@@ -1,0 +1,269 @@
+//! Dynamic NFT module (#250).
+//!
+//! NFTs that evolve based on tipping activity and creator milestones.
+//! Supports trait updates, rarity score calculation, and evolution history.
+
+use soroban_sdk::{contracttype, symbol_short, Address, Env, Map, String, Vec};
+
+use crate::DataKey;
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+/// Rarity tier derived from the rarity score.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum RarityTier {
+    Common,
+    Uncommon,
+    Rare,
+    Epic,
+    Legendary,
+}
+
+/// A dynamic NFT record.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DynamicNft {
+    pub id: u64,
+    pub owner: Address,
+    /// Current evolution level (starts at 0).
+    pub level: u32,
+    /// Trait key→value map (e.g. "color" → "gold").
+    pub traits: Map<String, String>,
+    /// Rarity score in basis points (0–10 000).
+    pub rarity_score: u32,
+    pub rarity_tier: RarityTier,
+    /// Cumulative tips that have contributed to this NFT's evolution.
+    pub total_tips_contributed: i128,
+    pub metadata_uri: String,
+    pub minted_at: u64,
+    pub updated_at: u64,
+}
+
+/// A single evolution history entry.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct EvolutionEvent {
+    pub nft_id: u64,
+    pub old_level: u32,
+    pub new_level: u32,
+    pub old_rarity_score: u32,
+    pub new_rarity_score: u32,
+    pub timestamp: u64,
+    pub trigger: String,
+}
+
+// ── DataKey sub-keys ─────────────────────────────────────────────────────────
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum DynNftKey {
+    Counter,
+    Nft(u64),
+    /// List of NFT IDs owned by an address.
+    OwnerNfts(Address),
+    /// Evolution history list for an NFT.
+    History(u64),
+}
+
+// ── Rarity helpers ────────────────────────────────────────────────────────────
+
+/// Compute rarity score from level and total tips.
+///
+/// Score = min(10_000, level * 500 + tips_bps)
+/// where tips_bps = min(5_000, total_tips / 1_000_000) (1 XLM = 1 point, capped at 5 000).
+pub fn compute_rarity_score(level: u32, total_tips: i128) -> u32 {
+    let level_pts = (level as u32).saturating_mul(500);
+    let tip_pts = (total_tips / 1_000_000).min(5_000) as u32;
+    (level_pts.saturating_add(tip_pts)).min(10_000)
+}
+
+pub fn rarity_tier_from_score(score: u32) -> RarityTier {
+    match score {
+        0..=1999 => RarityTier::Common,
+        2000..=3999 => RarityTier::Uncommon,
+        4000..=5999 => RarityTier::Rare,
+        6000..=7999 => RarityTier::Epic,
+        _ => RarityTier::Legendary,
+    }
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+fn load_nft(env: &Env, id: u64) -> DynamicNft {
+    env.storage()
+        .persistent()
+        .get(&DataKey::DynamicNft(DynNftKey::Nft(id)))
+        .unwrap_or_else(|| panic!("NFT not found"))
+}
+
+fn save_nft(env: &Env, nft: &DynamicNft) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::DynamicNft(DynNftKey::Nft(nft.id)), nft);
+}
+
+fn append_history(env: &Env, event: &EvolutionEvent) {
+    let key = DataKey::DynamicNft(DynNftKey::History(event.nft_id));
+    let mut history: Vec<EvolutionEvent> = env.storage().persistent().get(&key).unwrap_or_else(|| Vec::new(env));
+    history.push_back(event.clone());
+    env.storage().persistent().set(&key, &history);
+}
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+/// Mint a new dynamic NFT.
+///
+/// Returns the NFT ID.
+/// Emits `("dnft_mint",)` with `(id, owner, level, rarity_score)`.
+pub fn mint(
+    env: &Env,
+    owner: &Address,
+    metadata_uri: String,
+    initial_traits: Map<String, String>,
+) -> u64 {
+    let id: u64 = env
+        .storage()
+        .persistent()
+        .get(&DataKey::DynamicNft(DynNftKey::Counter))
+        .unwrap_or(0);
+    env.storage()
+        .persistent()
+        .set(&DataKey::DynamicNft(DynNftKey::Counter), &(id + 1));
+
+    let now = env.ledger().timestamp();
+    let rarity_score = compute_rarity_score(0, 0);
+    let nft = DynamicNft {
+        id,
+        owner: owner.clone(),
+        level: 0,
+        traits: initial_traits,
+        rarity_score,
+        rarity_tier: rarity_tier_from_score(rarity_score),
+        total_tips_contributed: 0,
+        metadata_uri,
+        minted_at: now,
+        updated_at: now,
+    };
+
+    save_nft(env, &nft);
+
+    let mut owned: Vec<u64> = env
+        .storage()
+        .persistent()
+        .get(&DataKey::DynamicNft(DynNftKey::OwnerNfts(owner.clone())))
+        .unwrap_or_else(|| Vec::new(env));
+    owned.push_back(id);
+    env.storage()
+        .persistent()
+        .set(&DataKey::DynamicNft(DynNftKey::OwnerNfts(owner.clone())), &owned);
+
+    env.events().publish(
+        (symbol_short!("dnft_mnt"),),
+        (id, owner.clone(), 0u32, rarity_score),
+    );
+
+    id
+}
+
+/// Record a tip contribution to an NFT and trigger evolution if thresholds are met.
+///
+/// Evolution thresholds (cumulative tips in stroops):
+/// - Level 1: 100 XLM (1_000_000_000)
+/// - Level 2: 500 XLM
+/// - Level 3: 1 000 XLM
+/// - Level 4: 5 000 XLM
+/// - Level 5: 10 000 XLM (max)
+///
+/// Emits `("dnft_tip",)` with `(id, tip_amount, new_total)`.
+/// Emits `("dnft_evo",)` with `(id, old_level, new_level, new_rarity_score)` on evolution.
+pub fn record_tip(env: &Env, nft_id: u64, tip_amount: i128) {
+    let mut nft = load_nft(env, nft_id);
+    nft.total_tips_contributed = nft.total_tips_contributed.saturating_add(tip_amount);
+
+    let new_level = level_for_tips(nft.total_tips_contributed);
+    let new_score = compute_rarity_score(new_level, nft.total_tips_contributed);
+
+    if new_level > nft.level {
+        let event = EvolutionEvent {
+            nft_id,
+            old_level: nft.level,
+            new_level,
+            old_rarity_score: nft.rarity_score,
+            new_rarity_score: new_score,
+            timestamp: env.ledger().timestamp(),
+            trigger: String::from_str(env, "tip"),
+        };
+        append_history(env, &event);
+
+        env.events().publish(
+            (symbol_short!("dnft_evo"),),
+            (nft_id, nft.level, new_level, new_score),
+        );
+
+        nft.level = new_level;
+    }
+
+    nft.rarity_score = new_score;
+    nft.rarity_tier = rarity_tier_from_score(new_score);
+    nft.updated_at = env.ledger().timestamp();
+    save_nft(env, &nft);
+
+    env.events().publish(
+        (symbol_short!("dnft_tip"),),
+        (nft_id, tip_amount, nft.total_tips_contributed),
+    );
+}
+
+fn level_for_tips(total: i128) -> u32 {
+    const XLM: i128 = 10_000_000; // 1 XLM in stroops
+    if total >= 10_000 * XLM { 5 }
+    else if total >= 5_000 * XLM { 4 }
+    else if total >= 1_000 * XLM { 3 }
+    else if total >= 500 * XLM { 2 }
+    else if total >= 100 * XLM { 1 }
+    else { 0 }
+}
+
+/// Update a trait on an NFT. Only the owner may call (enforced in lib.rs).
+///
+/// Emits `("dnft_trait",)` with `(id, key, value)`.
+pub fn update_trait(env: &Env, nft_id: u64, key: String, value: String) {
+    let mut nft = load_nft(env, nft_id);
+    nft.traits.set(key.clone(), value.clone());
+    nft.updated_at = env.ledger().timestamp();
+    save_nft(env, &nft);
+    env.events().publish(
+        (symbol_short!("dnft_trt"),),
+        (nft_id, key, value),
+    );
+}
+
+/// Update the metadata URI. Only the owner may call (enforced in lib.rs).
+pub fn update_metadata(env: &Env, nft_id: u64, metadata_uri: String) {
+    let mut nft = load_nft(env, nft_id);
+    nft.metadata_uri = metadata_uri;
+    nft.updated_at = env.ledger().timestamp();
+    save_nft(env, &nft);
+}
+
+/// Returns the NFT record.
+pub fn get_nft(env: &Env, nft_id: u64) -> DynamicNft {
+    load_nft(env, nft_id)
+}
+
+/// Returns all NFT IDs owned by `owner`.
+pub fn get_owner_nfts(env: &Env, owner: &Address) -> Vec<u64> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::DynamicNft(DynNftKey::OwnerNfts(owner.clone())))
+        .unwrap_or_else(|| Vec::new(env))
+}
+
+/// Returns the evolution history for an NFT.
+pub fn get_evolution_history(env: &Env, nft_id: u64) -> Vec<EvolutionEvent> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::DynamicNft(DynNftKey::History(nft_id)))
+        .unwrap_or_else(|| Vec::new(env))
+}

--- a/contracts/tipjar/src/lib.rs
+++ b/contracts/tipjar/src/lib.rs
@@ -85,6 +85,18 @@ pub mod twap_oracle;
 // Tip payment channels
 pub mod payment_channel;
 
+// Streaming vesting (#247)
+pub mod streaming_vesting;
+
+// Merkle distributor (#248)
+pub mod merkle_distributor;
+
+// Soulbound tokens (#249)
+pub mod soulbound_token;
+
+// Dynamic NFTs (#250)
+pub mod dynamic_nft;
+
 /// A tip record that includes an optional memo and timestamp.
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -851,6 +863,14 @@ pub enum DataKey {
     PaymentChannel(Address, Address, Address),
     /// Global counter for payment channel IDs.
     ChannelCounter,
+    /// Streaming vesting stream keyed by sub-key.
+    VestingStream(streaming_vesting::VestingStreamKey),
+    /// Merkle distributor keyed by sub-key.
+    MerkleDistributor(merkle_distributor::MerkleKey),
+    /// Soulbound token keyed by sub-key.
+    SoulboundToken(soulbound_token::SbtKey),
+    /// Dynamic NFT keyed by sub-key.
+    DynamicNft(dynamic_nft::DynNftKey),
 }
 
 #[contracterror]
@@ -8862,6 +8882,225 @@ a
         let finalized_batches: u64 = env.storage().instance().get(&DataKey::RollupFinalizedCount).unwrap_or(0);
         let challenged_batches: u64 = env.storage().instance().get(&DataKey::RollupChallengedCount).unwrap_or(0);
         rollup::RollupState { enabled, sequencer, challenge_period, pending_batches, finalized_batches, challenged_batches }
+    }
+
+    // ── Streaming Vesting (#247) ──────────────────────────────────────────────
+
+    /// Create a streaming vesting position.
+    ///
+    /// Tokens unlock linearly per second over `duration_seconds`.
+    /// Transfers `total_amount` of `token` from `sender` into escrow.
+    /// Returns the stream ID.
+    pub fn sv_create(
+        env: Env,
+        sender: Address,
+        recipient: Address,
+        token: Address,
+        total_amount: i128,
+        duration_seconds: u64,
+    ) -> u64 {
+        Self::require_not_paused(&env);
+        sender.require_auth();
+        let whitelisted: bool = env.storage().instance()
+            .get(&DataKey::TokenWhitelist(token.clone())).unwrap_or(false);
+        if !whitelisted { panic_with_error!(&env, TipJarError::TokenNotWhitelisted); }
+        streaming_vesting::create(&env, &sender, &recipient, &token, total_amount, duration_seconds)
+    }
+
+    /// Withdraw all currently vested tokens for a streaming vesting stream.
+    ///
+    /// Returns the amount withdrawn.
+    pub fn sv_withdraw(env: Env, recipient: Address, stream_id: u64) -> i128 {
+        Self::require_not_paused(&env);
+        recipient.require_auth();
+        streaming_vesting::withdraw(&env, &recipient, stream_id)
+    }
+
+    /// Cancel a streaming vesting stream. Only the original sender may cancel.
+    ///
+    /// Vested-but-unwithdrawn tokens go to the recipient; unvested tokens are refunded to sender.
+    pub fn sv_cancel(env: Env, sender: Address, stream_id: u64) {
+        Self::require_not_paused(&env);
+        sender.require_auth();
+        streaming_vesting::cancel(&env, &sender, stream_id)
+    }
+
+    /// Returns the amount currently available to withdraw for a stream.
+    pub fn sv_available(env: Env, stream_id: u64) -> i128 {
+        streaming_vesting::available_to_withdraw(&env, stream_id)
+    }
+
+    /// Returns the streaming vesting stream record.
+    pub fn sv_get_stream(env: Env, stream_id: u64) -> streaming_vesting::VestingStream {
+        streaming_vesting::get_stream(&env, stream_id)
+    }
+
+    /// Returns all stream IDs for a recipient.
+    pub fn sv_get_recipient_streams(env: Env, recipient: Address) -> Vec<u64> {
+        streaming_vesting::get_recipient_streams(&env, &recipient)
+    }
+
+    /// Returns all stream IDs for a sender.
+    pub fn sv_get_sender_streams(env: Env, sender: Address) -> Vec<u64> {
+        streaming_vesting::get_sender_streams(&env, &sender)
+    }
+
+    // ── Merkle Distributor (#248) ─────────────────────────────────────────────
+
+    /// Create a Merkle distribution campaign.
+    ///
+    /// Transfers `total_amount` of `token` from `creator` into escrow.
+    /// Returns the distribution ID.
+    pub fn md_create(
+        env: Env,
+        creator: Address,
+        token: Address,
+        root: BytesN<32>,
+        total_amount: i128,
+    ) -> u64 {
+        Self::require_not_paused(&env);
+        creator.require_auth();
+        let whitelisted: bool = env.storage().instance()
+            .get(&DataKey::TokenWhitelist(token.clone())).unwrap_or(false);
+        if !whitelisted { panic_with_error!(&env, TipJarError::TokenNotWhitelisted); }
+        merkle_distributor::create_distribution(&env, &creator, &token, root, total_amount)
+    }
+
+    /// Claim an allocation from a Merkle distribution.
+    ///
+    /// `proof` is an ordered list of sibling hashes from leaf to root.
+    pub fn md_claim(
+        env: Env,
+        distribution_id: u64,
+        recipient: Address,
+        amount: i128,
+        proof: Vec<BytesN<32>>,
+    ) {
+        Self::require_not_paused(&env);
+        recipient.require_auth();
+        merkle_distributor::claim(&env, distribution_id, &recipient, amount, proof)
+    }
+
+    /// Deactivate a Merkle distribution. Admin only.
+    pub fn md_deactivate(env: Env, admin: Address, distribution_id: u64) {
+        admin.require_auth();
+        let stored_admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+        if admin != stored_admin { panic_with_error!(&env, TipJarError::Unauthorized); }
+        merkle_distributor::deactivate(&env, distribution_id)
+    }
+
+    /// Returns whether `recipient` has already claimed from `distribution_id`.
+    pub fn md_is_claimed(env: Env, distribution_id: u64, recipient: Address) -> bool {
+        merkle_distributor::is_claimed(&env, distribution_id, &recipient)
+    }
+
+    /// Returns the Merkle distribution record.
+    pub fn md_get_distribution(env: Env, distribution_id: u64) -> merkle_distributor::MerkleDistribution {
+        merkle_distributor::get_distribution(&env, distribution_id)
+    }
+
+    // ── Soulbound Tokens (#249) ───────────────────────────────────────────────
+
+    /// Mint a soulbound token to `owner`. Admin only.
+    ///
+    /// Returns the token ID.
+    pub fn sbt_mint(
+        env: Env,
+        admin: Address,
+        owner: Address,
+        achievement: String,
+        metadata: String,
+    ) -> u64 {
+        admin.require_auth();
+        let stored_admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+        if admin != stored_admin { panic_with_error!(&env, TipJarError::Unauthorized); }
+        soulbound_token::mint(&env, &owner, achievement, metadata)
+    }
+
+    /// Revoke a soulbound token. Admin only.
+    pub fn sbt_revoke(env: Env, admin: Address, token_id: u64) {
+        admin.require_auth();
+        let stored_admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+        if admin != stored_admin { panic_with_error!(&env, TipJarError::Unauthorized); }
+        soulbound_token::revoke(&env, token_id)
+    }
+
+    /// Returns the soulbound token record.
+    pub fn sbt_get(env: Env, token_id: u64) -> soulbound_token::SoulboundToken {
+        soulbound_token::get_token(&env, token_id)
+    }
+
+    /// Returns all SBT IDs owned by `owner`.
+    pub fn sbt_get_owner_tokens(env: Env, owner: Address) -> Vec<u64> {
+        soulbound_token::get_owner_tokens(&env, &owner)
+    }
+
+    /// Returns `true` if `owner` holds a non-revoked SBT for `achievement`.
+    pub fn sbt_has_achievement(env: Env, owner: Address, achievement: String) -> bool {
+        soulbound_token::has_achievement(&env, &owner, &achievement)
+    }
+
+    // ── Dynamic NFTs (#250) ───────────────────────────────────────────────────
+
+    /// Mint a dynamic NFT. Admin only.
+    ///
+    /// Returns the NFT ID.
+    pub fn dnft_mint(
+        env: Env,
+        admin: Address,
+        owner: Address,
+        metadata_uri: String,
+        initial_traits: Map<String, String>,
+    ) -> u64 {
+        admin.require_auth();
+        let stored_admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+        if admin != stored_admin { panic_with_error!(&env, TipJarError::Unauthorized); }
+        dynamic_nft::mint(&env, &owner, metadata_uri, initial_traits)
+    }
+
+    /// Record a tip contribution to a dynamic NFT, potentially triggering evolution.
+    ///
+    /// Anyone may call this to associate a tip with an NFT.
+    pub fn dnft_record_tip(env: Env, nft_id: u64, tip_amount: i128) {
+        if tip_amount <= 0 { panic_with_error!(&env, TipJarError::InvalidAmount); }
+        dynamic_nft::record_tip(&env, nft_id, tip_amount)
+    }
+
+    /// Update a trait on a dynamic NFT. Only the NFT owner may call.
+    pub fn dnft_update_trait(
+        env: Env,
+        owner: Address,
+        nft_id: u64,
+        key: String,
+        value: String,
+    ) {
+        owner.require_auth();
+        let nft = dynamic_nft::get_nft(&env, nft_id);
+        if nft.owner != owner { panic_with_error!(&env, TipJarError::Unauthorized); }
+        dynamic_nft::update_trait(&env, nft_id, key, value)
+    }
+
+    /// Update the metadata URI of a dynamic NFT. Only the NFT owner may call.
+    pub fn dnft_update_metadata(env: Env, owner: Address, nft_id: u64, metadata_uri: String) {
+        owner.require_auth();
+        let nft = dynamic_nft::get_nft(&env, nft_id);
+        if nft.owner != owner { panic_with_error!(&env, TipJarError::Unauthorized); }
+        dynamic_nft::update_metadata(&env, nft_id, metadata_uri)
+    }
+
+    /// Returns the dynamic NFT record.
+    pub fn dnft_get(env: Env, nft_id: u64) -> dynamic_nft::DynamicNft {
+        dynamic_nft::get_nft(&env, nft_id)
+    }
+
+    /// Returns all NFT IDs owned by `owner`.
+    pub fn dnft_get_owner_nfts(env: Env, owner: Address) -> Vec<u64> {
+        dynamic_nft::get_owner_nfts(&env, &owner)
+    }
+
+    /// Returns the evolution history for a dynamic NFT.
+    pub fn dnft_get_history(env: Env, nft_id: u64) -> Vec<dynamic_nft::EvolutionEvent> {
+        dynamic_nft::get_evolution_history(&env, nft_id)
     }
 }
 

--- a/contracts/tipjar/src/merkle_distributor.rs
+++ b/contracts/tipjar/src/merkle_distributor.rs
@@ -1,0 +1,218 @@
+//! Merkle distributor module (#248).
+//!
+//! Gas-efficient batch tip claims using a Merkle tree.
+//! The admin commits a Merkle root; claimants supply a proof to claim their allocation.
+
+use soroban_sdk::{contracttype, symbol_short, token, Address, Bytes, BytesN, Env, Vec};
+
+use crate::DataKey;
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+/// A Merkle distribution campaign.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct MerkleDistribution {
+    pub id: u64,
+    /// SHA-256 Merkle root of (recipient || amount) leaves.
+    pub root: BytesN<32>,
+    pub token: Address,
+    /// Total tokens deposited for this distribution.
+    pub total_amount: i128,
+    /// Tokens already claimed.
+    pub claimed_amount: i128,
+    pub created_at: u64,
+    pub active: bool,
+}
+
+// ── DataKey sub-keys ─────────────────────────────────────────────────────────
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum MerkleKey {
+    Counter,
+    Distribution(u64),
+    /// Whether (distribution_id, recipient) has already claimed.
+    Claimed(u64, Address),
+}
+
+// ── Leaf hashing ─────────────────────────────────────────────────────────────
+
+/// Compute the leaf hash for `(recipient, amount)`.
+///
+/// Leaf = SHA-256(recipient_xdr_bytes || amount_le_bytes)
+fn leaf_hash(env: &Env, recipient: &Address, amount: i128) -> BytesN<32> {
+    let mut data = Bytes::new(env);
+    // Encode recipient via XDR serialisation.
+    let addr_bytes = recipient.to_xdr(env);
+    data.append(&addr_bytes);
+    let amount_bytes = Bytes::from_array(env, &amount.to_le_bytes());
+    data.append(&amount_bytes);
+    env.crypto().sha256(&data)
+}
+
+/// Verify a Merkle proof.
+///
+/// `proof` is an ordered list of sibling hashes from leaf to root.
+/// Standard binary Merkle tree: at each level, sort the two children
+/// (smaller hash first) before hashing.
+pub fn verify_proof(
+    env: &Env,
+    root: &BytesN<32>,
+    recipient: &Address,
+    amount: i128,
+    proof: &Vec<BytesN<32>>,
+) -> bool {
+    let mut current = leaf_hash(env, recipient, amount);
+
+    for sibling in proof.iter() {
+        // Sort: smaller hash goes first to ensure deterministic ordering.
+        // Compare by converting to Bytes for ordering.
+        let mut data = Bytes::new(env);
+        let cur_bytes: Bytes = current.clone().into();
+        let sib_bytes: Bytes = sibling.clone().into();
+        if cur_bytes <= sib_bytes {
+            data.append(&cur_bytes);
+            data.append(&sib_bytes);
+        } else {
+            data.append(&sib_bytes);
+            data.append(&cur_bytes);
+        }
+        current = env.crypto().sha256(&data);
+    }
+
+    &current == root
+}
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+/// Create a new Merkle distribution.
+///
+/// Transfers `total_amount` of `token` from `creator` into escrow.
+/// Returns the distribution ID.
+/// Emits `("md_create",)` with `(id, root, token, total_amount)`.
+pub fn create_distribution(
+    env: &Env,
+    creator: &Address,
+    token_addr: &Address,
+    root: BytesN<32>,
+    total_amount: i128,
+) -> u64 {
+    assert!(total_amount > 0, "amount must be positive");
+
+    let id: u64 = env
+        .storage()
+        .persistent()
+        .get(&DataKey::MerkleDistributor(MerkleKey::Counter))
+        .unwrap_or(0);
+    env.storage()
+        .persistent()
+        .set(&DataKey::MerkleDistributor(MerkleKey::Counter), &(id + 1));
+
+    let dist = MerkleDistribution {
+        id,
+        root,
+        token: token_addr.clone(),
+        total_amount,
+        claimed_amount: 0,
+        created_at: env.ledger().timestamp(),
+        active: true,
+    };
+
+    env.storage()
+        .persistent()
+        .set(&DataKey::MerkleDistributor(MerkleKey::Distribution(id)), &dist);
+
+    token::Client::new(env, token_addr).transfer(creator, &env.current_contract_address(), &total_amount);
+
+    env.events().publish(
+        (symbol_short!("md_crt"),),
+        (id, dist.root.clone(), token_addr.clone(), total_amount),
+    );
+
+    id
+}
+
+/// Claim an allocation from a Merkle distribution.
+///
+/// Verifies the proof, marks the claim, and transfers `amount` to `recipient`.
+/// Panics if already claimed, proof invalid, or insufficient funds.
+/// Emits `("md_claim",)` with `(distribution_id, recipient, amount)`.
+pub fn claim(
+    env: &Env,
+    distribution_id: u64,
+    recipient: &Address,
+    amount: i128,
+    proof: Vec<BytesN<32>>,
+) {
+    assert!(amount > 0, "amount must be positive");
+
+    let claimed_key = DataKey::MerkleDistributor(MerkleKey::Claimed(distribution_id, recipient.clone()));
+    let already_claimed: bool = env.storage().persistent().get(&claimed_key).unwrap_or(false);
+    assert!(!already_claimed, "already claimed");
+
+    let mut dist: MerkleDistribution = env
+        .storage()
+        .persistent()
+        .get(&DataKey::MerkleDistributor(MerkleKey::Distribution(distribution_id)))
+        .unwrap_or_else(|| panic!("distribution not found"));
+
+    assert!(dist.active, "distribution not active");
+    assert!(
+        verify_proof(env, &dist.root, recipient, amount, &proof),
+        "invalid proof"
+    );
+    assert!(
+        dist.claimed_amount.saturating_add(amount) <= dist.total_amount,
+        "insufficient funds"
+    );
+
+    // Mark claimed before transfer (CEI).
+    env.storage().persistent().set(&claimed_key, &true);
+    dist.claimed_amount = dist.claimed_amount.saturating_add(amount);
+    env.storage()
+        .persistent()
+        .set(&DataKey::MerkleDistributor(MerkleKey::Distribution(distribution_id)), &dist);
+
+    token::Client::new(env, &dist.token).transfer(
+        &env.current_contract_address(),
+        recipient,
+        &amount,
+    );
+
+    env.events().publish(
+        (symbol_short!("md_clm"),),
+        (distribution_id, recipient.clone(), amount),
+    );
+}
+
+/// Deactivate a distribution (admin). Remaining unclaimed tokens stay in contract.
+/// Emits `("md_deact",)` with `(distribution_id,)`.
+pub fn deactivate(env: &Env, distribution_id: u64) {
+    let mut dist: MerkleDistribution = env
+        .storage()
+        .persistent()
+        .get(&DataKey::MerkleDistributor(MerkleKey::Distribution(distribution_id)))
+        .unwrap_or_else(|| panic!("distribution not found"));
+    dist.active = false;
+    env.storage()
+        .persistent()
+        .set(&DataKey::MerkleDistributor(MerkleKey::Distribution(distribution_id)), &dist);
+    env.events().publish((symbol_short!("md_dea"),), (distribution_id,));
+}
+
+/// Returns whether `recipient` has already claimed from `distribution_id`.
+pub fn is_claimed(env: &Env, distribution_id: u64, recipient: &Address) -> bool {
+    env.storage()
+        .persistent()
+        .get(&DataKey::MerkleDistributor(MerkleKey::Claimed(distribution_id, recipient.clone())))
+        .unwrap_or(false)
+}
+
+/// Returns the distribution record.
+pub fn get_distribution(env: &Env, distribution_id: u64) -> MerkleDistribution {
+    env.storage()
+        .persistent()
+        .get(&DataKey::MerkleDistributor(MerkleKey::Distribution(distribution_id)))
+        .unwrap_or_else(|| panic!("distribution not found"))
+}

--- a/contracts/tipjar/src/soulbound_token.rs
+++ b/contracts/tipjar/src/soulbound_token.rs
@@ -1,0 +1,141 @@
+//! Soulbound token (SBT) module (#249).
+//!
+//! Non-transferable tokens representing tip achievements and milestones.
+//! Supports minting, achievement tracking, revocation, and metadata storage.
+
+use soroban_sdk::{contracttype, symbol_short, Address, Env, String, Vec};
+
+use crate::DataKey;
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+/// A soulbound token record.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SoulboundToken {
+    pub id: u64,
+    /// The address this SBT is bound to (non-transferable).
+    pub owner: Address,
+    /// Achievement category (e.g. "top_tipper", "milestone_100").
+    pub achievement: String,
+    /// Optional metadata URI or JSON string.
+    pub metadata: String,
+    pub minted_at: u64,
+    pub revoked: bool,
+}
+
+// ── DataKey sub-keys ─────────────────────────────────────────────────────────
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum SbtKey {
+    Counter,
+    Token(u64),
+    /// List of SBT IDs owned by an address.
+    OwnerTokens(Address),
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+fn load_token(env: &Env, id: u64) -> SoulboundToken {
+    env.storage()
+        .persistent()
+        .get(&DataKey::SoulboundToken(SbtKey::Token(id)))
+        .unwrap_or_else(|| panic!("SBT not found"))
+}
+
+fn save_token(env: &Env, token: &SoulboundToken) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::SoulboundToken(SbtKey::Token(token.id)), token);
+}
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+/// Mint a new soulbound token to `owner`.
+///
+/// Returns the token ID.
+/// Emits `("sbt_mint",)` with `(id, owner, achievement)`.
+pub fn mint(
+    env: &Env,
+    owner: &Address,
+    achievement: String,
+    metadata: String,
+) -> u64 {
+    let id: u64 = env
+        .storage()
+        .persistent()
+        .get(&DataKey::SoulboundToken(SbtKey::Counter))
+        .unwrap_or(0);
+    env.storage()
+        .persistent()
+        .set(&DataKey::SoulboundToken(SbtKey::Counter), &(id + 1));
+
+    let sbt = SoulboundToken {
+        id,
+        owner: owner.clone(),
+        achievement: achievement.clone(),
+        metadata,
+        minted_at: env.ledger().timestamp(),
+        revoked: false,
+    };
+
+    save_token(env, &sbt);
+
+    // Track owner's tokens.
+    let mut tokens: Vec<u64> = env
+        .storage()
+        .persistent()
+        .get(&DataKey::SoulboundToken(SbtKey::OwnerTokens(owner.clone())))
+        .unwrap_or_else(|| Vec::new(env));
+    tokens.push_back(id);
+    env.storage()
+        .persistent()
+        .set(&DataKey::SoulboundToken(SbtKey::OwnerTokens(owner.clone())), &tokens);
+
+    env.events().publish(
+        (symbol_short!("sbt_mnt"),),
+        (id, owner.clone(), achievement),
+    );
+
+    id
+}
+
+/// Revoke a soulbound token. Only callable by the contract admin (enforced in lib.rs).
+///
+/// Emits `("sbt_rev",)` with `(id, owner)`.
+pub fn revoke(env: &Env, token_id: u64) {
+    let mut sbt = load_token(env, token_id);
+    assert!(!sbt.revoked, "already revoked");
+    sbt.revoked = true;
+    save_token(env, &sbt);
+    env.events().publish(
+        (symbol_short!("sbt_rev"),),
+        (token_id, sbt.owner),
+    );
+}
+
+/// Returns the SBT record.
+pub fn get_token(env: &Env, token_id: u64) -> SoulboundToken {
+    load_token(env, token_id)
+}
+
+/// Returns all SBT IDs owned by `owner`.
+pub fn get_owner_tokens(env: &Env, owner: &Address) -> Vec<u64> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::SoulboundToken(SbtKey::OwnerTokens(owner.clone())))
+        .unwrap_or_else(|| Vec::new(env))
+}
+
+/// Returns `true` if `owner` holds a non-revoked SBT for `achievement`.
+pub fn has_achievement(env: &Env, owner: &Address, achievement: &String) -> bool {
+    let ids = get_owner_tokens(env, owner);
+    for id in ids.iter() {
+        let sbt = load_token(env, id);
+        if !sbt.revoked && &sbt.achievement == achievement {
+            return true;
+        }
+    }
+    false
+}

--- a/contracts/tipjar/src/streaming_vesting.rs
+++ b/contracts/tipjar/src/streaming_vesting.rs
@@ -1,0 +1,241 @@
+//! Streaming vesting module (#247).
+//!
+//! Tips unlock continuously per second over a vesting period.
+//! Supports cancellation (refunds unvested portion to sender) and partial withdrawals.
+
+use soroban_sdk::{contracttype, symbol_short, token, Address, Env, Vec};
+
+use crate::DataKey;
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+/// Status of a streaming vesting position.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum VestingStreamStatus {
+    Active,
+    Cancelled,
+    Completed,
+}
+
+/// A streaming vesting record: tokens unlock linearly per second.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct VestingStream {
+    pub id: u64,
+    pub sender: Address,
+    pub recipient: Address,
+    pub token: Address,
+    /// Total tokens deposited into this stream.
+    pub total_amount: i128,
+    /// Tokens already withdrawn by the recipient.
+    pub withdrawn: i128,
+    /// Unix timestamp when streaming begins.
+    pub start_time: u64,
+    /// Unix timestamp when streaming ends (all tokens fully vested).
+    pub end_time: u64,
+    pub status: VestingStreamStatus,
+    pub created_at: u64,
+}
+
+// ── DataKey sub-keys ─────────────────────────────────────────────────────────
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum VestingStreamKey {
+    /// Global counter for stream IDs.
+    Counter,
+    /// Individual stream record keyed by ID.
+    Record(u64),
+    /// List of stream IDs where `address` is the recipient.
+    RecipientStreams(Address),
+    /// List of stream IDs where `address` is the sender.
+    SenderStreams(Address),
+}
+
+// ── Internal helpers ─────────────────────────────────────────────────────────
+
+/// Compute how many tokens have vested up to `now`.
+fn vested_at(stream: &VestingStream, now: u64) -> i128 {
+    if now <= stream.start_time {
+        return 0;
+    }
+    let duration = stream.end_time.saturating_sub(stream.start_time);
+    if duration == 0 {
+        return stream.total_amount;
+    }
+    let elapsed = now.min(stream.end_time).saturating_sub(stream.start_time);
+    (stream.total_amount * elapsed as i128) / duration as i128
+}
+
+fn load_stream(env: &Env, id: u64) -> VestingStream {
+    env.storage()
+        .persistent()
+        .get(&DataKey::VestingStream(VestingStreamKey::Record(id)))
+        .unwrap_or_else(|| panic!("VestingStream not found"))
+}
+
+fn save_stream(env: &Env, stream: &VestingStream) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::VestingStream(VestingStreamKey::Record(stream.id)), stream);
+}
+
+fn push_to_list(env: &Env, key: DataKey, id: u64) {
+    let mut list: Vec<u64> = env.storage().persistent().get(&key).unwrap_or_else(|| Vec::new(env));
+    list.push_back(id);
+    env.storage().persistent().set(&key, &list);
+}
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+/// Create a new streaming vesting position.
+///
+/// Transfers `total_amount` of `token` from `sender` into escrow.
+/// `duration_seconds` must be > 0.
+/// Returns the stream ID.
+/// Emits `("vs_create",)` with `(id, sender, recipient, total_amount, end_time)`.
+pub fn create(
+    env: &Env,
+    sender: &Address,
+    recipient: &Address,
+    token_addr: &Address,
+    total_amount: i128,
+    duration_seconds: u64,
+) -> u64 {
+    assert!(total_amount > 0, "amount must be positive");
+    assert!(duration_seconds > 0, "duration must be positive");
+
+    let id: u64 = env
+        .storage()
+        .persistent()
+        .get(&DataKey::VestingStream(VestingStreamKey::Counter))
+        .unwrap_or(0);
+    env.storage()
+        .persistent()
+        .set(&DataKey::VestingStream(VestingStreamKey::Counter), &(id + 1));
+
+    let now = env.ledger().timestamp();
+    let stream = VestingStream {
+        id,
+        sender: sender.clone(),
+        recipient: recipient.clone(),
+        token: token_addr.clone(),
+        total_amount,
+        withdrawn: 0,
+        start_time: now,
+        end_time: now.saturating_add(duration_seconds),
+        status: VestingStreamStatus::Active,
+        created_at: now,
+    };
+
+    save_stream(env, &stream);
+    push_to_list(env, DataKey::VestingStream(VestingStreamKey::RecipientStreams(recipient.clone())), id);
+    push_to_list(env, DataKey::VestingStream(VestingStreamKey::SenderStreams(sender.clone())), id);
+
+    token::Client::new(env, token_addr).transfer(sender, &env.current_contract_address(), &total_amount);
+
+    env.events().publish(
+        (symbol_short!("vs_crt"),),
+        (id, sender.clone(), recipient.clone(), total_amount, stream.end_time),
+    );
+
+    id
+}
+
+/// Withdraw all currently vested (but not yet withdrawn) tokens to the recipient.
+///
+/// Returns the amount withdrawn.
+/// Emits `("vs_wdr",)` with `(id, recipient, amount)`.
+pub fn withdraw(env: &Env, recipient: &Address, stream_id: u64) -> i128 {
+    let mut stream = load_stream(env, stream_id);
+    assert!(&stream.recipient == recipient, "unauthorized");
+    assert!(stream.status == VestingStreamStatus::Active, "stream not active");
+
+    let now = env.ledger().timestamp();
+    let vested = vested_at(&stream, now);
+    let available = vested.saturating_sub(stream.withdrawn);
+    assert!(available > 0, "nothing to withdraw");
+
+    stream.withdrawn = stream.withdrawn.saturating_add(available);
+    if now >= stream.end_time {
+        stream.status = VestingStreamStatus::Completed;
+    }
+    save_stream(env, &stream);
+
+    token::Client::new(env, &stream.token).transfer(
+        &env.current_contract_address(),
+        recipient,
+        &available,
+    );
+
+    env.events().publish(
+        (symbol_short!("vs_wdr"),),
+        (stream_id, recipient.clone(), available),
+    );
+
+    available
+}
+
+/// Cancel a stream. Only the original sender may cancel.
+///
+/// Transfers vested-but-unwithdrawn tokens to the recipient and refunds
+/// the unvested remainder to the sender.
+/// Emits `("vs_cancel",)` with `(id, refunded_to_sender, paid_to_recipient)`.
+pub fn cancel(env: &Env, sender: &Address, stream_id: u64) {
+    let mut stream = load_stream(env, stream_id);
+    assert!(&stream.sender == sender, "unauthorized");
+    assert!(stream.status == VestingStreamStatus::Active, "stream not active");
+
+    let now = env.ledger().timestamp();
+    let vested = vested_at(&stream, now);
+    let recipient_amount = vested.saturating_sub(stream.withdrawn);
+    let sender_refund = stream.total_amount.saturating_sub(vested);
+
+    stream.status = VestingStreamStatus::Cancelled;
+    save_stream(env, &stream);
+
+    let tok = token::Client::new(env, &stream.token);
+    if recipient_amount > 0 {
+        tok.transfer(&env.current_contract_address(), &stream.recipient, &recipient_amount);
+    }
+    if sender_refund > 0 {
+        tok.transfer(&env.current_contract_address(), sender, &sender_refund);
+    }
+
+    env.events().publish(
+        (symbol_short!("vs_can"),),
+        (stream_id, sender_refund, recipient_amount),
+    );
+}
+
+/// Returns the amount currently available to withdraw for a stream.
+pub fn available_to_withdraw(env: &Env, stream_id: u64) -> i128 {
+    let stream = load_stream(env, stream_id);
+    if stream.status != VestingStreamStatus::Active {
+        return 0;
+    }
+    let vested = vested_at(&stream, env.ledger().timestamp());
+    vested.saturating_sub(stream.withdrawn)
+}
+
+/// Returns the stream record.
+pub fn get_stream(env: &Env, stream_id: u64) -> VestingStream {
+    load_stream(env, stream_id)
+}
+
+/// Returns all stream IDs for a recipient.
+pub fn get_recipient_streams(env: &Env, recipient: &Address) -> Vec<u64> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::VestingStream(VestingStreamKey::RecipientStreams(recipient.clone())))
+        .unwrap_or_else(|| Vec::new(env))
+}
+
+/// Returns all stream IDs for a sender.
+pub fn get_sender_streams(env: &Env, sender: &Address) -> Vec<u64> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::VestingStream(VestingStreamKey::SenderStreams(sender.clone())))
+        .unwrap_or_else(|| Vec::new(env))
+}


### PR DESCRIPTION
## Summary

Implements all four features requested in issues #247, #248, #249, and #250 in a single PR.

---

### #247 — Streaming Vesting (`streaming_vesting.rs`)

Tokens unlock continuously per second over a configurable duration.

- `sv_create` — deposit tokens into a vesting stream
- `sv_withdraw` — recipient withdraws currently vested amount (partial withdrawals supported)
- `sv_cancel` — sender cancels; vested portion goes to recipient, unvested refunded to sender
- `sv_available` / `sv_get_stream` / `sv_get_recipient_streams` / `sv_get_sender_streams`

### #248 — Merkle Distributor (`merkle_distributor.rs`)

Gas-efficient batch tip claims via a Merkle tree committed on-chain.

- `md_create` — admin commits a Merkle root and deposits total allocation
- `md_claim` — claimant supplies a proof to claim their allocation (duplicate-claim prevented)
- `md_deactivate` — admin deactivates a distribution
- `md_is_claimed` / `md_get_distribution`

### #249 — Soulbound Tokens (`soulbound_token.rs`)

Non-transferable tokens representing tip achievements and milestones.

- `sbt_mint` — admin mints an SBT to an owner with an achievement tag and metadata
- `sbt_revoke` — admin revokes an SBT
- `sbt_get` / `sbt_get_owner_tokens` / `sbt_has_achievement`
- Transfer is prevented by design (no transfer method exists)

### #250 — Dynamic NFTs (`dynamic_nft.rs`)

NFTs that evolve based on tipping activity.

- `dnft_mint` — admin mints an NFT with initial traits
- `dnft_record_tip` — records a tip contribution; triggers level-up and rarity recalculation at thresholds (100/500/1k/5k/10k XLM)
- `dnft_update_trait` / `dnft_update_metadata` — owner updates traits/metadata
- `dnft_get` / `dnft_get_owner_nfts` / `dnft_get_history`
- Rarity tiers: Common → Uncommon → Rare → Epic → Legendary

---

## Changes

- `contracts/tipjar/src/streaming_vesting.rs` (new)
- `contracts/tipjar/src/merkle_distributor.rs` (new)
- `contracts/tipjar/src/soulbound_token.rs` (new)
- `contracts/tipjar/src/dynamic_nft.rs` (new)
- `contracts/tipjar/src/lib.rs` — added `pub mod` declarations, four new `DataKey` variants, and contract entry-point methods (`sv_*`, `md_*`, `sbt_*`, `dnft_*`)

Closes #247
Closes #248
Closes #249
Closes #250