### PR TITLE
feat: implement tip derivatives platform

### DIFF
--- a/contracts/tipjar/Cargo.toml
+++ b/contracts/tipjar/Cargo.toml
@@ -98,3 +98,7 @@ path = "tests/fractional_ownership_tests.rs"
 [[test]]
 name = "royalty_split_tests"
 path = "tests/royalty_split_tests.rs"
+
+[[test]]
+name = "derivatives_tests"
+path = "tests/derivatives_tests.rs"

--- a/contracts/tipjar/src/derivatives/mod.rs
+++ b/contracts/tipjar/src/derivatives/mod.rs
@@ -1,0 +1,477 @@
+//! Tip Derivatives Platform
+//!
+//! Unified module for complex tip-based financial instruments:
+//! - **TipOption**: call/put options on tip token amounts
+//! - **TipFuture**: forward contracts on tip delivery
+//! - **TipSwap**: fixed-for-floating tip rate swaps
+//!
+//! Each instrument goes through a lifecycle:
+//! `Open → Active → (Exercised | Settled | Expired | Liquidated)`
+//!
+//! Collateral is locked at open time and released at settlement.
+//! Risk is managed via per-account position limits and margin health checks.
+
+pub mod pricing;
+pub mod risk;
+pub mod settlement;
+
+use soroban_sdk::{contracttype, token, Address, Env, Vec};
+
+use crate::DataKey;
+
+// ── Constants ────────────────────────────────────────────────────────────────
+
+/// Basis-point denominator (10 000 = 100%).
+pub const BPS: i128 = 10_000;
+
+/// Fixed-point precision for prices (1_000_000 = 1.0).
+pub const PRICE_PRECISION: i128 = 1_000_000;
+
+/// Default initial margin requirement: 15% of notional.
+pub const DEFAULT_INITIAL_MARGIN_BPS: i128 = 1_500;
+
+/// Default maintenance margin: 7.5% of notional.
+pub const DEFAULT_MAINTENANCE_MARGIN_BPS: i128 = 750;
+
+/// Liquidation penalty: 3% of notional paid to liquidator.
+pub const DEFAULT_LIQUIDATION_PENALTY_BPS: i128 = 300;
+
+/// Maximum open positions per account.
+pub const MAX_POSITIONS_PER_ACCOUNT: u32 = 50;
+
+// ── Derivative types ─────────────────────────────────────────────────────────
+
+/// The kind of derivative instrument.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq, Copy)]
+pub enum DerivativeKind {
+    /// European call option: right to buy at strike.
+    Call,
+    /// European put option: right to sell at strike.
+    Put,
+    /// Cash-settled futures contract.
+    Future,
+    /// Fixed-for-floating tip rate swap.
+    Swap,
+}
+
+/// Lifecycle state shared by all derivative types.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq, Copy)]
+pub enum DerivativeStatus {
+    /// Waiting for a counterparty to match.
+    Open,
+    /// Both sides matched; contract is live.
+    Active,
+    /// Holder exercised the option before expiry.
+    Exercised,
+    /// Contract reached expiry and was cash-settled.
+    Settled,
+    /// Contract expired worthless (out-of-the-money).
+    Expired,
+    /// A party was liquidated due to insufficient margin.
+    Liquidated,
+    /// Cancelled before matching.
+    Cancelled,
+}
+
+/// A unified derivative contract record.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DerivativeContract {
+    /// Unique contract ID.
+    pub id: u64,
+    /// Instrument type.
+    pub kind: DerivativeKind,
+    /// Current lifecycle status.
+    pub status: DerivativeStatus,
+    /// Initiating party (writer for options, long for futures/swaps).
+    pub party_a: Address,
+    /// Counterparty (holder for options, short for futures/swaps). None until matched.
+    pub party_b: Option<Address>,
+    /// Underlying tip token.
+    pub token: Address,
+    /// Notional size in token base units.
+    pub notional: i128,
+    /// Strike / contract price in token base units (PRICE_PRECISION scale).
+    pub strike: i128,
+    /// Premium paid by party_b to party_a at match time (options only).
+    pub premium: i128,
+    /// Collateral locked by party_a.
+    pub collateral_a: i128,
+    /// Collateral locked by party_b.
+    pub collateral_b: i128,
+    /// Last mark price (oracle feed, PRICE_PRECISION scale).
+    pub mark_price: i128,
+    /// Expiry / settlement timestamp (unix seconds).
+    pub expires_at: u64,
+    /// Creation timestamp.
+    pub created_at: u64,
+    /// Settlement price recorded at expiry.
+    pub settlement_price: i128,
+}
+
+/// Per-account portfolio summary.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DerivativePortfolio {
+    pub account: Address,
+    /// Number of open/active contracts as party_a.
+    pub initiated_count: u32,
+    /// Number of open/active contracts as party_b.
+    pub matched_count: u32,
+    /// Total collateral locked across all contracts.
+    pub total_collateral: i128,
+    /// Cumulative realised P&L.
+    pub realised_pnl: i128,
+}
+
+/// Global configuration for the derivatives module.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DerivativesConfig {
+    pub initial_margin_bps: i128,
+    pub maintenance_margin_bps: i128,
+    pub liquidation_penalty_bps: i128,
+    pub max_positions: u32,
+}
+
+// ── Storage helpers ──────────────────────────────────────────────────────────
+
+pub fn get_config(env: &Env) -> DerivativesConfig {
+    env.storage()
+        .persistent()
+        .get(&DataKey::DerivativesConfig)
+        .unwrap_or(DerivativesConfig {
+            initial_margin_bps: DEFAULT_INITIAL_MARGIN_BPS,
+            maintenance_margin_bps: DEFAULT_MAINTENANCE_MARGIN_BPS,
+            liquidation_penalty_bps: DEFAULT_LIQUIDATION_PENALTY_BPS,
+            max_positions: MAX_POSITIONS_PER_ACCOUNT,
+        })
+}
+
+pub fn save_config(env: &Env, cfg: &DerivativesConfig) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::DerivativesConfig, cfg);
+}
+
+pub fn get_contract(env: &Env, id: u64) -> Option<DerivativeContract> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::Derivative(id))
+}
+
+pub fn save_contract(env: &Env, dc: &DerivativeContract) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::Derivative(dc.id), dc);
+}
+
+fn next_id(env: &Env) -> u64 {
+    let id: u64 = env
+        .storage()
+        .persistent()
+        .get(&DataKey::DerivativeCounter)
+        .unwrap_or(0u64)
+        + 1;
+    env.storage()
+        .persistent()
+        .set(&DataKey::DerivativeCounter, &id);
+    id
+}
+
+pub fn get_portfolio(env: &Env, account: &Address) -> DerivativePortfolio {
+    env.storage()
+        .persistent()
+        .get(&DataKey::DerivativePortfolio(account.clone()))
+        .unwrap_or(DerivativePortfolio {
+            account: account.clone(),
+            initiated_count: 0,
+            matched_count: 0,
+            total_collateral: 0,
+            realised_pnl: 0,
+        })
+}
+
+pub fn save_portfolio(env: &Env, p: &DerivativePortfolio) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::DerivativePortfolio(p.account.clone()), p);
+}
+
+pub fn get_account_contracts(env: &Env, account: &Address) -> Vec<u64> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::DerivativeAccountContracts(account.clone()))
+        .unwrap_or_else(|| Vec::new(env))
+}
+
+fn add_account_contract(env: &Env, account: &Address, id: u64) {
+    let mut list = get_account_contracts(env, account);
+    if !list.contains(&id) {
+        list.push_back(id);
+        env.storage()
+            .persistent()
+            .set(&DataKey::DerivativeAccountContracts(account.clone()), &list);
+    }
+}
+
+pub fn get_active_ids(env: &Env) -> Vec<u64> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::DerivativeActiveList)
+        .unwrap_or_else(|| Vec::new(env))
+}
+
+fn add_active(env: &Env, id: u64) {
+    let mut list = get_active_ids(env);
+    if !list.contains(&id) {
+        list.push_back(id);
+        env.storage()
+            .persistent()
+            .set(&DataKey::DerivativeActiveList, &list);
+    }
+}
+
+pub fn remove_active(env: &Env, id: u64) {
+    let list = get_active_ids(env);
+    let mut updated: Vec<u64> = Vec::new(env);
+    for i in 0..list.len() {
+        let v = list.get(i).unwrap();
+        if v != id {
+            updated.push_back(v);
+        }
+    }
+    env.storage()
+        .persistent()
+        .set(&DataKey::DerivativeActiveList, &updated);
+}
+
+// ── Core operations ──────────────────────────────────────────────────────────
+
+/// Open a new derivative contract. The initiating party (`party_a`) posts
+/// initial collateral. Returns the new contract ID.
+///
+/// For options, `premium` is the amount party_b will pay at match time.
+/// For futures/swaps, `premium` should be 0.
+pub fn open(
+    env: &Env,
+    party_a: &Address,
+    kind: DerivativeKind,
+    token: &Address,
+    notional: i128,
+    strike: i128,
+    premium: i128,
+    expires_at: u64,
+) -> u64 {
+    assert!(notional > 0, "notional must be positive");
+    assert!(strike > 0, "strike must be positive");
+    assert!(expires_at > env.ledger().timestamp(), "expiry must be in the future");
+
+    let cfg = get_config(env);
+    risk::check_position_limit(env, party_a, &cfg);
+
+    let collateral_a = required_collateral(kind, notional, strike, cfg.initial_margin_bps);
+
+    let token_client = token::Client::new(env, token);
+    token_client.transfer(party_a, &env.current_contract_address(), &collateral_a);
+
+    let id = next_id(env);
+    let now = env.ledger().timestamp();
+
+    let dc = DerivativeContract {
+        id,
+        kind,
+        status: DerivativeStatus::Open,
+        party_a: party_a.clone(),
+        party_b: None,
+        token: token.clone(),
+        notional,
+        strike,
+        premium,
+        collateral_a,
+        collateral_b: 0,
+        mark_price: strike,
+        expires_at,
+        created_at: now,
+        settlement_price: 0,
+    };
+
+    save_contract(env, &dc);
+    add_active(env, id);
+    add_account_contract(env, party_a, id);
+
+    let mut portfolio = get_portfolio(env, party_a);
+    portfolio.initiated_count += 1;
+    portfolio.total_collateral += collateral_a;
+    save_portfolio(env, &portfolio);
+
+    id
+}
+
+/// Match the counterparty (`party_b`) to an open contract.
+/// For options, party_b pays the premium to party_a and posts their collateral.
+/// For futures/swaps, party_b posts initial margin.
+pub fn match_contract(env: &Env, party_b: &Address, id: u64) {
+    let mut dc = get_contract(env, id).expect("contract not found");
+    assert!(dc.status == DerivativeStatus::Open, "contract not open");
+    assert!(dc.party_b.is_none(), "already matched");
+
+    let cfg = get_config(env);
+    risk::check_position_limit(env, party_b, &cfg);
+
+    let token_client = token::Client::new(env, &dc.token);
+
+    // For options: party_b pays premium to party_a and posts collateral
+    // For futures/swaps: party_b posts initial margin
+    let collateral_b = match dc.kind {
+        DerivativeKind::Call | DerivativeKind::Put => {
+            if dc.premium > 0 {
+                token_client.transfer(party_b, &dc.party_a, &dc.premium);
+            }
+            // Buyer posts a smaller margin (premium already paid)
+            required_collateral(dc.kind, dc.notional, dc.strike, cfg.initial_margin_bps / 2)
+        }
+        DerivativeKind::Future | DerivativeKind::Swap => {
+            required_collateral(dc.kind, dc.notional, dc.strike, cfg.initial_margin_bps)
+        }
+    };
+
+    if collateral_b > 0 {
+        token_client.transfer(party_b, &env.current_contract_address(), &collateral_b);
+    }
+
+    dc.party_b = Some(party_b.clone());
+    dc.collateral_b = collateral_b;
+    dc.status = DerivativeStatus::Active;
+    save_contract(env, &dc);
+    add_account_contract(env, party_b, id);
+
+    let mut portfolio = get_portfolio(env, party_b);
+    portfolio.matched_count += 1;
+    portfolio.total_collateral += collateral_b;
+    save_portfolio(env, &portfolio);
+}
+
+/// Update the mark price for an active contract (called by oracle/admin).
+pub fn update_mark_price(env: &Env, id: u64, new_price: i128) {
+    let mut dc = get_contract(env, id).expect("contract not found");
+    assert!(dc.status == DerivativeStatus::Active, "contract not active");
+    assert!(new_price > 0, "price must be positive");
+    dc.mark_price = new_price;
+    save_contract(env, &dc);
+}
+
+/// Cancel an unmatched (Open) contract and refund party_a's collateral.
+pub fn cancel(env: &Env, caller: &Address, id: u64) {
+    let mut dc = get_contract(env, id).expect("contract not found");
+    assert!(dc.status == DerivativeStatus::Open, "can only cancel open contracts");
+    assert!(dc.party_a == *caller, "not the contract initiator");
+
+    let token_client = token::Client::new(env, &dc.token);
+    if dc.collateral_a > 0 {
+        token_client.transfer(&env.current_contract_address(), caller, &dc.collateral_a);
+    }
+
+    let mut portfolio = get_portfolio(env, caller);
+    portfolio.initiated_count = portfolio.initiated_count.saturating_sub(1);
+    portfolio.total_collateral = portfolio.total_collateral.saturating_sub(dc.collateral_a);
+    save_portfolio(env, &portfolio);
+
+    dc.status = DerivativeStatus::Cancelled;
+    save_contract(env, &dc);
+    remove_active(env, id);
+}
+
+/// Liquidate an under-margined position. The liquidator receives the penalty.
+/// Returns the penalty amount paid to the liquidator.
+pub fn liquidate(env: &Env, liquidator: &Address, id: u64) -> i128 {
+    let mut dc = get_contract(env, id).expect("contract not found");
+    assert!(dc.status == DerivativeStatus::Active, "contract not active");
+
+    let cfg = get_config(env);
+    let (under_a, under_b) = risk::check_margin_health(&dc, &cfg);
+    assert!(under_a || under_b, "no under-margined position");
+
+    let token_client = token::Client::new(env, &dc.token);
+    let notional_value = dc.notional * dc.mark_price / PRICE_PRECISION;
+    let penalty = notional_value * cfg.liquidation_penalty_bps / BPS;
+
+    if under_a {
+        let penalty_actual = penalty.min(dc.collateral_a);
+        if penalty_actual > 0 {
+            token_client.transfer(&env.current_contract_address(), liquidator, &penalty_actual);
+        }
+        let remaining = dc.collateral_a - penalty_actual;
+        if remaining > 0 {
+            token_client.transfer(&env.current_contract_address(), &dc.party_a, &remaining);
+        }
+        // Return party_b's collateral
+        if let Some(ref pb) = dc.party_b.clone() {
+            if dc.collateral_b > 0 {
+                token_client.transfer(&env.current_contract_address(), pb, &dc.collateral_b);
+            }
+            let mut p = get_portfolio(env, pb);
+            p.matched_count = p.matched_count.saturating_sub(1);
+            p.total_collateral = p.total_collateral.saturating_sub(dc.collateral_b);
+            save_portfolio(env, &p);
+        }
+        let mut p = get_portfolio(env, &dc.party_a);
+        p.initiated_count = p.initiated_count.saturating_sub(1);
+        p.total_collateral = p.total_collateral.saturating_sub(dc.collateral_a);
+        save_portfolio(env, &p);
+
+        dc.status = DerivativeStatus::Liquidated;
+        save_contract(env, &dc);
+        remove_active(env, id);
+        return penalty_actual;
+    }
+
+    // under_b
+    let party_b = dc.party_b.clone().expect("no party_b");
+    let penalty_actual = penalty.min(dc.collateral_b);
+    if penalty_actual > 0 {
+        token_client.transfer(&env.current_contract_address(), liquidator, &penalty_actual);
+    }
+    let remaining = dc.collateral_b - penalty_actual;
+    if remaining > 0 {
+        token_client.transfer(&env.current_contract_address(), &party_b, &remaining);
+    }
+    // Return party_a's collateral
+    if dc.collateral_a > 0 {
+        token_client.transfer(&env.current_contract_address(), &dc.party_a, &dc.collateral_a);
+    }
+    let mut pa = get_portfolio(env, &dc.party_a);
+    pa.initiated_count = pa.initiated_count.saturating_sub(1);
+    pa.total_collateral = pa.total_collateral.saturating_sub(dc.collateral_a);
+    save_portfolio(env, &pa);
+
+    let mut pb = get_portfolio(env, &party_b);
+    pb.matched_count = pb.matched_count.saturating_sub(1);
+    pb.total_collateral = pb.total_collateral.saturating_sub(dc.collateral_b);
+    save_portfolio(env, &pb);
+
+    dc.status = DerivativeStatus::Liquidated;
+    save_contract(env, &dc);
+    remove_active(env, id);
+
+    penalty_actual
+}
+
+// ── Internal helpers ─────────────────────────────────────────────────────────
+
+/// Calculate required collateral for a given instrument and margin rate.
+pub fn required_collateral(
+    kind: DerivativeKind,
+    notional: i128,
+    strike: i128,
+    margin_bps: i128,
+) -> i128 {
+    let notional_value = match kind {
+        DerivativeKind::Call => notional,
+        DerivativeKind::Put => notional * strike / PRICE_PRECISION,
+        DerivativeKind::Future | DerivativeKind::Swap => notional * strike / PRICE_PRECISION,
+    };
+    (notional_value * margin_bps / BPS).max(1)
+}

--- a/contracts/tipjar/src/derivatives/pricing.rs
+++ b/contracts/tipjar/src/derivatives/pricing.rs
@@ -1,0 +1,361 @@
+//! Derivative pricing models.
+//!
+//! Implements a simplified Black-Scholes-inspired pricing model suitable for
+//! on-chain integer arithmetic (no floating point). All values use fixed-point
+//! with `PRICE_PRECISION` (1_000_000 = 1.0) unless noted.
+//!
+//! # Approximations
+//! - The normal CDF is approximated with a rational polynomial (Abramowitz &
+//!   Stegun 26.2.17), accurate to ±7.5×10⁻⁸.
+//! - Square root uses Newton-Raphson iteration (converges in ~10 steps).
+//! - Natural log uses a table-free integer approximation.
+//!
+//! All intermediate values are scaled to avoid overflow within i128 range.
+
+use super::{DerivativeKind, PRICE_PRECISION};
+
+/// Volatility denominator: 10 000 bps = 100%.
+pub const VOL_BPS: i128 = 10_000;
+
+/// Time precision: seconds per year (365.25 days).
+pub const SECS_PER_YEAR: i128 = 31_557_600;
+
+/// Minimum time-to-expiry for pricing (1 hour in seconds).
+pub const MIN_TIME_SECS: u64 = 3_600;
+
+// ── Public API ───────────────────────────────────────────────────────────────
+
+/// Parameters for Black-Scholes pricing.
+pub struct PricingInput {
+    /// Current spot price (PRICE_PRECISION scale).
+    pub spot: i128,
+    /// Strike price (PRICE_PRECISION scale).
+    pub strike: i128,
+    /// Time to expiry in seconds.
+    pub time_to_expiry_secs: u64,
+    /// Annualised volatility in basis points (e.g. 5000 = 50%).
+    pub volatility_bps: u32,
+    /// Annualised risk-free rate in basis points (e.g. 500 = 5%).
+    pub risk_free_rate_bps: u32,
+}
+
+/// Computed option prices.
+pub struct OptionPrice {
+    /// Call option fair value (PRICE_PRECISION scale).
+    pub call: i128,
+    /// Put option fair value (PRICE_PRECISION scale).
+    pub put: i128,
+    /// Delta for the call (PRICE_PRECISION scale, 0..1_000_000).
+    pub call_delta: i128,
+    /// Delta for the put (PRICE_PRECISION scale, -1_000_000..0).
+    pub put_delta: i128,
+}
+
+/// Price a European call and put using the Black-Scholes formula.
+///
+/// Returns `None` if time_to_expiry is below `MIN_TIME_SECS` (treat as expired).
+pub fn black_scholes(input: &PricingInput) -> Option<OptionPrice> {
+    if input.time_to_expiry_secs < MIN_TIME_SECS {
+        return None;
+    }
+    if input.spot <= 0 || input.strike <= 0 {
+        return None;
+    }
+
+    // t = time fraction of year (PRICE_PRECISION scale)
+    let t = (input.time_to_expiry_secs as i128) * PRICE_PRECISION / SECS_PER_YEAR;
+
+    // sigma = volatility (PRICE_PRECISION scale)
+    let sigma = (input.volatility_bps as i128) * PRICE_PRECISION / VOL_BPS;
+
+    // r = risk-free rate (PRICE_PRECISION scale)
+    let r = (input.risk_free_rate_bps as i128) * PRICE_PRECISION / VOL_BPS;
+
+    // sigma^2 * t / 2  (scaled: PRICE_PRECISION)
+    let sigma_sq_t_half = sigma * sigma / PRICE_PRECISION * t / PRICE_PRECISION / 2;
+
+    // sqrt(sigma^2 * t) = sigma * sqrt(t)
+    let sigma_sqrt_t = sigma * isqrt(t) / isqrt(PRICE_PRECISION);
+
+    if sigma_sqrt_t == 0 {
+        return None;
+    }
+
+    // ln(S/K) approximation (PRICE_PRECISION scale)
+    let ln_s_k = iln(input.spot * PRICE_PRECISION / input.strike);
+
+    // d1 = (ln(S/K) + (r + sigma^2/2)*t) / (sigma*sqrt(t))
+    let r_t = r * t / PRICE_PRECISION;
+    let d1_num = ln_s_k + r_t + sigma_sq_t_half;
+    let d1 = d1_num * PRICE_PRECISION / sigma_sqrt_t;
+
+    // d2 = d1 - sigma*sqrt(t)
+    let d2 = d1 - sigma_sqrt_t;
+
+    // N(d1), N(d2) — standard normal CDF
+    let nd1 = norm_cdf(d1);
+    let nd2 = norm_cdf(d2);
+    let nd1_neg = PRICE_PRECISION - nd1; // N(-d1)
+    let nd2_neg = PRICE_PRECISION - nd2; // N(-d2)
+
+    // Discount factor e^(-r*t) ≈ 1 - r*t for small r*t (good enough for short tenors)
+    // For longer tenors use the series: e^x ≈ 1 + x + x^2/2
+    let neg_rt = r_t; // r*t (positive)
+    let discount = exp_neg(neg_rt); // e^(-r*t)
+
+    // Call = S*N(d1) - K*e^(-rT)*N(d2)
+    let call = input.spot * nd1 / PRICE_PRECISION
+        - input.strike * discount / PRICE_PRECISION * nd2 / PRICE_PRECISION;
+
+    // Put = K*e^(-rT)*N(-d2) - S*N(-d1)
+    let put = input.strike * discount / PRICE_PRECISION * nd2_neg / PRICE_PRECISION
+        - input.spot * nd1_neg / PRICE_PRECISION;
+
+    Some(OptionPrice {
+        call: call.max(0),
+        put: put.max(0),
+        call_delta: nd1,
+        put_delta: nd1 - PRICE_PRECISION, // N(d1) - 1
+    })
+}
+
+/// Price a futures contract: fair value = spot * e^(r*T).
+/// Returns the fair futures price (PRICE_PRECISION scale).
+pub fn futures_fair_value(
+    spot: i128,
+    time_to_expiry_secs: u64,
+    risk_free_rate_bps: u32,
+) -> i128 {
+    let t = (time_to_expiry_secs as i128) * PRICE_PRECISION / SECS_PER_YEAR;
+    let r = (risk_free_rate_bps as i128) * PRICE_PRECISION / VOL_BPS;
+    let rt = r * t / PRICE_PRECISION;
+    // e^(r*t) ≈ 1 + r*t + (r*t)^2/2
+    let exp_rt = PRICE_PRECISION + rt + rt * rt / PRICE_PRECISION / 2;
+    spot * exp_rt / PRICE_PRECISION
+}
+
+/// Price a fixed-for-floating swap: present value of fixed leg minus floating leg.
+/// Returns the net PV from the fixed-payer's perspective (PRICE_PRECISION scale).
+pub fn swap_fair_value(
+    fixed_rate_bps: u32,
+    floating_rate_bps: u32,
+    notional: i128,
+    time_to_expiry_secs: u64,
+) -> i128 {
+    let t = (time_to_expiry_secs as i128) * PRICE_PRECISION / SECS_PER_YEAR;
+    let fixed = (fixed_rate_bps as i128) * PRICE_PRECISION / VOL_BPS;
+    let floating = (floating_rate_bps as i128) * PRICE_PRECISION / VOL_BPS;
+    // PV = notional * (floating - fixed) * t
+    notional * (floating - fixed) / PRICE_PRECISION * t / PRICE_PRECISION
+}
+
+/// Compute the premium for a given derivative kind.
+/// Returns the fair premium in token base units.
+pub fn compute_premium(
+    kind: DerivativeKind,
+    input: &PricingInput,
+    notional: i128,
+) -> i128 {
+    match kind {
+        DerivativeKind::Call => {
+            black_scholes(input)
+                .map(|p| p.call * notional / PRICE_PRECISION)
+                .unwrap_or(0)
+        }
+        DerivativeKind::Put => {
+            black_scholes(input)
+                .map(|p| p.put * notional / PRICE_PRECISION)
+                .unwrap_or(0)
+        }
+        DerivativeKind::Future => {
+            let fair = futures_fair_value(
+                input.spot,
+                input.time_to_expiry_secs,
+                input.risk_free_rate_bps,
+            );
+            // Premium = |fair - strike| * notional / PRICE_PRECISION
+            (fair - input.strike).abs() * notional / PRICE_PRECISION
+        }
+        DerivativeKind::Swap => {
+            // For swaps, premium is the absolute PV difference
+            swap_fair_value(
+                input.risk_free_rate_bps,
+                input.volatility_bps, // reuse volatility_bps as floating rate
+                notional,
+                input.time_to_expiry_secs,
+            )
+            .abs()
+        }
+    }
+}
+
+// ── Integer math helpers ─────────────────────────────────────────────────────
+
+/// Integer square root via Newton-Raphson. Input and output are raw integers.
+pub fn isqrt(n: i128) -> i128 {
+    if n <= 0 {
+        return 0;
+    }
+    let mut x = n;
+    let mut y = (x + 1) / 2;
+    while y < x {
+        x = y;
+        y = (x + n / x) / 2;
+    }
+    x
+}
+
+/// Natural log approximation for x > 0 (PRICE_PRECISION scale input/output).
+/// Uses the identity ln(x) = 2*atanh((x-1)/(x+1)) with a 4-term series.
+pub fn iln(x: i128) -> i128 {
+    if x <= 0 {
+        return -10 * PRICE_PRECISION; // clamp to a large negative
+    }
+    if x == PRICE_PRECISION {
+        return 0;
+    }
+
+    // Reduce: find k such that x = 2^k * m, 0.5 <= m < 1 (in PRICE_PRECISION)
+    // ln(x) = k*ln(2) + ln(m)
+    // ln(2) ≈ 693_147 (PRICE_PRECISION scale)
+    const LN2: i128 = 693_147;
+
+    let mut val = x;
+    let mut k: i128 = 0;
+
+    while val >= 2 * PRICE_PRECISION {
+        val /= 2;
+        k += 1;
+    }
+    while val < PRICE_PRECISION {
+        val *= 2;
+        k -= 1;
+    }
+
+    // Now val is in [PRICE_PRECISION, 2*PRICE_PRECISION)
+    // Use atanh series: ln(v) = 2*atanh((v-1)/(v+1))
+    // t = (v-1)/(v+1)
+    let t = (val - PRICE_PRECISION) * PRICE_PRECISION / (val + PRICE_PRECISION);
+    let t2 = t * t / PRICE_PRECISION;
+    // 2*(t + t^3/3 + t^5/5 + t^7/7)
+    let series = t
+        + t * t2 / PRICE_PRECISION / 3
+        + t * t2 / PRICE_PRECISION * t2 / PRICE_PRECISION / 5
+        + t * t2 / PRICE_PRECISION * t2 / PRICE_PRECISION * t2 / PRICE_PRECISION / 7;
+    let ln_m = 2 * series;
+
+    k * LN2 + ln_m
+}
+
+/// e^(-x) approximation for x >= 0 (PRICE_PRECISION scale input/output).
+/// Uses the series: e^(-x) ≈ 1 - x + x^2/2 - x^3/6 (accurate for small x).
+pub fn exp_neg(x: i128) -> i128 {
+    if x <= 0 {
+        return PRICE_PRECISION;
+    }
+    let x2 = x * x / PRICE_PRECISION;
+    let x3 = x2 * x / PRICE_PRECISION;
+    let result = PRICE_PRECISION - x + x2 / 2 - x3 / 6;
+    result.max(0)
+}
+
+/// Standard normal CDF approximation (Abramowitz & Stegun 26.2.17).
+/// Input: z in PRICE_PRECISION scale. Output: probability in PRICE_PRECISION scale.
+pub fn norm_cdf(z: i128) -> i128 {
+    // Handle tails
+    if z <= -4 * PRICE_PRECISION {
+        return 0;
+    }
+    if z >= 4 * PRICE_PRECISION {
+        return PRICE_PRECISION;
+    }
+
+    let negative = z < 0;
+    let z_abs = z.abs();
+
+    // Rational approximation constants (scaled by 1_000_000)
+    // p = 0.2316419 → 231_642
+    const P: i128 = 231_642;
+    // a1..a5 coefficients × 1_000_000
+    const A1: i128 = 319_381_530;
+    const A2: i128 = -356_563_782;
+    const A3: i128 = 1_781_477_937;
+    const A4: i128 = -1_821_255_978;
+    const A5: i128 = 1_330_274_429;
+
+    // t = 1 / (1 + p*|z|)  (PRICE_PRECISION scale)
+    let denom = PRICE_PRECISION + P * z_abs / PRICE_PRECISION;
+    let t = PRICE_PRECISION * PRICE_PRECISION / denom;
+
+    // Polynomial in t
+    let t2 = t * t / PRICE_PRECISION;
+    let t3 = t2 * t / PRICE_PRECISION;
+    let t4 = t3 * t / PRICE_PRECISION;
+    let t5 = t4 * t / PRICE_PRECISION;
+
+    let poly = (A1 * t + A2 * t2 + A3 * t3 + A4 * t4 + A5 * t5) / PRICE_PRECISION;
+
+    // Standard normal PDF at z: phi(z) = e^(-z^2/2) / sqrt(2*pi)
+    // sqrt(2*pi) ≈ 2_506_628 (PRICE_PRECISION scale)
+    const SQRT_2PI: i128 = 2_506_628;
+    let z2_half = z_abs * z_abs / PRICE_PRECISION / 2;
+    let phi_num = exp_neg(z2_half);
+    let phi = phi_num * PRICE_PRECISION / SQRT_2PI;
+
+    let tail = phi * poly.abs() / PRICE_PRECISION;
+
+    if negative {
+        tail
+    } else {
+        PRICE_PRECISION - tail
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    extern crate std;
+    use super::*;
+
+    #[test]
+    fn test_isqrt() {
+        assert_eq!(isqrt(0), 0);
+        assert_eq!(isqrt(1_000_000 * 1_000_000), 1_000_000);
+        assert_eq!(isqrt(4 * 1_000_000 * 1_000_000), 2_000_000);
+    }
+
+    #[test]
+    fn test_norm_cdf_symmetry() {
+        let p0 = norm_cdf(0);
+        // N(0) ≈ 0.5
+        assert!((p0 - 500_000).abs() < 5_000, "N(0) should be ~0.5, got {}", p0);
+        let p_pos = norm_cdf(PRICE_PRECISION);
+        let p_neg = norm_cdf(-PRICE_PRECISION);
+        // N(1) + N(-1) ≈ 1
+        assert!((p_pos + p_neg - PRICE_PRECISION).abs() < 10_000);
+    }
+
+    #[test]
+    fn test_black_scholes_call_put_parity() {
+        // Put-call parity: C - P = S - K*e^(-rT)
+        let input = PricingInput {
+            spot: PRICE_PRECISION,       // S = 1.0
+            strike: PRICE_PRECISION,     // K = 1.0 (ATM)
+            time_to_expiry_secs: 86_400 * 30, // 30 days
+            volatility_bps: 5_000,       // 50%
+            risk_free_rate_bps: 500,     // 5%
+        };
+        let prices = black_scholes(&input).unwrap();
+        // ATM: call ≈ put (approximately, ignoring small r*T effect)
+        let diff = (prices.call - prices.put).abs();
+        assert!(diff < PRICE_PRECISION / 10, "ATM call/put should be close: call={} put={}", prices.call, prices.put);
+    }
+
+    #[test]
+    fn test_futures_fair_value() {
+        let spot = PRICE_PRECISION; // 1.0
+        let fair = futures_fair_value(spot, 86_400 * 365, 500); // 1 year, 5%
+        // Should be approximately 1.05 * PRICE_PRECISION
+        assert!(fair > PRICE_PRECISION, "futures should be above spot");
+        assert!(fair < 11 * PRICE_PRECISION / 10, "futures should be < 1.1 * spot");
+    }
+}

--- a/contracts/tipjar/src/derivatives/risk.rs
+++ b/contracts/tipjar/src/derivatives/risk.rs
@@ -1,0 +1,162 @@
+//! Risk management for the derivatives platform.
+//!
+//! Responsibilities:
+//! - Enforce per-account position limits.
+//! - Check margin health (initial and maintenance).
+//! - Compute portfolio-level health factor.
+//! - Identify which side of a contract is under-margined.
+
+use super::{
+    DerivativeContract, DerivativeKind, DerivativeStatus, DerivativesConfig,
+    get_active_ids, get_account_contracts, get_contract, get_portfolio,
+    BPS, PRICE_PRECISION,
+};
+use soroban_sdk::{Address, Env};
+
+/// Health factor precision: 1_000_000 = 1.0 (healthy threshold).
+pub const HEALTH_PRECISION: i128 = 1_000_000;
+
+/// Portfolio health summary.
+pub struct PortfolioHealth {
+    /// Total collateral locked (token base units).
+    pub total_collateral: i128,
+    /// Total notional exposure (token base units).
+    pub total_notional: i128,
+    /// Unrealised P&L (can be negative).
+    pub unrealised_pnl: i128,
+    /// Health factor: (collateral + unrealised_pnl) / required_maintenance_margin.
+    /// Values < HEALTH_PRECISION indicate under-margined.
+    pub health_factor: i128,
+    /// Number of active contracts.
+    pub active_count: u32,
+}
+
+// ── Position limit checks ────────────────────────────────────────────────────
+
+/// Panic if the account has reached the maximum number of open positions.
+pub fn check_position_limit(env: &Env, account: &Address, cfg: &DerivativesConfig) {
+    let portfolio = get_portfolio(env, account);
+    let total = portfolio.initiated_count + portfolio.matched_count;
+    assert!(
+        total < cfg.max_positions,
+        "position limit reached"
+    );
+}
+
+// ── Margin health ────────────────────────────────────────────────────────────
+
+/// Check whether either side of a contract is below maintenance margin.
+/// Returns `(party_a_under, party_b_under)`.
+pub fn check_margin_health(
+    dc: &DerivativeContract,
+    cfg: &DerivativesConfig,
+) -> (bool, bool) {
+    let notional_value = dc.notional * dc.mark_price / PRICE_PRECISION;
+    let maintenance = notional_value * cfg.maintenance_margin_bps / BPS;
+
+    // Unrealised P&L for party_a (long for futures, writer for options)
+    let pnl_a = unrealised_pnl_a(dc);
+    let effective_a = dc.collateral_a + pnl_a;
+
+    let under_a = effective_a < maintenance;
+
+    let under_b = if dc.party_b.is_some() {
+        let pnl_b = -pnl_a; // zero-sum
+        let effective_b = dc.collateral_b + pnl_b;
+        effective_b < maintenance
+    } else {
+        false
+    };
+
+    (under_a, under_b)
+}
+
+/// Compute the unrealised P&L for party_a given the current mark price.
+/// - Futures/Swap: long P&L = (mark - strike) * notional / PRICE_PRECISION
+/// - Call option: intrinsic = max(mark - strike, 0) * notional / PRICE_PRECISION
+/// - Put option: intrinsic = max(strike - mark, 0) * notional / PRICE_PRECISION
+pub fn unrealised_pnl_a(dc: &DerivativeContract) -> i128 {
+    match dc.kind {
+        DerivativeKind::Future | DerivativeKind::Swap => {
+            (dc.mark_price - dc.strike) * dc.notional / PRICE_PRECISION
+        }
+        DerivativeKind::Call => {
+            let intrinsic = (dc.mark_price - dc.strike).max(0);
+            intrinsic * dc.notional / PRICE_PRECISION
+        }
+        DerivativeKind::Put => {
+            let intrinsic = (dc.strike - dc.mark_price).max(0);
+            intrinsic * dc.notional / PRICE_PRECISION
+        }
+    }
+}
+
+// ── Portfolio health ─────────────────────────────────────────────────────────
+
+/// Compute the overall portfolio health for an account.
+pub fn portfolio_health(env: &Env, account: &Address, cfg: &DerivativesConfig) -> PortfolioHealth {
+    let ids = get_account_contracts(env, account);
+    let mut total_collateral: i128 = 0;
+    let mut total_notional: i128 = 0;
+    let mut unrealised_pnl: i128 = 0;
+    let mut active_count: u32 = 0;
+
+    for i in 0..ids.len() {
+        let id = ids.get(i).unwrap();
+        if let Some(dc) = get_contract(env, id) {
+            if dc.status != DerivativeStatus::Active {
+                continue;
+            }
+            active_count += 1;
+            let notional_value = dc.notional * dc.mark_price / PRICE_PRECISION;
+            total_notional += notional_value;
+
+            if dc.party_a == *account {
+                total_collateral += dc.collateral_a;
+                unrealised_pnl += unrealised_pnl_a(&dc);
+            } else if dc.party_b.as_ref() == Some(account) {
+                total_collateral += dc.collateral_b;
+                unrealised_pnl -= unrealised_pnl_a(&dc); // party_b is opposite
+            }
+        }
+    }
+
+    let required_maintenance = total_notional * cfg.maintenance_margin_bps / BPS;
+    let health_factor = if required_maintenance == 0 {
+        HEALTH_PRECISION * 10 // no exposure → very healthy
+    } else {
+        (total_collateral + unrealised_pnl) * HEALTH_PRECISION / required_maintenance
+    };
+
+    PortfolioHealth {
+        total_collateral,
+        total_notional,
+        unrealised_pnl,
+        health_factor,
+        active_count,
+    }
+}
+
+/// Returns true if the account's portfolio is healthy (health_factor >= 1.0).
+pub fn is_healthy(env: &Env, account: &Address, cfg: &DerivativesConfig) -> bool {
+    portfolio_health(env, account, cfg).health_factor >= HEALTH_PRECISION
+}
+
+/// Scan all active contracts and return IDs of contracts with at least one
+/// under-margined side. Useful for liquidation bots.
+pub fn find_liquidatable(env: &Env, cfg: &DerivativesConfig) -> soroban_sdk::Vec<u64> {
+    let active = get_active_ids(env);
+    let mut result: soroban_sdk::Vec<u64> = soroban_sdk::Vec::new(env);
+    for i in 0..active.len() {
+        let id = active.get(i).unwrap();
+        if let Some(dc) = get_contract(env, id) {
+            if dc.status == DerivativeStatus::Active {
+                let (under_a, under_b) = check_margin_health(&dc, cfg);
+                if under_a || under_b {
+                    result.push_back(id);
+                }
+            }
+        }
+    }
+    result
+}

--- a/contracts/tipjar/src/derivatives/settlement.rs
+++ b/contracts/tipjar/src/derivatives/settlement.rs
@@ -1,0 +1,269 @@
+//! Settlement engine for the derivatives platform.
+//!
+//! Handles:
+//! - **Option exercise**: holder exercises before expiry (American-style allowed).
+//! - **Expiry settlement**: cash-settle all expired contracts against the final
+//!   oracle price.
+//! - **Batch expiry**: process multiple expired contracts in one call.
+//!
+//! All settlements are cash-settled (no physical delivery of tokens).
+//! Net P&L is transferred between the two parties; remaining collateral is
+//! returned to each party.
+
+use super::{
+    DerivativeContract, DerivativeKind, DerivativeStatus,
+    get_contract, get_portfolio, remove_active, save_contract, save_portfolio,
+    PRICE_PRECISION,
+};
+use soroban_sdk::{token, Address, Env};
+
+// ── Option exercise ──────────────────────────────────────────────────────────
+
+/// Exercise an option contract. Only the holder (`party_b`) may call this.
+/// The contract must be Active and not yet expired.
+///
+/// Cash settlement: the intrinsic value is transferred from party_a to party_b.
+/// Both parties receive their remaining collateral back.
+pub fn exercise_option(env: &Env, holder: &Address, id: u64) {
+    let mut dc = get_contract(env, id).expect("contract not found");
+    assert!(dc.status == DerivativeStatus::Active, "contract not active");
+    assert!(
+        dc.kind == DerivativeKind::Call || dc.kind == DerivativeKind::Put,
+        "not an option"
+    );
+    let party_b = dc.party_b.clone().expect("no counterparty");
+    assert!(party_b == *holder, "only the holder can exercise");
+    assert!(
+        env.ledger().timestamp() <= dc.expires_at,
+        "option has expired"
+    );
+
+    let intrinsic = intrinsic_value(&dc, dc.mark_price);
+    assert!(intrinsic > 0, "option is out of the money");
+
+    let token_client = token::Client::new(env, &dc.token);
+
+    // Pay intrinsic value from party_a's collateral to party_b
+    let payout = intrinsic.min(dc.collateral_a);
+    if payout > 0 {
+        token_client.transfer(&env.current_contract_address(), holder, &payout);
+    }
+
+    // Return remaining collateral to party_a
+    let remaining_a = dc.collateral_a - payout;
+    if remaining_a > 0 {
+        token_client.transfer(&env.current_contract_address(), &dc.party_a, &remaining_a);
+    }
+
+    // Return party_b's collateral
+    if dc.collateral_b > 0 {
+        token_client.transfer(&env.current_contract_address(), holder, &dc.collateral_b);
+    }
+
+    _update_portfolios_on_close(env, &dc, payout, -payout);
+
+    dc.settlement_price = dc.mark_price;
+    dc.status = DerivativeStatus::Exercised;
+    save_contract(env, &dc);
+    remove_active(env, id);
+}
+
+// ── Expiry settlement ────────────────────────────────────────────────────────
+
+/// Settle a single expired contract at the given final price.
+/// Can be called by anyone once `expires_at` has passed.
+///
+/// For futures/swaps: net P&L is transferred between parties.
+/// For options: if in-the-money, intrinsic value is paid to party_b; otherwise
+/// the contract expires worthless and collateral is returned.
+pub fn settle_expired(env: &Env, id: u64, final_price: i128) {
+    let mut dc = get_contract(env, id).expect("contract not found");
+    assert!(dc.status == DerivativeStatus::Active, "contract not active");
+    assert!(
+        env.ledger().timestamp() > dc.expires_at,
+        "contract not yet expired"
+    );
+    assert!(final_price > 0, "invalid final price");
+
+    dc.settlement_price = final_price;
+    dc.mark_price = final_price;
+
+    let token_client = token::Client::new(env, &dc.token);
+
+    match dc.kind {
+        DerivativeKind::Call | DerivativeKind::Put => {
+            let intrinsic = intrinsic_value(&dc, final_price);
+            if intrinsic > 0 {
+                // In-the-money: pay intrinsic to party_b from party_a's collateral
+                let party_b = dc.party_b.clone().expect("no party_b");
+                let payout = intrinsic.min(dc.collateral_a);
+                if payout > 0 {
+                    token_client.transfer(&env.current_contract_address(), &party_b, &payout);
+                }
+                let remaining_a = dc.collateral_a - payout;
+                if remaining_a > 0 {
+                    token_client.transfer(
+                        &env.current_contract_address(),
+                        &dc.party_a,
+                        &remaining_a,
+                    );
+                }
+                if dc.collateral_b > 0 {
+                    token_client.transfer(
+                        &env.current_contract_address(),
+                        &party_b,
+                        &dc.collateral_b,
+                    );
+                }
+                _update_portfolios_on_close(env, &dc, -payout, payout);
+                dc.status = DerivativeStatus::Settled;
+            } else {
+                // Out-of-the-money: return all collateral
+                _return_all_collateral(env, &dc, &token_client);
+                dc.status = DerivativeStatus::Expired;
+            }
+        }
+        DerivativeKind::Future | DerivativeKind::Swap => {
+            // Cash-settle: long P&L = (final - strike) * notional / PRICE_PRECISION
+            let pnl_a = (final_price - dc.strike) * dc.notional / PRICE_PRECISION;
+            _settle_futures_pnl(env, &dc, &token_client, pnl_a);
+            dc.status = DerivativeStatus::Settled;
+        }
+    }
+
+    save_contract(env, &dc);
+    remove_active(env, id);
+}
+
+/// Batch-settle all expired contracts from the active list.
+/// Returns the number of contracts settled.
+pub fn settle_all_expired(env: &Env, final_prices: &[(u64, i128)]) -> u32 {
+    // Build a lookup: contract_id → final_price
+    // Since we can't use std HashMap in no_std, iterate linearly (list is bounded).
+    let active = super::get_active_ids(env);
+    let mut count: u32 = 0;
+    let now = env.ledger().timestamp();
+
+    for i in 0..active.len() {
+        let id = active.get(i).unwrap();
+        if let Some(dc) = get_contract(env, id) {
+            if dc.status == DerivativeStatus::Active && now > dc.expires_at {
+                // Find the matching final price
+                let mut price_opt: Option<i128> = None;
+                for (cid, price) in final_prices.iter() {
+                    if *cid == id {
+                        price_opt = Some(*price);
+                        break;
+                    }
+                }
+                if let Some(price) = price_opt {
+                    settle_expired(env, id, price);
+                    count += 1;
+                }
+            }
+        }
+    }
+    count
+}
+
+// ── Internal helpers ─────────────────────────────────────────────────────────
+
+/// Compute the intrinsic value of an option at a given price.
+fn intrinsic_value(dc: &DerivativeContract, price: i128) -> i128 {
+    match dc.kind {
+        DerivativeKind::Call => {
+            let diff = price - dc.strike;
+            if diff > 0 {
+                diff * dc.notional / PRICE_PRECISION
+            } else {
+                0
+            }
+        }
+        DerivativeKind::Put => {
+            let diff = dc.strike - price;
+            if diff > 0 {
+                diff * dc.notional / PRICE_PRECISION
+            } else {
+                0
+            }
+        }
+        _ => 0,
+    }
+}
+
+/// Settle a futures/swap contract given the long-side P&L.
+fn _settle_futures_pnl(
+    env: &Env,
+    dc: &DerivativeContract,
+    token_client: &token::Client,
+    pnl_a: i128,
+) {
+    let party_b = dc.party_b.clone().expect("no party_b");
+
+    if pnl_a >= 0 {
+        // party_a profits: transfer pnl_a from party_b's collateral to party_a
+        let transfer = pnl_a.min(dc.collateral_b);
+        if transfer > 0 {
+            token_client.transfer(&env.current_contract_address(), &dc.party_a, &transfer);
+        }
+        // Return remaining collateral
+        let rem_a = dc.collateral_a;
+        let rem_b = dc.collateral_b - transfer;
+        if rem_a > 0 {
+            token_client.transfer(&env.current_contract_address(), &dc.party_a, &rem_a);
+        }
+        if rem_b > 0 {
+            token_client.transfer(&env.current_contract_address(), &party_b, &rem_b);
+        }
+        _update_portfolios_on_close(env, dc, pnl_a, -pnl_a);
+    } else {
+        // party_b profits: transfer |pnl_a| from party_a's collateral to party_b
+        let loss_a = (-pnl_a).min(dc.collateral_a);
+        if loss_a > 0 {
+            token_client.transfer(&env.current_contract_address(), &party_b, &loss_a);
+        }
+        let rem_a = dc.collateral_a - loss_a;
+        let rem_b = dc.collateral_b;
+        if rem_a > 0 {
+            token_client.transfer(&env.current_contract_address(), &dc.party_a, &rem_a);
+        }
+        if rem_b > 0 {
+            token_client.transfer(&env.current_contract_address(), &party_b, &rem_b);
+        }
+        _update_portfolios_on_close(env, dc, pnl_a, -pnl_a);
+    }
+}
+
+/// Return all collateral to both parties (used for expired worthless options).
+fn _return_all_collateral(
+    env: &Env,
+    dc: &DerivativeContract,
+    token_client: &token::Client,
+) {
+    if dc.collateral_a > 0 {
+        token_client.transfer(&env.current_contract_address(), &dc.party_a, &dc.collateral_a);
+    }
+    if let Some(ref pb) = dc.party_b {
+        if dc.collateral_b > 0 {
+            token_client.transfer(&env.current_contract_address(), pb, &dc.collateral_b);
+        }
+    }
+    _update_portfolios_on_close(env, dc, 0, 0);
+}
+
+/// Update portfolio counters and realised P&L after a contract closes.
+fn _update_portfolios_on_close(env: &Env, dc: &DerivativeContract, pnl_a: i128, pnl_b: i128) {
+    let mut pa = get_portfolio(env, &dc.party_a);
+    pa.initiated_count = pa.initiated_count.saturating_sub(1);
+    pa.total_collateral = pa.total_collateral.saturating_sub(dc.collateral_a);
+    pa.realised_pnl += pnl_a;
+    save_portfolio(env, &pa);
+
+    if let Some(ref pb_addr) = dc.party_b {
+        let mut pb = get_portfolio(env, pb_addr);
+        pb.matched_count = pb.matched_count.saturating_sub(1);
+        pb.total_collateral = pb.total_collateral.saturating_sub(dc.collateral_b);
+        pb.realised_pnl += pnl_b;
+        save_portfolio(env, &pb);
+    }
+}

--- a/contracts/tipjar/src/lib.rs
+++ b/contracts/tipjar/src/lib.rs
@@ -94,6 +94,9 @@ pub mod meta_tx;
 // Royalty splits for collaborative content and team tips
 pub mod royalty;
 
+// Unified derivatives platform: options, futures, swaps
+pub mod derivatives;
+
 /// A tip record that includes an optional memo and timestamp.
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -874,6 +877,19 @@ pub enum DataKey {
     MetaTxRecord(u64),
     /// Global meta-transaction record counter.
     MetaTxCounter,
+    // ── Derivatives platform ──────────────────────────────────────────────
+    /// Unified derivative contract record keyed by contract ID.
+    Derivative(u64),
+    /// Global counter for derivative contract IDs.
+    DerivativeCounter,
+    /// Per-account derivative portfolio summary.
+    DerivativePortfolio(Address),
+    /// List of contract IDs an account is party to.
+    DerivativeAccountContracts(Address),
+    /// List of all active derivative contract IDs.
+    DerivativeActiveList,
+    /// Global derivatives module configuration.
+    DerivativesConfig,
 }
 
 #[contracterror]

--- a/contracts/tipjar/tests/derivatives_tests.rs
+++ b/contracts/tipjar/tests/derivatives_tests.rs
@@ -1,0 +1,455 @@
+//! Integration tests for the Tip Derivatives Platform.
+//!
+//! Tests cover:
+//! - Opening and matching all four derivative kinds
+//! - Pricing model sanity checks
+//! - Risk management (position limits, margin health)
+//! - Settlement: exercise, expiry, expiry-worthless, futures P&L
+
+#![cfg(test)]
+
+extern crate std;
+
+use soroban_sdk::{
+    testutils::{Address as _, Ledger},
+    token, Address, Env,
+};
+use tipjar::{
+    derivatives::{
+        self, DerivativeKind, DerivativeStatus,
+        PRICE_PRECISION,
+    },
+    derivatives::pricing::{
+        black_scholes, futures_fair_value, swap_fair_value, PricingInput,
+        isqrt, norm_cdf,
+    },
+    derivatives::risk::{
+        check_margin_health, portfolio_health, find_liquidatable, HEALTH_PRECISION,
+    },
+    derivatives::settlement,
+};
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+fn create_token(env: &Env, admin: &Address) -> Address {
+    env.register_stellar_asset_contract(admin.clone())
+}
+
+fn mint(env: &Env, token: &Address, to: &Address, amount: i128) {
+    let client = token::StellarAssetClient::new(env, token);
+    client.mint(to, &amount);
+}
+
+// ── Pricing unit tests ───────────────────────────────────────────────────────
+
+#[test]
+fn test_isqrt_basic() {
+    assert_eq!(isqrt(0), 0);
+    assert_eq!(isqrt(PRICE_PRECISION * PRICE_PRECISION), PRICE_PRECISION);
+    assert_eq!(isqrt(4 * PRICE_PRECISION * PRICE_PRECISION), 2 * PRICE_PRECISION);
+}
+
+#[test]
+fn test_norm_cdf_at_zero() {
+    let p = norm_cdf(0);
+    // N(0) ≈ 0.5
+    assert!((p - 500_000).abs() < 5_000, "N(0) should be ~0.5, got {}", p);
+}
+
+#[test]
+fn test_norm_cdf_symmetry() {
+    let p1 = norm_cdf(PRICE_PRECISION);
+    let p_neg1 = norm_cdf(-PRICE_PRECISION);
+    assert!((p1 + p_neg1 - PRICE_PRECISION).abs() < 10_000, "symmetry failed");
+}
+
+#[test]
+fn test_black_scholes_atm() {
+    let input = PricingInput {
+        spot: PRICE_PRECISION,
+        strike: PRICE_PRECISION,
+        time_to_expiry_secs: 86_400 * 30,
+        volatility_bps: 5_000,
+        risk_free_rate_bps: 500,
+    };
+    let prices = black_scholes(&input).expect("should price ATM option");
+    // ATM call and put should be close
+    let diff = (prices.call - prices.put).abs();
+    assert!(diff < PRICE_PRECISION / 10, "ATM call/put diff too large: {}", diff);
+    assert!(prices.call > 0, "call should be positive");
+    assert!(prices.put > 0, "put should be positive");
+}
+
+#[test]
+fn test_black_scholes_deep_itm_call() {
+    let input = PricingInput {
+        spot: 2 * PRICE_PRECISION,  // S = 2.0
+        strike: PRICE_PRECISION,    // K = 1.0
+        time_to_expiry_secs: 86_400 * 30,
+        volatility_bps: 3_000,
+        risk_free_rate_bps: 500,
+    };
+    let prices = black_scholes(&input).expect("should price deep ITM call");
+    // Deep ITM call ≈ S - K = 1.0
+    assert!(prices.call > PRICE_PRECISION * 9 / 10, "deep ITM call should be close to intrinsic");
+    // Deep ITM put ≈ 0
+    assert!(prices.put < PRICE_PRECISION / 10, "deep ITM put should be near zero");
+}
+
+#[test]
+fn test_futures_fair_value_above_spot() {
+    let fair = futures_fair_value(PRICE_PRECISION, 86_400 * 365, 500);
+    assert!(fair > PRICE_PRECISION, "futures should be above spot with positive rate");
+    assert!(fair < 11 * PRICE_PRECISION / 10, "futures should be < 1.1x spot");
+}
+
+#[test]
+fn test_swap_fair_value_zero_when_equal() {
+    let pv = swap_fair_value(500, 500, PRICE_PRECISION, 86_400 * 365);
+    assert_eq!(pv, 0, "swap PV should be zero when rates are equal");
+}
+
+#[test]
+fn test_swap_fair_value_positive_when_floating_higher() {
+    let pv = swap_fair_value(500, 1_000, PRICE_PRECISION, 86_400 * 365);
+    assert!(pv > 0, "fixed payer profits when floating > fixed");
+}
+
+// ── Derivative lifecycle tests ───────────────────────────────────────────────
+
+#[test]
+fn test_open_and_cancel_call_option() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let writer = Address::generate(&env);
+    let token = create_token(&env, &admin);
+    mint(&env, &token, &writer, 10_000_000);
+
+    let now = env.ledger().timestamp();
+    let expires_at = now + 86_400;
+
+    let id = derivatives::open(
+        &env,
+        &writer,
+        DerivativeKind::Call,
+        &token,
+        1_000_000,       // notional
+        PRICE_PRECISION, // strike = 1.0
+        50_000,          // premium
+        expires_at,
+    );
+
+    let dc = derivatives::get_contract(&env, id).unwrap();
+    assert_eq!(dc.status, DerivativeStatus::Open);
+    assert_eq!(dc.kind, DerivativeKind::Call);
+    assert!(dc.collateral_a > 0);
+
+    // Cancel before matching
+    derivatives::cancel(&env, &writer, id);
+    let dc = derivatives::get_contract(&env, id).unwrap();
+    assert_eq!(dc.status, DerivativeStatus::Cancelled);
+}
+
+#[test]
+fn test_open_and_match_put_option() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let writer = Address::generate(&env);
+    let holder = Address::generate(&env);
+    let token = create_token(&env, &admin);
+    mint(&env, &token, &writer, 10_000_000);
+    mint(&env, &token, &holder, 10_000_000);
+
+    let now = env.ledger().timestamp();
+    let expires_at = now + 86_400;
+
+    let id = derivatives::open(
+        &env,
+        &writer,
+        DerivativeKind::Put,
+        &token,
+        1_000_000,
+        PRICE_PRECISION,
+        30_000,
+        expires_at,
+    );
+
+    derivatives::match_contract(&env, &holder, id);
+
+    let dc = derivatives::get_contract(&env, id).unwrap();
+    assert_eq!(dc.status, DerivativeStatus::Active);
+    assert_eq!(dc.party_b, Some(holder.clone()));
+    assert!(dc.collateral_b > 0);
+}
+
+#[test]
+fn test_open_and_match_futures() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let long = Address::generate(&env);
+    let short = Address::generate(&env);
+    let token = create_token(&env, &admin);
+    mint(&env, &token, &long, 10_000_000);
+    mint(&env, &token, &short, 10_000_000);
+
+    let now = env.ledger().timestamp();
+    let expires_at = now + 86_400 * 30;
+
+    let id = derivatives::open(
+        &env,
+        &long,
+        DerivativeKind::Future,
+        &token,
+        1_000_000,
+        PRICE_PRECISION,
+        0,
+        expires_at,
+    );
+
+    derivatives::match_contract(&env, &short, id);
+
+    let dc = derivatives::get_contract(&env, id).unwrap();
+    assert_eq!(dc.status, DerivativeStatus::Active);
+    assert!(dc.collateral_a > 0);
+    assert!(dc.collateral_b > 0);
+}
+
+#[test]
+fn test_update_mark_price() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let long = Address::generate(&env);
+    let short = Address::generate(&env);
+    let token = create_token(&env, &admin);
+    mint(&env, &token, &long, 10_000_000);
+    mint(&env, &token, &short, 10_000_000);
+
+    let now = env.ledger().timestamp();
+    let id = derivatives::open(
+        &env, &long, DerivativeKind::Future, &token,
+        1_000_000, PRICE_PRECISION, 0, now + 86_400,
+    );
+    derivatives::match_contract(&env, &short, id);
+
+    let new_price = 12 * PRICE_PRECISION / 10; // 1.2
+    derivatives::update_mark_price(&env, id, new_price);
+
+    let dc = derivatives::get_contract(&env, id).unwrap();
+    assert_eq!(dc.mark_price, new_price);
+}
+
+// ── Risk management tests ────────────────────────────────────────────────────
+
+#[test]
+fn test_margin_health_healthy() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let long = Address::generate(&env);
+    let short = Address::generate(&env);
+    let token = create_token(&env, &admin);
+    mint(&env, &token, &long, 10_000_000);
+    mint(&env, &token, &short, 10_000_000);
+
+    let now = env.ledger().timestamp();
+    let id = derivatives::open(
+        &env, &long, DerivativeKind::Future, &token,
+        1_000_000, PRICE_PRECISION, 0, now + 86_400,
+    );
+    derivatives::match_contract(&env, &short, id);
+
+    let dc = derivatives::get_contract(&env, id).unwrap();
+    let cfg = derivatives::get_config(&env);
+    let (under_a, under_b) = check_margin_health(&dc, &cfg);
+    // At initial margin, both sides should be healthy
+    assert!(!under_a, "party_a should not be under-margined at open");
+    assert!(!under_b, "party_b should not be under-margined at open");
+}
+
+#[test]
+fn test_portfolio_health_no_positions() {
+    let env = Env::default();
+    let account = Address::generate(&env);
+    let cfg = derivatives::get_config(&env);
+    let health = portfolio_health(&env, &account, &cfg);
+    assert_eq!(health.active_count, 0);
+    assert!(health.health_factor >= HEALTH_PRECISION);
+}
+
+#[test]
+fn test_find_liquidatable_empty() {
+    let env = Env::default();
+    let cfg = derivatives::get_config(&env);
+    let result = find_liquidatable(&env, &cfg);
+    assert_eq!(result.len(), 0);
+}
+
+// ── Settlement tests ─────────────────────────────────────────────────────────
+
+#[test]
+fn test_settle_expired_futures_long_profit() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let long = Address::generate(&env);
+    let short = Address::generate(&env);
+    let token = create_token(&env, &admin);
+    mint(&env, &token, &long, 10_000_000);
+    mint(&env, &token, &short, 10_000_000);
+
+    let now = env.ledger().timestamp();
+    let expires_at = now + 100;
+
+    let id = derivatives::open(
+        &env, &long, DerivativeKind::Future, &token,
+        1_000_000, PRICE_PRECISION, 0, expires_at,
+    );
+    derivatives::match_contract(&env, &short, id);
+
+    // Advance time past expiry
+    env.ledger().with_mut(|l| l.timestamp = expires_at + 1);
+
+    // Final price above strike → long profits
+    let final_price = 12 * PRICE_PRECISION / 10;
+    settlement::settle_expired(&env, id, final_price);
+
+    let dc = derivatives::get_contract(&env, id).unwrap();
+    assert_eq!(dc.status, DerivativeStatus::Settled);
+    assert_eq!(dc.settlement_price, final_price);
+}
+
+#[test]
+fn test_settle_expired_call_option_itm() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let writer = Address::generate(&env);
+    let holder = Address::generate(&env);
+    let token = create_token(&env, &admin);
+    mint(&env, &token, &writer, 10_000_000);
+    mint(&env, &token, &holder, 10_000_000);
+
+    let now = env.ledger().timestamp();
+    let expires_at = now + 100;
+
+    let id = derivatives::open(
+        &env, &writer, DerivativeKind::Call, &token,
+        1_000_000, PRICE_PRECISION, 50_000, expires_at,
+    );
+    derivatives::match_contract(&env, &holder, id);
+
+    env.ledger().with_mut(|l| l.timestamp = expires_at + 1);
+
+    // Final price above strike → call is ITM
+    let final_price = 15 * PRICE_PRECISION / 10;
+    settlement::settle_expired(&env, id, final_price);
+
+    let dc = derivatives::get_contract(&env, id).unwrap();
+    assert_eq!(dc.status, DerivativeStatus::Settled);
+}
+
+#[test]
+fn test_settle_expired_call_option_otm() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let writer = Address::generate(&env);
+    let holder = Address::generate(&env);
+    let token = create_token(&env, &admin);
+    mint(&env, &token, &writer, 10_000_000);
+    mint(&env, &token, &holder, 10_000_000);
+
+    let now = env.ledger().timestamp();
+    let expires_at = now + 100;
+
+    let id = derivatives::open(
+        &env, &writer, DerivativeKind::Call, &token,
+        1_000_000, PRICE_PRECISION, 50_000, expires_at,
+    );
+    derivatives::match_contract(&env, &holder, id);
+
+    env.ledger().with_mut(|l| l.timestamp = expires_at + 1);
+
+    // Final price below strike → call is OTM, expires worthless
+    let final_price = PRICE_PRECISION / 2;
+    settlement::settle_expired(&env, id, final_price);
+
+    let dc = derivatives::get_contract(&env, id).unwrap();
+    assert_eq!(dc.status, DerivativeStatus::Expired);
+}
+
+#[test]
+fn test_exercise_call_option_itm() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let writer = Address::generate(&env);
+    let holder = Address::generate(&env);
+    let token = create_token(&env, &admin);
+    mint(&env, &token, &writer, 10_000_000);
+    mint(&env, &token, &holder, 10_000_000);
+
+    let now = env.ledger().timestamp();
+    let expires_at = now + 86_400;
+
+    let id = derivatives::open(
+        &env, &writer, DerivativeKind::Call, &token,
+        1_000_000, PRICE_PRECISION, 50_000, expires_at,
+    );
+    derivatives::match_contract(&env, &holder, id);
+
+    // Move mark price above strike
+    let new_price = 15 * PRICE_PRECISION / 10;
+    derivatives::update_mark_price(&env, id, new_price);
+
+    settlement::exercise_option(&env, &holder, id);
+
+    let dc = derivatives::get_contract(&env, id).unwrap();
+    assert_eq!(dc.status, DerivativeStatus::Exercised);
+}
+
+#[test]
+fn test_open_swap_and_match() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let fixed_payer = Address::generate(&env);
+    let floating_payer = Address::generate(&env);
+    let token = create_token(&env, &admin);
+    mint(&env, &token, &fixed_payer, 10_000_000);
+    mint(&env, &token, &floating_payer, 10_000_000);
+
+    let now = env.ledger().timestamp();
+    let expires_at = now + 86_400 * 90;
+
+    let id = derivatives::open(
+        &env,
+        &fixed_payer,
+        DerivativeKind::Swap,
+        &token,
+        1_000_000,
+        PRICE_PRECISION,
+        0,
+        expires_at,
+    );
+
+    derivatives::match_contract(&env, &floating_payer, id);
+
+    let dc = derivatives::get_contract(&env, id).unwrap();
+    assert_eq!(dc.status, DerivativeStatus::Active);
+    assert_eq!(dc.kind, DerivativeKind::Swap);
+}


### PR DESCRIPTION
 implement tip derivatives platform
  
  Add unified derivatives module supporting call/put options, futures,
  and fixed-for-floating swaps on tip tokens.
  
  - derivatives/mod.rs: core types (DerivativeKind, DerivativeContract,
    DerivativePortfolio), lifecycle ops (open, match, cancel, liquidate)
  - derivatives/pricing.rs: Black-Scholes option pricing, futures
    fair value, swap PV — all no_std integer fixed-point arithmetic
  - derivatives/risk.rs: position limits, margin health checks,
    portfolio health factor, liquidation scanner
  - derivatives/settlement.rs: option exercise, expiry cash settlement,
    batch settlement engine
  - lib.rs: pub mod derivatives + 6 new DataKey variants
  - tests/derivatives_tests.rs: 15 tests covering all instrument kinds
    and settlement paths
  
  Closes #202