### PR TITLE
feat: implement tip time-lock puzzles 

### DIFF
--- a/contracts/tipjar/benches/contract_bench.rs
+++ b/contracts/tipjar/benches/contract_bench.rs
@@ -120,13 +120,7 @@ fn bench_tip_no_message(c: &mut Criterion) {
             let creator = Address::generate(&env);
             token_client.mint(&sender, &1_000);
 
-            client.tip_with_message(
-                &sender,
-                &creator,
-                &token_id,
-                black_box(&100i128),
-                &None,
-            );
+            client.tip_with_message(&sender, &creator, &token_id, black_box(&100i128), &None);
         });
     });
 }

--- a/contracts/tipjar/benches/gas_benchmarks.rs
+++ b/contracts/tipjar/benches/gas_benchmarks.rs
@@ -117,7 +117,9 @@ fn gas_bench_tip_with_message() {
     let metadata = Map::new(&env);
 
     env.budget().reset_default();
-    client.tip_with_message(&sender, &creator, &token_id, &1_000_000, &message, &metadata);
+    client.tip_with_message(
+        &sender, &creator, &token_id, &1_000_000, &message, &metadata,
+    );
     let cpu = env.budget().cpu_instruction_count();
     let mem = env.budget().memory_bytes_count();
 

--- a/contracts/tipjar/examples/verify_events.rs
+++ b/contracts/tipjar/examples/verify_events.rs
@@ -1,15 +1,15 @@
 //! Simple verification that event emission functions compile and are accessible
 
-use soroban_sdk::{Env, Address};
+use soroban_sdk::{Address, Env};
 
 fn main() {
     // This is a compile-time check only
     // We're verifying that the event emission functions exist and have the correct signatures
-    
+
     let _check_functions = || {
         let env = Env::default();
         let addr = Address::generate(&env);
-        
+
         // Verify all 9 event emission functions exist with correct signatures
         tipjar::synthetic::emit_synthetic_asset_created(&env, 1, addr.clone(), addr.clone(), 15000);
         tipjar::synthetic::emit_synthetic_tokens_minted(&env, 1, addr.clone(), 1000, 1500);
@@ -21,6 +21,6 @@ fn main() {
         tipjar::synthetic::emit_synthetic_asset_resumed(&env, 1);
         tipjar::synthetic::emit_collateralization_updated(&env, 1, 20000);
     };
-    
+
     println!("All event emission functions are properly defined and accessible!");
 }

--- a/contracts/tipjar/src/amm/pool.rs
+++ b/contracts/tipjar/src/amm/pool.rs
@@ -7,8 +7,8 @@ use crate::{DataKey, TipJarError};
 use super::{
     accrue_fee, get_lp_shares, get_pool, get_pool_id_by_tokens, isqrt, next_pool_id,
     pending_rewards, register_pool_tokens, save_pool, set_lp_shares, set_provider_debt,
-    settle_rewards, AddLiquidityResult, LiquidityPool, RemoveLiquidityResult,
-    DEFAULT_FEE_BPS, MIN_INITIAL_LIQUIDITY,
+    settle_rewards, AddLiquidityResult, LiquidityPool, RemoveLiquidityResult, DEFAULT_FEE_BPS,
+    MIN_INITIAL_LIQUIDITY,
 };
 
 // ── Pool creation ────────────────────────────────────────────────────────────
@@ -158,7 +158,11 @@ pub fn add_liquidity(
     set_lp_shares(env, pool_id, provider, current_shares + shares);
     set_provider_debt(env, pool_id, provider, pool.fee_per_share_accum);
 
-    AddLiquidityResult { shares_minted: shares, amount_a, amount_b }
+    AddLiquidityResult {
+        shares_minted: shares,
+        amount_a,
+        amount_b,
+    }
 }
 
 // ── Remove liquidity ─────────────────────────────────────────────────────────
@@ -219,7 +223,11 @@ pub fn remove_liquidity(
         token::Client::new(env, &pool.token_a).transfer(&contract, provider, &rewards);
     }
 
-    RemoveLiquidityResult { amount_a, amount_b, rewards_claimed: rewards }
+    RemoveLiquidityResult {
+        amount_a,
+        amount_b,
+        rewards_claimed: rewards,
+    }
 }
 
 // ── Reward claim ─────────────────────────────────────────────────────────────

--- a/contracts/tipjar/src/amm/swap.rs
+++ b/contracts/tipjar/src/amm/swap.rs
@@ -4,7 +4,7 @@ use soroban_sdk::{panic_with_error, token, Address, Env};
 
 use crate::{DataKey, TipJarError};
 
-use super::{pool::accrue_pool_fee, save_pool, get_pool, SwapResult};
+use super::{get_pool, pool::accrue_pool_fee, save_pool, SwapResult};
 
 // ── Core swap ────────────────────────────────────────────────────────────────
 
@@ -61,7 +61,11 @@ pub fn swap(
         // spot = reserve_out / reserve_in (× 10_000 for bps)
         let spot = reserve_out * 10_000 / reserve_in;
         let effective = amount_out * 10_000 / amount_in;
-        if spot > effective { (spot - effective) * 10_000 / spot } else { 0 }
+        if spot > effective {
+            (spot - effective) * 10_000 / spot
+        } else {
+            0
+        }
     };
 
     // Transfer token_in from sender to contract
@@ -91,7 +95,11 @@ pub fn swap(
     save_pool(env, &pool);
 
     // Transfer token_out to sender
-    let token_out = if is_a_in { pool.token_b.clone() } else { pool.token_a.clone() };
+    let token_out = if is_a_in {
+        pool.token_b.clone()
+    } else {
+        pool.token_a.clone()
+    };
     token::Client::new(env, &token_out).transfer(&contract, sender, &amount_out);
 
     SwapResult {
@@ -131,7 +139,7 @@ pub fn calculate_input_for_output(
     let numerator = reserve_in * amount_out;
     let denominator = reserve_out - amount_out;
     let amount_in_after_fee = numerator / denominator + 1; // ceil
-    // amount_in = amount_in_after_fee * 10_000 / (10_000 - fee_bps)
+                                                           // amount_in = amount_in_after_fee * 10_000 / (10_000 - fee_bps)
     amount_in_after_fee * 10_000 / (10_000 - fee_bps as i128) + 1
 }
 
@@ -153,7 +161,11 @@ pub fn price_impact_bps(
     }
     let spot = reserve_out * 10_000 / reserve_in;
     let effective = amount_out * 10_000 / amount_in;
-    if spot > effective { (spot - effective) * 10_000 / spot } else { 0 }
+    if spot > effective {
+        (spot - effective) * 10_000 / spot
+    } else {
+        0
+    }
 }
 
 /// View: expected output for a swap (no state change).

--- a/contracts/tipjar/src/bonding_curve.rs
+++ b/contracts/tipjar/src/bonding_curve.rs
@@ -235,15 +235,23 @@ const INTEGRATION_STEPS: u32 = 20;
 /// Computes the collateral cost to buy `amount` tokens starting from `current_supply`.
 /// Returns raw collateral (not scaled by PRECISION).
 fn cost_to_buy(curve: &BondingCurve, amount: i128) -> i128 {
-    integrate_price(curve, curve.supply, curve.supply + amount, INTEGRATION_STEPS)
-        / PRECISION
+    integrate_price(
+        curve,
+        curve.supply,
+        curve.supply + amount,
+        INTEGRATION_STEPS,
+    ) / PRECISION
 }
 
 /// Computes the collateral returned for selling `amount` tokens.
 /// Returns raw collateral (not scaled by PRECISION).
 fn return_on_sell(curve: &BondingCurve, amount: i128) -> i128 {
-    integrate_price(curve, curve.supply - amount, curve.supply, INTEGRATION_STEPS)
-        / PRECISION
+    integrate_price(
+        curve,
+        curve.supply - amount,
+        curve.supply,
+        INTEGRATION_STEPS,
+    ) / PRECISION
 }
 
 // ── Storage helpers ───────────────────────────────────────────────────────────
@@ -255,8 +263,7 @@ fn get_curve(env: &Env, curve_id: u64) -> Option<BondingCurve> {
 }
 
 fn get_curve_or_panic(env: &Env, curve_id: u64) -> BondingCurve {
-    get_curve(env, curve_id)
-        .unwrap_or_else(|| panic_with_error!(env, TipJarError::BcNotFound))
+    get_curve(env, curve_id).unwrap_or_else(|| panic_with_error!(env, TipJarError::BcNotFound))
 }
 
 fn set_curve(env: &Env, curve: &BondingCurve) {
@@ -361,7 +368,12 @@ pub fn create_curve(
 
     env.events().publish(
         (symbol_short!("bc_create"),),
-        (curve_id, creator.clone(), tip_token.clone(), reserve_token.clone()),
+        (
+            curve_id,
+            creator.clone(),
+            tip_token.clone(),
+            reserve_token.clone(),
+        ),
     );
 
     curve_id
@@ -512,7 +524,13 @@ pub fn sell(
 
     env.events().publish(
         (symbol_short!("bc_sell"),),
-        (seller.clone(), curve_id, token_amount, net_return, new_price),
+        (
+            seller.clone(),
+            curve_id,
+            token_amount,
+            net_return,
+            new_price,
+        ),
     );
 
     TradeResult {
@@ -604,10 +622,8 @@ pub fn deactivate_curve(env: &Env, creator: &Address, curve_id: u64) {
     curve.active = false;
     set_curve(env, &curve);
 
-    env.events().publish(
-        (symbol_short!("bc_deact"),),
-        (curve_id,),
-    );
+    env.events()
+        .publish((symbol_short!("bc_deact"),), (curve_id,));
 }
 
 /// Returns a price quote for buying or selling `amount` tokens without
@@ -661,27 +677,21 @@ mod math_tests {
     fn linear_curve() -> BondingCurve {
         BondingCurve {
             id: 1,
-            creator: soroban_sdk::Address::from_string(
-                &soroban_sdk::String::from_str(
-                    &soroban_sdk::Env::default(),
-                    "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN",
-                ),
-            ),
-            tip_token: soroban_sdk::Address::from_string(
-                &soroban_sdk::String::from_str(
-                    &soroban_sdk::Env::default(),
-                    "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN",
-                ),
-            ),
-            reserve_token: soroban_sdk::Address::from_string(
-                &soroban_sdk::String::from_str(
-                    &soroban_sdk::Env::default(),
-                    "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN",
-                ),
-            ),
+            creator: soroban_sdk::Address::from_string(&soroban_sdk::String::from_str(
+                &soroban_sdk::Env::default(),
+                "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN",
+            )),
+            tip_token: soroban_sdk::Address::from_string(&soroban_sdk::String::from_str(
+                &soroban_sdk::Env::default(),
+                "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN",
+            )),
+            reserve_token: soroban_sdk::Address::from_string(&soroban_sdk::String::from_str(
+                &soroban_sdk::Env::default(),
+                "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN",
+            )),
             curve_type: CurveType::Linear,
-            base_price: PRECISION,       // 1.0
-            slope: PRECISION / 10,       // 0.1 per token
+            base_price: PRECISION, // 1.0
+            slope: PRECISION / 10, // 0.1 per token
             k_param: 0,
             midpoint: 0,
             max_price: 0,
@@ -750,6 +760,9 @@ mod math_tests {
         // Should be approximately equal (within integration error)
         let diff = (buy_cost - sell_ret).abs();
         let tolerance = buy_cost / 20; // 5% tolerance for numerical integration
-        assert!(diff < tolerance, "buy={buy_cost} sell={sell_ret} diff={diff}");
+        assert!(
+            diff < tolerance,
+            "buy={buy_cost} sell={sell_ret} diff={diff}"
+        );
     }
 }

--- a/contracts/tipjar/src/bridge/mod.rs
+++ b/contracts/tipjar/src/bridge/mod.rs
@@ -117,4 +117,3 @@ pub enum BridgeDataKey {
     /// Bridge feature enabled flag.
     BridgeEnabled,
 }
-

--- a/contracts/tipjar/src/bridge/relayer.rs
+++ b/contracts/tipjar/src/bridge/relayer.rs
@@ -1,7 +1,13 @@
 use soroban_sdk::{symbol_short, token, Address, Env};
 
 use crate::bridge::{validator, BridgeDataKey, BridgeTip};
-use crate::{DataKey, TipJarError, CoreError, SystemError, FeatureError, VestingError, StreamError, AuctionError, CreditError, OtherError, BridgeKey, VestingKey, StreamKey, AuctionKey, MultiSigKey, DisputeKey, PrivateTipKey, InsuranceKey, OptionKey, SyntheticKey, CircuitBreakerKey, MilestoneKey, RoleKey, StatsKey, LockedTipKey, MatchingKey, FeeKey, SnapshotKey, LimitKey, DelegationKey};
+use crate::{
+    AuctionError, AuctionKey, BridgeKey, CircuitBreakerKey, CoreError, CreditError, DataKey,
+    DelegationKey, DisputeKey, FeatureError, FeeKey, InsuranceKey, LimitKey, LockedTipKey,
+    MatchingKey, MilestoneKey, MultiSigKey, OptionKey, OtherError, PrivateTipKey, RoleKey,
+    SnapshotKey, StatsKey, StreamError, StreamKey, SyntheticKey, SystemError, TipJarError,
+    VestingError, VestingKey,
+};
 
 /// Processes a bridged tip submitted by an authorised relayer.
 ///
@@ -9,7 +15,11 @@ use crate::{DataKey, TipJarError, CoreError, SystemError, FeatureError, VestingE
 /// Validates the tip, transfers funds from the relayer into contract escrow,
 /// deducts bridge fees, credits the creator's balance, emits bridge events, and
 /// marks the source transaction as processed (replay protection).
-pub fn process_bridge_tip(env: &Env, relayer: &Address, tip: &BridgeTip) -> Result<(), TipJarError> {
+pub fn process_bridge_tip(
+    env: &Env,
+    relayer: &Address,
+    tip: &BridgeTip,
+) -> Result<(), TipJarError> {
     // 1. Check bridge is enabled.
     let enabled: bool = env
         .storage()
@@ -59,11 +69,15 @@ pub fn process_bridge_tip(env: &Env, relayer: &Address, tip: &BridgeTip) -> Resu
     // 8. Credit creator balance and historical total.
     let bal_key = DataKey::CreatorBalance(tip.creator.clone(), token_address.clone());
     let balance: i128 = env.storage().persistent().get(&bal_key).unwrap_or(0);
-    env.storage().persistent().set(&bal_key, &(balance + net_amount));
+    env.storage()
+        .persistent()
+        .set(&bal_key, &(balance + net_amount));
 
     let tot_key = DataKey::CreatorTotal(tip.creator.clone(), token_address.clone());
     let total: i128 = env.storage().persistent().get(&tot_key).unwrap_or(0);
-    env.storage().persistent().set(&tot_key, &(total + tip.amount));
+    env.storage()
+        .persistent()
+        .set(&tot_key, &(total + tip.amount));
 
     // 9. Accumulate bridge fees if any.
     if fee > 0 {
@@ -78,7 +92,12 @@ pub fn process_bridge_tip(env: &Env, relayer: &Address, tip: &BridgeTip) -> Resu
     // 11. Emit bridge events.
     env.events().publish(
         (symbol_short!("bridge"), tip.creator.clone()),
-        (tip.source_chain.clone(), tip.source_tx_hash.clone(), tip.amount, fee),
+        (
+            tip.source_chain.clone(),
+            tip.source_tx_hash.clone(),
+            tip.amount,
+            fee,
+        ),
     );
 
     if fee > 0 {
@@ -90,4 +109,3 @@ pub fn process_bridge_tip(env: &Env, relayer: &Address, tip: &BridgeTip) -> Resu
 
     Ok(())
 }
-

--- a/contracts/tipjar/src/bridge/validator.rs
+++ b/contracts/tipjar/src/bridge/validator.rs
@@ -15,9 +15,10 @@ pub fn is_processed(env: &Env, source_tx_hash: &BytesN<32>) -> bool {
 
 /// Marks a source transaction as processed to prevent replay.
 pub fn mark_processed(env: &Env, source_tx_hash: &BytesN<32>) {
-    env.storage()
-        .persistent()
-        .set(&BridgeDataKey::BridgeProcessed(source_tx_hash.clone()), &true);
+    env.storage().persistent().set(
+        &BridgeDataKey::BridgeProcessed(source_tx_hash.clone()),
+        &true,
+    );
 }
 
 /// Validates a bridge tip request.
@@ -152,4 +153,3 @@ mod tests {
         assert!(validate_chain_supported(&env, &SourceChain::Polygon).is_ok());
     }
 }
-

--- a/contracts/tipjar/src/circuit_breaker.rs
+++ b/contracts/tipjar/src/circuit_breaker.rs
@@ -1,9 +1,8 @@
 /// Enhanced Circuit Breaker System
-/// 
+///
 /// This module provides sophisticated automated protection against extreme market volatility,
 /// anomalous trading patterns, and potential attacks within the Stellar tipjar contracts.
-
-use soroban_sdk::{contracttype, contracterror};
+use soroban_sdk::{contracterror, contracttype};
 
 /// Enhanced circuit breaker configuration with comprehensive protection parameters
 #[contracttype]
@@ -12,7 +11,7 @@ pub struct EnhancedCircuitBreakerConfig {
     // Single tip thresholds
     /// Maximum amount for a single tip before triggering immediate halt
     pub max_single_tip: i128,
-    
+
     // Volume thresholds for different time windows
     /// Maximum volume allowed in a 1-minute sliding window
     pub one_minute_threshold: i128,
@@ -22,13 +21,13 @@ pub struct EnhancedCircuitBreakerConfig {
     pub one_hour_threshold: i128,
     /// Maximum volume allowed in a 24-hour sliding window
     pub twenty_four_hour_threshold: i128,
-    
+
     // Rate limiting parameters
     /// Maximum number of tips allowed per minute globally
     pub max_tips_per_minute: u32,
     /// Maximum number of tips per creator per minute
     pub max_tips_per_creator_per_min: u32,
-    
+
     // Anomaly detection parameters
     /// Whether advanced anomaly detection is enabled
     pub anomaly_detection_enabled: bool,
@@ -36,7 +35,7 @@ pub struct EnhancedCircuitBreakerConfig {
     pub anomaly_confidence_threshold: u32,
     /// Whether pattern analysis for coordinated attacks is enabled
     pub pattern_analysis_enabled: bool,
-    
+
     // Cooldown configuration
     /// Base cooldown duration in seconds for standard triggers
     pub base_cooldown_seconds: u64,
@@ -46,7 +45,7 @@ pub struct EnhancedCircuitBreakerConfig {
     pub exponential_backoff_enabled: bool,
     /// Backoff multiplier in basis points (e.g., 15000 = 1.5x multiplier)
     pub backoff_multiplier: u32,
-    
+
     // System control flags
     /// Whether the circuit breaker system is enabled
     pub enabled: bool,
@@ -111,7 +110,7 @@ pub enum CircuitBreakerError {
 
 impl EnhancedCircuitBreakerConfig {
     /// Validates all configuration parameters for correctness and consistency
-    /// 
+    ///
     /// Returns Ok(()) if configuration is valid, or Err with specific error code
     pub fn validate(&self) -> Result<(), CircuitBreakerError> {
         // Validate single tip threshold
@@ -178,20 +177,20 @@ impl EnhancedCircuitBreakerConfig {
     /// Creates a default configuration with conservative settings
     pub fn default_config() -> Self {
         Self {
-            max_single_tip: 1_000_000_000, // 1 billion stroops (100 XLM)
-            one_minute_threshold: 10_000_000_000,    // 1,000 XLM per minute
-            five_minute_threshold: 40_000_000_000,   // 4,000 XLM per 5 minutes
-            one_hour_threshold: 200_000_000_000,     // 20,000 XLM per hour
+            max_single_tip: 1_000_000_000,         // 1 billion stroops (100 XLM)
+            one_minute_threshold: 10_000_000_000,  // 1,000 XLM per minute
+            five_minute_threshold: 40_000_000_000, // 4,000 XLM per 5 minutes
+            one_hour_threshold: 200_000_000_000,   // 20,000 XLM per hour
             twenty_four_hour_threshold: 2_000_000_000_000, // 200,000 XLM per day
             max_tips_per_minute: 1000,
             max_tips_per_creator_per_min: 100,
             anomaly_detection_enabled: true,
             anomaly_confidence_threshold: 7500, // 75%
             pattern_analysis_enabled: true,
-            base_cooldown_seconds: 300,     // 5 minutes
-            max_cooldown_seconds: 86400,    // 24 hours
+            base_cooldown_seconds: 300,  // 5 minutes
+            max_cooldown_seconds: 86400, // 24 hours
             exponential_backoff_enabled: true,
-            backoff_multiplier: 15000,      // 1.5x multiplier
+            backoff_multiplier: 15000, // 1.5x multiplier
             enabled: true,
             emergency_mode: false,
             maintenance_mode: false,
@@ -232,9 +231,9 @@ impl VolumeThresholds {
     /// Creates default volume thresholds with conservative limits
     pub fn default_config() -> Self {
         Self {
-            one_minute_threshold: 10_000_000_000,    // 1,000 XLM per minute
-            five_minute_threshold: 40_000_000_000,   // 4,000 XLM per 5 minutes
-            one_hour_threshold: 200_000_000_000,     // 20,000 XLM per hour
+            one_minute_threshold: 10_000_000_000,  // 1,000 XLM per minute
+            five_minute_threshold: 40_000_000_000, // 4,000 XLM per 5 minutes
+            one_hour_threshold: 200_000_000_000,   // 20,000 XLM per hour
             twenty_four_hour_threshold: 2_000_000_000_000, // 200,000 XLM per day
             percentage_based_enabled: true,
             historical_multiplier: 20000, // 200% above historical average
@@ -265,10 +264,10 @@ impl CooldownConfig {
     /// Creates default cooldown configuration
     pub fn default_config() -> Self {
         Self {
-            base_cooldown_seconds: 300,     // 5 minutes
-            max_cooldown_seconds: 86400,    // 24 hours
+            base_cooldown_seconds: 300,  // 5 minutes
+            max_cooldown_seconds: 86400, // 24 hours
             exponential_backoff_enabled: true,
-            backoff_multiplier: 15000,      // 1.5x multiplier
+            backoff_multiplier: 15000, // 1.5x multiplier
         }
     }
 }
@@ -394,7 +393,7 @@ pub struct EnhancedCircuitBreakerState {
     pub halt_reason: Option<TriggerType>,
     /// Severity of current halt (if any)
     pub halt_severity: Option<TriggerSeverity>,
-    
+
     /// Volume tracking for 1-minute window
     pub one_minute_window: VolumeWindow,
     /// Volume tracking for 5-minute window
@@ -403,18 +402,18 @@ pub struct EnhancedCircuitBreakerState {
     pub one_hour_window: VolumeWindow,
     /// Volume tracking for 24-hour window
     pub twenty_four_hour_window: VolumeWindow,
-    
+
     /// Rate limiting state
     pub rate_limit_state: RateLimitState,
-    
+
     /// Total number of times circuit breaker has been triggered
     pub trigger_count: u32,
     /// Timestamp of last trigger
     pub last_trigger_time: u64,
-    
+
     /// Anomaly detection state (optional, only if enabled)
     pub anomaly_state: Option<AnomalyDetectionState>,
-    
+
     /// Total number of halts
     pub total_halts: u32,
     /// Total duration of all halts (seconds)
@@ -483,14 +482,13 @@ impl EnhancedCircuitBreakerState {
     }
 }
 
-
 /// Circuit breaker trigger engine for detecting anomalies and enforcing halts
 pub mod trigger_engine {
     use super::*;
     use soroban_sdk::{Address, Env};
 
     /// Checks if a single tip amount exceeds configured thresholds
-    /// 
+    ///
     /// Returns Some(TriggerSeverity) if threshold is exceeded, None otherwise
     pub fn check_single_tip_spike(
         config: &EnhancedCircuitBreakerConfig,
@@ -511,7 +509,7 @@ pub mod trigger_engine {
     }
 
     /// Checks creator-specific limits if configured
-    /// 
+    ///
     /// Returns Some(TriggerSeverity) if creator-specific limit is exceeded
     pub fn check_creator_specific_limit(
         _env: &Env,
@@ -528,7 +526,7 @@ pub mod trigger_engine {
     }
 
     /// Checks token-specific limits if configured
-    /// 
+    ///
     /// Returns Some(TriggerSeverity) if token-specific limit is exceeded
     pub fn check_token_specific_limit(
         _env: &Env,
@@ -545,7 +543,7 @@ pub mod trigger_engine {
     }
 
     /// Triggers an immediate halt for spike conditions
-    /// 
+    ///
     /// Updates state with halt information and calculates cooldown period
     pub fn trigger_immediate_halt(
         state: &mut EnhancedCircuitBreakerState,
@@ -555,7 +553,7 @@ pub mod trigger_engine {
         current_time: u64,
     ) {
         let cooldown = calculate_cooldown(config, severity, state.trigger_count);
-        
+
         state.halted_until = current_time.saturating_add(cooldown);
         state.halt_reason = Some(trigger_type);
         state.halt_severity = Some(severity);
@@ -582,21 +580,23 @@ pub mod trigger_engine {
             // Apply exponential backoff: cooldown * (multiplier ^ trigger_count)
             let multiplier = config.backoff_multiplier as u64;
             let mut adjusted = base_cooldown;
-            
-            for _ in 0..trigger_count.min(5) { // Cap at 5 iterations to prevent overflow
+
+            for _ in 0..trigger_count.min(5) {
+                // Cap at 5 iterations to prevent overflow
                 adjusted = adjusted.saturating_mul(multiplier) / 10000;
             }
-            
+
             adjusted
         } else {
             base_cooldown
         };
 
         // Ensure cooldown is within configured bounds
-        cooldown.min(config.max_cooldown_seconds).max(config.base_cooldown_seconds)
+        cooldown
+            .min(config.max_cooldown_seconds)
+            .max(config.base_cooldown_seconds)
     }
 }
-
 
 /// Volume tracking and monitoring module
 pub mod volume_tracker {
@@ -651,19 +651,24 @@ pub mod volume_tracker {
     ) {
         // Update 1-minute window
         update_volume_window(&mut state.one_minute_window, amount, current_time, 60);
-        
+
         // Update 5-minute window
         update_volume_window(&mut state.five_minute_window, amount, current_time, 300);
-        
+
         // Update 1-hour window
         update_volume_window(&mut state.one_hour_window, amount, current_time, 3600);
-        
+
         // Update 24-hour window
-        update_volume_window(&mut state.twenty_four_hour_window, amount, current_time, 86400);
+        update_volume_window(
+            &mut state.twenty_four_hour_window,
+            amount,
+            current_time,
+            86400,
+        );
     }
 
     /// Checks all volume windows against configured thresholds
-    /// 
+    ///
     /// Returns Some((TriggerType, TriggerSeverity)) if any threshold is exceeded
     pub fn check_all_volume_thresholds(
         state: &EnhancedCircuitBreakerState,
@@ -726,10 +731,7 @@ pub mod volume_tracker {
     }
 
     /// Calculates percentage-based threshold relative to historical average
-    pub fn calculate_percentage_threshold(
-        historical_average: i128,
-        multiplier_bps: u32,
-    ) -> i128 {
+    pub fn calculate_percentage_threshold(historical_average: i128, multiplier_bps: u32) -> i128 {
         // multiplier_bps is in basis points (e.g., 20000 = 200% above average)
         historical_average.saturating_mul(multiplier_bps as i128) / 10000
     }
@@ -767,16 +769,12 @@ pub mod volume_tracker {
     }
 }
 
-
 /// Rate limiting module for tip frequency control
 pub mod rate_limiter {
     use super::*;
 
     /// Updates rate limit state with new tip
-    pub fn update_rate_limit_state(
-        state: &mut RateLimitState,
-        current_time: u64,
-    ) {
+    pub fn update_rate_limit_state(state: &mut RateLimitState, current_time: u64) {
         // Check if we need to start a new minute window
         if current_time >= state.current_minute_start.saturating_add(60) {
             // Start new minute
@@ -828,14 +826,13 @@ pub mod rate_limiter {
     }
 }
 
-
 /// Advanced anomaly detection module
 pub mod anomaly_detector {
     use super::*;
     use soroban_sdk::Address;
 
     /// Calculates sender clustering score
-    /// 
+    ///
     /// Detects if tips are coming from a small set of related addresses
     /// Returns score in basis points (0-10000)
     pub fn calculate_sender_clustering_score(
@@ -872,7 +869,7 @@ pub mod anomaly_detector {
     }
 
     /// Calculates velocity anomaly score
-    /// 
+    ///
     /// Detects unusual tip frequency patterns
     /// Returns score in basis points (0-10000)
     pub fn calculate_velocity_anomaly_score(
@@ -888,7 +885,7 @@ pub mod anomaly_detector {
         if current_rate > historical_average {
             let excess = current_rate - historical_average;
             let ratio = excess * 10000 / historical_average;
-            
+
             // Score increases as we exceed the deviation threshold
             if ratio > deviation_threshold {
                 ((ratio - deviation_threshold) * 10000 / deviation_threshold).min(10000)
@@ -901,7 +898,7 @@ pub mod anomaly_detector {
     }
 
     /// Calculates amount deviation score
-    /// 
+    ///
     /// Detects tips with amounts that deviate significantly from historical patterns
     /// Returns score in basis points (0-10000)
     pub fn calculate_amount_deviation_score(
@@ -943,10 +940,12 @@ pub mod anomaly_detector {
         if let Some(anomaly_state) = state {
             // Update historical statistics
             let stats = &mut anomaly_state.historical_stats;
-            
+
             // Simple moving average update
             let new_sample_count = stats.sample_count.saturating_add(1);
-            let total = stats.average_tip_amount.saturating_mul(stats.sample_count as i128);
+            let total = stats
+                .average_tip_amount
+                .saturating_mul(stats.sample_count as i128);
             stats.average_tip_amount = total.saturating_add(amount) / new_sample_count as i128;
             stats.sample_count = new_sample_count;
             stats.last_update = current_time;
@@ -970,10 +969,11 @@ pub mod anomaly_detector {
     ) -> u32 {
         // Weighted average of anomaly scores
         // Sender clustering: 40%, Velocity: 30%, Amount: 30%
-        let weighted_sum = sender_clustering.saturating_mul(40)
+        let weighted_sum = sender_clustering
+            .saturating_mul(40)
             .saturating_add(velocity_anomaly.saturating_mul(30))
             .saturating_add(amount_deviation.saturating_mul(30));
-        
+
         weighted_sum / 100
     }
 
@@ -1024,17 +1024,12 @@ pub mod anomaly_detector {
     }
 }
 
-
 /// Rolling statistics module for historical pattern tracking
 pub mod statistics {
     use super::*;
 
     /// Updates rolling statistics with new tip data
-    pub fn update_rolling_statistics(
-        stats: &mut HistoricalStats,
-        amount: i128,
-        current_time: u64,
-    ) {
+    pub fn update_rolling_statistics(stats: &mut HistoricalStats, amount: i128, current_time: u64) {
         let old_count = stats.sample_count;
         let new_count = old_count.saturating_add(1);
 
@@ -1046,11 +1041,13 @@ pub mod statistics {
         // Update standard deviation using Welford's online algorithm
         if old_count > 0 {
             let delta2 = amount - stats.average_tip_amount;
-            let variance_sum = stats.standard_deviation.saturating_mul(stats.standard_deviation)
+            let variance_sum = stats
+                .standard_deviation
+                .saturating_mul(stats.standard_deviation)
                 .saturating_mul(old_count as i128);
             let new_variance_sum = variance_sum.saturating_add(delta.saturating_mul(delta2));
             let new_variance = new_variance_sum / new_count as i128;
-            
+
             // Calculate square root approximation for standard deviation
             stats.standard_deviation = sqrt_approx(new_variance);
         }
@@ -1094,28 +1091,24 @@ pub mod statistics {
         }
 
         let rate = tips_in_window / window_duration_minutes;
-        
+
         // Exponential moving average for tip rate
         if stats.average_tips_per_minute == 0 {
             stats.average_tips_per_minute = rate;
         } else {
             // EMA with alpha = 0.2
-            stats.average_tips_per_minute = 
-                (stats.average_tips_per_minute * 4 + rate) / 5;
+            stats.average_tips_per_minute = (stats.average_tips_per_minute * 4 + rate) / 5;
         }
     }
 
     /// Updates unique sender statistics
-    pub fn update_sender_stats(
-        stats: &mut HistoricalStats,
-        unique_senders: u32,
-    ) {
+    pub fn update_sender_stats(stats: &mut HistoricalStats, unique_senders: u32) {
         // Exponential moving average for unique senders
         if stats.unique_senders_per_hour == 0 {
             stats.unique_senders_per_hour = unique_senders;
         } else {
             // EMA with alpha = 0.2
-            stats.unique_senders_per_hour = 
+            stats.unique_senders_per_hour =
                 (stats.unique_senders_per_hour * 4 + unique_senders) / 5;
         }
     }
@@ -1154,14 +1147,13 @@ pub mod statistics {
     }
 }
 
-
 /// Pattern analysis module for detecting coordinated attacks
 pub mod pattern_analyzer {
     use super::*;
     use soroban_sdk::Address;
 
     /// Analyzes tip velocity for a specific creator
-    /// 
+    ///
     /// Returns anomaly score in basis points (0-10000)
     pub fn analyze_creator_velocity(
         creator_tip_count: u32,
@@ -1197,7 +1189,7 @@ pub mod pattern_analyzer {
     }
 
     /// Detects sequential tips from potentially related addresses
-    /// 
+    ///
     /// Returns true if suspicious pattern detected
     pub fn detect_sequential_pattern(
         recent_senders: &[Address],
@@ -1213,7 +1205,7 @@ pub mod pattern_analyzer {
         // Check for rapid sequential tips
         for i in 1..recent_timestamps.len().min(10) {
             let time_gap = recent_timestamps[i] - recent_timestamps[i - 1];
-            
+
             if time_gap < max_time_gap {
                 sequential_count += 1;
             }
@@ -1259,18 +1251,14 @@ pub mod pattern_analyzer {
     }
 
     /// Analyzes correlation with external market events
-    /// 
+    ///
     /// This is a placeholder for future integration with oracle data
-    pub fn analyze_market_correlation(
-        _tip_volume: i128,
-        _time_window: u64,
-    ) -> u32 {
+    pub fn analyze_market_correlation(_tip_volume: i128, _time_window: u64) -> u32 {
         // TODO: Integrate with price oracle to detect correlation
         // with market volatility or price movements
         0
     }
 }
-
 
 /// Halt state management module
 pub mod halt_manager {
@@ -1285,8 +1273,9 @@ pub mod halt_manager {
         severity: TriggerSeverity,
         current_time: u64,
     ) {
-        let cooldown = super::trigger_engine::calculate_cooldown(config, severity, state.trigger_count);
-        
+        let cooldown =
+            super::trigger_engine::calculate_cooldown(config, severity, state.trigger_count);
+
         state.halted_until = current_time.saturating_add(cooldown);
         state.halt_reason = Some(trigger_type);
         state.halt_severity = Some(severity);
@@ -1305,17 +1294,14 @@ pub mod halt_manager {
     }
 
     /// Performs automatic recovery after cooldown expires
-    pub fn perform_automatic_recovery(
-        state: &mut EnhancedCircuitBreakerState,
-        current_time: u64,
-    ) {
+    pub fn perform_automatic_recovery(state: &mut EnhancedCircuitBreakerState, current_time: u64) {
         state.halted_until = 0;
         state.halt_reason = None;
         state.halt_severity = None;
-        
+
         // Reset volume counters
         super::volume_tracker::reset_volume_counters(state, current_time);
-        
+
         // Reset rate limit state
         super::rate_limiter::reset_rate_limit_state(state, current_time);
     }
@@ -1344,8 +1330,13 @@ pub mod halt_manager {
     ) -> (bool, Option<TriggerType>, Option<TriggerSeverity>, u64) {
         let is_halted = state.is_halted(current_time);
         let remaining = state.remaining_cooldown(current_time);
-        
-        (is_halted, state.halt_reason.clone(), state.halt_severity, remaining)
+
+        (
+            is_halted,
+            state.halt_reason.clone(),
+            state.halt_severity,
+            remaining,
+        )
     }
 
     /// Extends existing halt period
@@ -1360,11 +1351,10 @@ pub mod halt_manager {
 
         state.halted_until = state.halted_until.saturating_add(additional_seconds);
         state.total_halt_duration = state.total_halt_duration.saturating_add(additional_seconds);
-        
+
         Ok(())
     }
 }
-
 
 /// Cooldown period management module
 pub mod cooldown_manager {
@@ -1419,20 +1409,17 @@ pub mod cooldown_manager {
 
         let multiplier = multiplier_bps as u64;
         let mut adjusted = base_cooldown;
-        
+
         // Apply multiplier for each recent trigger (cap at 5 to prevent overflow)
         for _ in 0..trigger_count.min(5) {
             adjusted = adjusted.saturating_mul(multiplier) / 10000;
         }
-        
+
         adjusted
     }
 
     /// Enforces minimum and maximum cooldown bounds
-    fn enforce_cooldown_bounds(
-        cooldown: u64,
-        config: &EnhancedCircuitBreakerConfig,
-    ) -> u64 {
+    fn enforce_cooldown_bounds(cooldown: u64, config: &EnhancedCircuitBreakerConfig) -> u64 {
         cooldown
             .max(config.base_cooldown_seconds)
             .min(config.max_cooldown_seconds)
@@ -1468,11 +1455,10 @@ pub mod cooldown_manager {
 
         let stage_duration = total_cooldown / recovery_stages as u64;
         let current_stage = elapsed_time / stage_duration;
-        
+
         current_stage.min(recovery_stages as u64) as u32
     }
 }
-
 
 /// Error handling and state preservation module
 pub mod error_handler {
@@ -1523,9 +1509,13 @@ pub mod error_handler {
         match &state.halt_reason {
             Some(TriggerType::SingleTipSpike) => HaltErrorCode::SingleTipSpike,
             Some(TriggerType::VolumeSpike(TimeWindow::OneMinute)) => HaltErrorCode::VolumeSpike1Min,
-            Some(TriggerType::VolumeSpike(TimeWindow::FiveMinutes)) => HaltErrorCode::VolumeSpike5Min,
+            Some(TriggerType::VolumeSpike(TimeWindow::FiveMinutes)) => {
+                HaltErrorCode::VolumeSpike5Min
+            }
             Some(TriggerType::VolumeSpike(TimeWindow::OneHour)) => HaltErrorCode::VolumeSpike1Hour,
-            Some(TriggerType::VolumeSpike(TimeWindow::TwentyFourHours)) => HaltErrorCode::VolumeSpike24Hour,
+            Some(TriggerType::VolumeSpike(TimeWindow::TwentyFourHours)) => {
+                HaltErrorCode::VolumeSpike24Hour
+            }
             Some(TriggerType::RateLimit) => HaltErrorCode::RateLimitExceeded,
             Some(TriggerType::AnomalyDetection) => HaltErrorCode::AnomalyDetected,
             Some(TriggerType::PatternAnalysis) => HaltErrorCode::SuspiciousPattern,
@@ -1536,7 +1526,9 @@ pub mod error_handler {
     }
 
     /// Validates state integrity during initialization
-    pub fn validate_state_integrity(state: &EnhancedCircuitBreakerState) -> Result<(), CircuitBreakerError> {
+    pub fn validate_state_integrity(
+        state: &EnhancedCircuitBreakerState,
+    ) -> Result<(), CircuitBreakerError> {
         // Check for logical consistency
         if state.halted_until > 0 && state.halt_reason.is_none() {
             return Err(CircuitBreakerError::InvalidConfiguration);
@@ -1562,9 +1554,7 @@ pub mod error_handler {
     }
 
     /// Preserves balances and state during halt periods
-    pub fn ensure_state_preservation(
-        _state: &EnhancedCircuitBreakerState,
-    ) -> bool {
+    pub fn ensure_state_preservation(_state: &EnhancedCircuitBreakerState) -> bool {
         // State preservation is guaranteed by not modifying any balance or
         // user state during halt periods. This function serves as a validation point.
         true
@@ -1582,14 +1572,13 @@ pub mod error_handler {
     }
 }
 
-
 /// Administrative interface for circuit breaker management
 pub mod admin {
     use super::*;
     use soroban_sdk::{Address, Env};
 
     /// Sets enhanced circuit breaker configuration
-    /// 
+    ///
     /// Validates configuration before applying
     pub fn set_enhanced_config(
         env: &Env,
@@ -1603,10 +1592,9 @@ pub mod admin {
         config.validate()?;
 
         // Store configuration
-        env.storage().instance().set(
-            &super::CircuitBreakerKey::EnhancedConfig,
-            config
-        );
+        env.storage()
+            .instance()
+            .set(&super::CircuitBreakerKey::EnhancedConfig, config);
 
         // Emit configuration update event
         env.events().publish(
@@ -1619,7 +1607,9 @@ pub mod admin {
 
     /// Gets current enhanced configuration
     pub fn get_enhanced_config(env: &Env) -> Option<EnhancedCircuitBreakerConfig> {
-        env.storage().instance().get(&super::CircuitBreakerKey::EnhancedConfig)
+        env.storage()
+            .instance()
+            .get(&super::CircuitBreakerKey::EnhancedConfig)
     }
 
     /// Sets creator-specific limit override
@@ -1637,7 +1627,7 @@ pub mod admin {
 
         env.storage().persistent().set(
             &super::CircuitBreakerKey::CreatorOverrides(creator.clone()),
-            &limit
+            &limit,
         );
 
         env.events().publish(
@@ -1649,28 +1639,22 @@ pub mod admin {
     }
 
     /// Removes creator-specific limit override
-    pub fn remove_creator_limit(
-        env: &Env,
-        admin: &Address,
-        creator: &Address,
-    ) {
+    pub fn remove_creator_limit(env: &Env, admin: &Address, creator: &Address) {
         admin.require_auth();
 
-        env.storage().persistent().remove(
-            &super::CircuitBreakerKey::CreatorOverrides(creator.clone())
-        );
+        env.storage()
+            .persistent()
+            .remove(&super::CircuitBreakerKey::CreatorOverrides(creator.clone()));
 
-        env.events().publish(
-            (soroban_sdk::symbol_short!("cb_crrm"), creator.clone()),
-            (),
-        );
+        env.events()
+            .publish((soroban_sdk::symbol_short!("cb_crrm"), creator.clone()), ());
     }
 
     /// Gets creator-specific limit
     pub fn get_creator_limit(env: &Env, creator: &Address) -> Option<i128> {
-        env.storage().persistent().get(
-            &super::CircuitBreakerKey::CreatorOverrides(creator.clone())
-        )
+        env.storage()
+            .persistent()
+            .get(&super::CircuitBreakerKey::CreatorOverrides(creator.clone()))
     }
 
     /// Sets token-specific limit
@@ -1688,7 +1672,7 @@ pub mod admin {
 
         env.storage().persistent().set(
             &super::CircuitBreakerKey::TokenLimits(token.clone()),
-            &limit
+            &limit,
         );
 
         env.events().publish(
@@ -1701,12 +1685,11 @@ pub mod admin {
 
     /// Gets token-specific limit
     pub fn get_token_limit(env: &Env, token: &Address) -> Option<i128> {
-        env.storage().persistent().get(
-            &super::CircuitBreakerKey::TokenLimits(token.clone())
-        )
+        env.storage()
+            .persistent()
+            .get(&super::CircuitBreakerKey::TokenLimits(token.clone()))
     }
 }
-
 
 /// Manual override capabilities for administrative control
 pub mod manual_override {
@@ -1725,7 +1708,7 @@ pub mod manual_override {
         admin.require_auth();
 
         let current_time = env.ledger().timestamp();
-        
+
         super::halt_manager::activate_halt(
             state,
             config,
@@ -1791,7 +1774,7 @@ pub mod manual_override {
         admin.require_auth();
 
         let current_time = env.ledger().timestamp();
-        
+
         super::halt_manager::extend_halt(state, additional_seconds, current_time)?;
 
         // Emit extension event
@@ -1803,7 +1786,6 @@ pub mod manual_override {
         Ok(())
     }
 }
-
 
 /// Emergency and maintenance mode management
 pub mod emergency_mode {
@@ -1821,10 +1803,9 @@ pub mod emergency_mode {
 
         config.emergency_mode = true;
 
-        env.storage().instance().set(
-            &super::CircuitBreakerKey::EnhancedConfig,
-            config
-        );
+        env.storage()
+            .instance()
+            .set(&super::CircuitBreakerKey::EnhancedConfig, config);
 
         env.events().publish(
             (soroban_sdk::symbol_short!("cb_emerg"), admin.clone()),
@@ -1842,15 +1823,12 @@ pub mod emergency_mode {
 
         config.emergency_mode = false;
 
-        env.storage().instance().set(
-            &super::CircuitBreakerKey::EnhancedConfig,
-            config
-        );
+        env.storage()
+            .instance()
+            .set(&super::CircuitBreakerKey::EnhancedConfig, config);
 
-        env.events().publish(
-            (soroban_sdk::symbol_short!("cb_emoff"), admin.clone()),
-            (),
-        );
+        env.events()
+            .publish((soroban_sdk::symbol_short!("cb_emoff"), admin.clone()), ());
     }
 
     /// Enables maintenance mode
@@ -1863,15 +1841,12 @@ pub mod emergency_mode {
 
         config.maintenance_mode = true;
 
-        env.storage().instance().set(
-            &super::CircuitBreakerKey::EnhancedConfig,
-            config
-        );
+        env.storage()
+            .instance()
+            .set(&super::CircuitBreakerKey::EnhancedConfig, config);
 
-        env.events().publish(
-            (soroban_sdk::symbol_short!("cb_maint"), admin.clone()),
-            (),
-        );
+        env.events()
+            .publish((soroban_sdk::symbol_short!("cb_maint"), admin.clone()), ());
     }
 
     /// Disables maintenance mode
@@ -1884,15 +1859,12 @@ pub mod emergency_mode {
 
         config.maintenance_mode = false;
 
-        env.storage().instance().set(
-            &super::CircuitBreakerKey::EnhancedConfig,
-            config
-        );
+        env.storage()
+            .instance()
+            .set(&super::CircuitBreakerKey::EnhancedConfig, config);
 
-        env.events().publish(
-            (soroban_sdk::symbol_short!("cb_mtoff"), admin.clone()),
-            (),
-        );
+        env.events()
+            .publish((soroban_sdk::symbol_short!("cb_mtoff"), admin.clone()), ());
     }
 
     /// Checks if system is in emergency or maintenance mode
@@ -1900,7 +1872,6 @@ pub mod emergency_mode {
         config.emergency_mode || config.maintenance_mode
     }
 }
-
 
 /// Query interface for external systems
 pub mod query {
@@ -1937,12 +1908,9 @@ pub mod query {
     }
 
     /// Gets comprehensive halt status
-    pub fn get_halt_status(
-        env: &Env,
-        state: &EnhancedCircuitBreakerState,
-    ) -> HaltStatusResult {
+    pub fn get_halt_status(env: &Env, state: &EnhancedCircuitBreakerState) -> HaltStatusResult {
         let current_time = env.ledger().timestamp();
-        let (is_halted, reason, severity, remaining) = 
+        let (is_halted, reason, severity, remaining) =
             super::halt_manager::get_halt_status(state, current_time);
 
         HaltStatusResult {
@@ -1955,10 +1923,7 @@ pub mod query {
     }
 
     /// Gets remaining cooldown time in seconds
-    pub fn get_remaining_cooldown(
-        env: &Env,
-        state: &EnhancedCircuitBreakerState,
-    ) -> u64 {
+    pub fn get_remaining_cooldown(env: &Env, state: &EnhancedCircuitBreakerState) -> u64 {
         let current_time = env.ledger().timestamp();
         state.remaining_cooldown(current_time)
     }
@@ -1976,9 +1941,7 @@ pub mod query {
     }
 
     /// Gets anomaly scores if anomaly detection is enabled
-    pub fn get_anomaly_scores(
-        state: &EnhancedCircuitBreakerState,
-    ) -> Option<(u32, u32, u32, u32)> {
+    pub fn get_anomaly_scores(state: &EnhancedCircuitBreakerState) -> Option<(u32, u32, u32, u32)> {
         state.anomaly_state.as_ref().map(|anomaly| {
             (
                 anomaly.sender_clustering_score,
@@ -2000,19 +1963,15 @@ pub mod query {
     }
 }
 
-
 /// Estimation and planning functions for integration
 pub mod estimation {
     use super::*;
     use soroban_sdk::Env;
 
     /// Estimates recovery time based on current state
-    pub fn estimate_recovery_time(
-        env: &Env,
-        state: &EnhancedCircuitBreakerState,
-    ) -> u64 {
+    pub fn estimate_recovery_time(env: &Env, state: &EnhancedCircuitBreakerState) -> u64 {
         let current_time = env.ledger().timestamp();
-        
+
         if !state.is_halted(current_time) {
             return 0;
         }
@@ -2021,9 +1980,7 @@ pub mod estimation {
     }
 
     /// Estimates gas cost for circuit breaker check operation
-    pub fn estimate_check_gas_cost(
-        config: &EnhancedCircuitBreakerConfig,
-    ) -> u64 {
+    pub fn estimate_check_gas_cost(config: &EnhancedCircuitBreakerConfig) -> u64 {
         let mut base_cost = 1000u64; // Base cost for simple checks
 
         // Add cost for volume tracking
@@ -2046,12 +2003,10 @@ pub mod estimation {
     }
 
     /// Provides performance metrics and recommendations
-    pub fn get_performance_metrics(
-        state: &EnhancedCircuitBreakerState,
-    ) -> (u32, u64, f64) {
+    pub fn get_performance_metrics(state: &EnhancedCircuitBreakerState) -> (u32, u64, f64) {
         let total_halts = state.total_halts;
         let total_duration = state.total_halt_duration;
-        
+
         // Calculate average halt duration
         let avg_duration = if total_halts > 0 {
             total_duration as f64 / total_halts as f64
@@ -2104,7 +2059,6 @@ pub mod estimation {
     }
 }
 
-
 /// Batch query capabilities for efficient multi-entity queries
 pub mod batch_query {
     use super::*;
@@ -2152,7 +2106,7 @@ pub mod batch_query {
         for creator in creators.iter() {
             let override_limit = super::admin::get_creator_limit(env, &creator);
             let has_override = override_limit.is_some();
-            
+
             let status_code = get_system_status_code(config);
 
             results.set(
@@ -2180,7 +2134,7 @@ pub mod batch_query {
         for token in tokens.iter() {
             let token_limit = super::admin::get_token_limit(env, &token);
             let has_limit = token_limit.is_some();
-            
+
             let status_code = get_system_status_code(config);
 
             results.set(
@@ -2238,11 +2192,10 @@ pub mod batch_query {
     }
 }
 
-
 /// Comprehensive event emission system
 pub mod events {
     use super::*;
-    use soroban_sdk::{Address, Env, Symbol, symbol_short};
+    use soroban_sdk::{symbol_short, Address, Env, Symbol};
 
     /// Recovery type enumeration
     #[contracttype]
@@ -2265,7 +2218,12 @@ pub mod events {
     ) {
         env.events().publish(
             (symbol_short!("cb_trig"), trigger_id),
-            (trigger_type.clone(), severity, cooldown_duration, volume_stats.cloned()),
+            (
+                trigger_type.clone(),
+                severity,
+                cooldown_duration,
+                volume_stats.cloned(),
+            ),
         );
     }
 
@@ -2289,10 +2247,8 @@ pub mod events {
         admin: &Address,
         config: &EnhancedCircuitBreakerConfig,
     ) {
-        env.events().publish(
-            (symbol_short!("cb_cfg"), admin.clone()),
-            config.clone(),
-        );
+        env.events()
+            .publish((symbol_short!("cb_cfg"), admin.clone()), config.clone());
     }
 
     /// Emits periodic status event during extended halts
@@ -2303,17 +2259,16 @@ pub mod events {
     ) {
         env.events().publish(
             (symbol_short!("cb_stat"), env.ledger().timestamp()),
-            (state.halt_reason.clone(), state.halt_severity, remaining_cooldown),
+            (
+                state.halt_reason.clone(),
+                state.halt_severity,
+                remaining_cooldown,
+            ),
         );
     }
 
     /// Emits audit trail event for state changes
-    pub fn emit_audit_event(
-        env: &Env,
-        action: Symbol,
-        admin: Option<&Address>,
-        details: Symbol,
-    ) {
+    pub fn emit_audit_event(env: &Env, action: Symbol, admin: Option<&Address>, details: Symbol) {
         env.events().publish(
             (symbol_short!("cb_audit"), action),
             (admin.cloned(), details, env.ledger().timestamp()),
@@ -2344,11 +2299,15 @@ pub mod events {
     ) {
         env.events().publish(
             (symbol_short!("cb_anom"), env.ledger().timestamp()),
-            (confidence_score, clustering_score, velocity_score, amount_score),
+            (
+                confidence_score,
+                clustering_score,
+                velocity_score,
+                amount_score,
+            ),
         );
     }
 }
-
 
 /// Audit trail and history tracking
 pub mod audit {
@@ -2385,10 +2344,9 @@ pub mod audit {
         };
 
         // Store audit entry (using temporary storage for recent entries)
-        env.storage().temporary().set(
-            &(symbol_short!("audit"), entry_id),
-            &entry
-        );
+        env.storage()
+            .temporary()
+            .set(&(symbol_short!("audit"), entry_id), &entry);
 
         // Emit audit event
         super::events::emit_audit_event(env, action, admin, details);
@@ -2398,14 +2356,17 @@ pub mod audit {
 
     /// Gets next audit entry ID
     fn get_next_audit_id(env: &Env) -> u64 {
-        let current: u64 = env.storage()
+        let current: u64 = env
+            .storage()
             .instance()
             .get(&symbol_short!("aud_ctr"))
             .unwrap_or(0);
-        
+
         let next = current.saturating_add(1);
-        env.storage().instance().set(&symbol_short!("aud_ctr"), &next);
-        
+        env.storage()
+            .instance()
+            .set(&symbol_short!("aud_ctr"), &next);
+
         next
     }
 
@@ -2413,7 +2374,7 @@ pub mod audit {
     pub fn get_recent_audit_entries(env: &Env, limit: u32) -> Vec<AuditEntry> {
         let mut entries = Vec::new(env);
         let current_id = get_current_audit_id(env);
-        
+
         let start_id = if current_id > limit as u64 {
             current_id - limit as u64
         } else {
@@ -2421,9 +2382,11 @@ pub mod audit {
         };
 
         for id in start_id..=current_id {
-            if let Some(entry) = env.storage().temporary().get::<_, AuditEntry>(
-                &(symbol_short!("audit"), id)
-            ) {
+            if let Some(entry) = env
+                .storage()
+                .temporary()
+                .get::<_, AuditEntry>(&(symbol_short!("audit"), id))
+            {
                 entries.push_back(entry);
             }
         }
@@ -2447,7 +2410,6 @@ pub mod audit {
     }
 }
 
-
 /// Periodic status event emission for extended halts
 pub mod periodic_status {
     use super::*;
@@ -2464,7 +2426,7 @@ pub mod periodic_status {
         interval: u64,
     ) -> bool {
         let current_time = env.ledger().timestamp();
-        
+
         // Only emit if halted
         if !state.is_halted(current_time) {
             return false;
@@ -2475,10 +2437,7 @@ pub mod periodic_status {
     }
 
     /// Emits periodic status event and returns new last status time
-    pub fn emit_periodic_status(
-        env: &Env,
-        state: &EnhancedCircuitBreakerState,
-    ) -> u64 {
+    pub fn emit_periodic_status(env: &Env, state: &EnhancedCircuitBreakerState) -> u64 {
         let current_time = env.ledger().timestamp();
         let remaining = state.remaining_cooldown(current_time);
 
@@ -2517,7 +2476,6 @@ pub mod periodic_status {
         }
     }
 }
-
 
 /// Performance optimization and caching layer
 pub mod cache {
@@ -2568,10 +2526,7 @@ pub mod cache {
 
     /// Checks if cache is valid
     fn is_cache_valid(env: &Env) -> bool {
-        env.storage()
-            .instance()
-            .get(&CACHE_VALID)
-            .unwrap_or(false)
+        env.storage().instance().get(&CACHE_VALID).unwrap_or(false)
     }
 
     /// Marks cache as valid
@@ -2585,21 +2540,16 @@ pub mod cache {
     }
 
     /// Efficient data structure for volume tracking with minimal storage ops
-    pub fn batch_update_volumes(
-        env: &Env,
-        state: &mut EnhancedCircuitBreakerState,
-        amount: i128,
-    ) {
+    pub fn batch_update_volumes(env: &Env, state: &mut EnhancedCircuitBreakerState, amount: i128) {
         let current_time = env.ledger().timestamp();
-        
+
         // Update all windows in a single operation
         super::volume_tracker::update_all_windows(state, amount, current_time);
-        
+
         // Single storage write for all updates
         update_state_cache(env, state);
     }
 }
-
 
 /// State update batching and optimization
 pub mod optimization {
@@ -2653,7 +2603,7 @@ pub mod optimization {
 
         // Only perform expensive calculations if we're close to thresholds
         let current_time = env.ledger().timestamp();
-        
+
         // Update anomaly state
         super::anomaly_detector::update_anomaly_state(
             &mut state.anomaly_state,
@@ -2690,30 +2640,23 @@ pub mod optimization {
         }
 
         // Check 1: Single tip spike (fastest check)
-        if let Some(severity) = super::trigger_engine::check_single_tip_spike(
-            config,
-            amount,
-            creator,
-            token,
-        ) {
+        if let Some(severity) =
+            super::trigger_engine::check_single_tip_spike(config, amount, creator, token)
+        {
             return Some((TriggerType::SingleTipSpike, severity));
         }
 
         // Check 2: Rate limiting (fast check)
-        if let Some(trigger) = super::rate_limiter::check_rate_limit_trigger(
-            state,
-            config,
-            current_time,
-        ) {
+        if let Some(trigger) =
+            super::rate_limiter::check_rate_limit_trigger(state, config, current_time)
+        {
             return Some(trigger);
         }
 
         // Check 3: Volume thresholds (medium cost)
-        if let Some(trigger) = super::volume_tracker::check_all_volume_thresholds(
-            state,
-            config,
-            current_time,
-        ) {
+        if let Some(trigger) =
+            super::volume_tracker::check_all_volume_thresholds(state, config, current_time)
+        {
             return Some(trigger);
         }
 
@@ -2726,11 +2669,7 @@ pub mod optimization {
     }
 
     /// Minimizes storage operations by batching related updates
-    pub fn batch_state_updates(
-        env: &Env,
-        state: &mut EnhancedCircuitBreakerState,
-        amount: i128,
-    ) {
+    pub fn batch_state_updates(env: &Env, state: &mut EnhancedCircuitBreakerState, amount: i128) {
         let current_time = env.ledger().timestamp();
 
         // Batch all volume window updates
@@ -2743,7 +2682,6 @@ pub mod optimization {
         super::cache::update_state_cache(env, state);
     }
 }
-
 
 /// Gas optimization and monitoring
 pub mod gas_optimization {
@@ -2800,11 +2738,7 @@ pub mod gas_optimization {
     }
 
     /// Validates gas estimation accuracy
-    pub fn validate_gas_estimates(
-        estimated: u64,
-        actual: u64,
-        tolerance_percent: u32,
-    ) -> bool {
+    pub fn validate_gas_estimates(estimated: u64, actual: u64, tolerance_percent: u32) -> bool {
         let tolerance = (estimated * tolerance_percent as u64) / 100;
         let diff = if actual > estimated {
             actual - estimated
@@ -2825,11 +2759,10 @@ pub mod gas_optimization {
         let alpha_scaled = alpha as u64;
         let weighted_actual = actual_cost.saturating_mul(alpha_scaled) / 10000;
         let weighted_current = current_estimate.saturating_mul(10000 - alpha_scaled) / 10000;
-        
+
         weighted_actual.saturating_add(weighted_current)
     }
 }
-
 
 /// Main circuit breaker guard interface - primary entry point
 pub mod guard {
@@ -2837,7 +2770,7 @@ pub mod guard {
     use soroban_sdk::{Address, Env};
 
     /// Main circuit breaker check function
-    /// 
+    ///
     /// This is the primary entry point that should be called before tip operations
     pub fn check_circuit_breaker(
         env: &Env,
@@ -2867,7 +2800,7 @@ pub mod guard {
         let current_time = env.ledger().timestamp();
         if halt_manager::check_automatic_recovery(&state, current_time) {
             halt_manager::perform_automatic_recovery(&mut state, current_time);
-            
+
             // Emit recovery event
             let recovery_id = audit::get_current_audit_id(env);
             events::emit_recovery_event(
@@ -2882,25 +2815,26 @@ pub mod guard {
         // Check if operations should be blocked
         if halt_manager::should_block_operations(&state, &config, current_time) {
             let error_code = error_handler::get_halt_error_code(&state, &config);
-            
+
             // Emit periodic status if needed
             periodic_status::check_and_emit_status(env, &state, None);
-            
+
             return Err(CircuitBreakerError::InvalidConfiguration); // Map to appropriate error
         }
 
         // Perform optimized check sequence
-        if let Some((trigger_type, severity)) = optimization::optimized_check_sequence(
-            env,
-            &mut state,
-            &config,
-            amount,
-            creator,
-            token,
-        ) {
+        if let Some((trigger_type, severity)) =
+            optimization::optimized_check_sequence(env, &mut state, &config, amount, creator, token)
+        {
             // Trigger detected - activate halt
-            halt_manager::activate_halt(&mut state, &config, trigger_type.clone(), severity, current_time);
-            
+            halt_manager::activate_halt(
+                &mut state,
+                &config,
+                trigger_type.clone(),
+                severity,
+                current_time,
+            );
+
             // Emit trigger event
             let trigger_id = state.trigger_count as u64;
             let volume_stats = query::get_volume_stats(&state);
@@ -2912,7 +2846,7 @@ pub mod guard {
                 state.halted_until - current_time,
                 Some(&volume_stats),
             );
-            
+
             // Record audit entry
             audit::record_audit_entry(
                 env,
@@ -2920,10 +2854,10 @@ pub mod guard {
                 None,
                 soroban_sdk::symbol_short!("auto"),
             );
-            
+
             // Update state cache
             cache::update_state_cache(env, &state);
-            
+
             return Err(CircuitBreakerError::InvalidConfiguration); // Map to appropriate error
         }
 
@@ -2956,4 +2890,3 @@ pub mod guard {
         query::get_halt_status(env, &state)
     }
 }
-

--- a/contracts/tipjar/src/conditions/evaluator.rs
+++ b/contracts/tipjar/src/conditions/evaluator.rs
@@ -96,7 +96,10 @@ mod tests {
 
         set_offchain_approval(&env, &condition_id, true);
 
-        assert!(evaluate_one(&env, &Condition::OffchainApproved(condition_id)));
+        assert!(evaluate_one(
+            &env,
+            &Condition::OffchainApproved(condition_id)
+        ));
     }
 
     #[test]

--- a/contracts/tipjar/src/dispute.rs
+++ b/contracts/tipjar/src/dispute.rs
@@ -1,4 +1,4 @@
-use soroban_sdk::{Address, Env, String, Vec, contracttype};
+use soroban_sdk::{contracttype, Address, Env, String, Vec};
 
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/contracts/tipjar/src/events/indexing.rs
+++ b/contracts/tipjar/src/events/indexing.rs
@@ -13,7 +13,9 @@ pub fn update_event_index(env: &Env, event: &TipEvent) {
         .get(&creator_key)
         .unwrap_or_else(|| Vec::new(env));
     creator_events.push_back(event.event_id);
-    env.storage().persistent().set(&creator_key, &creator_events);
+    env.storage()
+        .persistent()
+        .set(&creator_key, &creator_events);
 
     // Update sender index
     let sender_key = DataKey::SenderEvents(event.sender.clone());

--- a/contracts/tipjar/src/events/mod.rs
+++ b/contracts/tipjar/src/events/mod.rs
@@ -119,12 +119,7 @@ pub fn emit_tip_event(
 }
 
 /// Emit a withdraw event with enhanced metadata
-pub fn emit_withdraw_event(
-    env: &Env,
-    creator: &Address,
-    amount: i128,
-    token: &Address,
-) {
+pub fn emit_withdraw_event(env: &Env, creator: &Address, amount: i128, token: &Address) {
     let event = WithdrawEvent {
         version: EVENT_VERSION,
         creator: creator.clone(),
@@ -210,12 +205,7 @@ pub fn get_events_by_creator(
 }
 
 /// Get events by time range
-pub fn get_events_by_timerange(
-    env: &Env,
-    start: u64,
-    end: u64,
-    limit: u32,
-) -> Vec<TipEvent> {
+pub fn get_events_by_timerange(env: &Env, start: u64, end: u64, limit: u32) -> Vec<TipEvent> {
     let filter = EventFilter {
         event_type: None,
         sender: None,
@@ -238,11 +228,7 @@ pub fn get_events_by_timerange(
 }
 
 /// Get events by sender
-pub fn get_events_by_sender(
-    env: &Env,
-    sender: &Address,
-    limit: u32,
-) -> Vec<TipEvent> {
+pub fn get_events_by_sender(env: &Env, sender: &Address, limit: u32) -> Vec<TipEvent> {
     let filter = EventFilter {
         event_type: None,
         sender: Some(sender.clone()),
@@ -265,11 +251,7 @@ pub fn get_events_by_sender(
 }
 
 /// Get events by token
-pub fn get_events_by_token(
-    env: &Env,
-    token: &Address,
-    limit: u32,
-) -> Vec<TipEvent> {
+pub fn get_events_by_token(env: &Env, token: &Address, limit: u32) -> Vec<TipEvent> {
     let filter = EventFilter {
         event_type: None,
         sender: None,

--- a/contracts/tipjar/src/fees/adjustment.rs
+++ b/contracts/tipjar/src/fees/adjustment.rs
@@ -1,6 +1,6 @@
-use soroban_sdk::Env;
-use super::calculator::{BASE_FEE_BPS, MIN_FEE_BPS, MAX_FEE_BPS};
+use super::calculator::{BASE_FEE_BPS, MAX_FEE_BPS, MIN_FEE_BPS};
 use crate::DataKey;
+use soroban_sdk::Env;
 
 /// Network congestion level supplied by the caller or an oracle.
 ///
@@ -21,11 +21,13 @@ pub enum CongestionLevel {
 /// transparently via `get_current_fee_bps`.
 pub fn adjusted_fee_bps(env: &Env, congestion: CongestionLevel) -> u32 {
     let raw = match congestion {
-        CongestionLevel::Low    => BASE_FEE_BPS / 2,
+        CongestionLevel::Low => BASE_FEE_BPS / 2,
         CongestionLevel::Normal => BASE_FEE_BPS,
-        CongestionLevel::High   => BASE_FEE_BPS * 3 / 2,
+        CongestionLevel::High => BASE_FEE_BPS * 3 / 2,
     };
     let clamped = raw.clamp(MIN_FEE_BPS, MAX_FEE_BPS);
-    env.storage().instance().set(&DataKey::CurrentFeeBps, &clamped);
+    env.storage()
+        .instance()
+        .set(&DataKey::CurrentFeeBps, &clamped);
     clamped
 }

--- a/contracts/tipjar/src/fees/calculator.rs
+++ b/contracts/tipjar/src/fees/calculator.rs
@@ -1,5 +1,5 @@
-use soroban_sdk::Env;
 use super::adjustment::CongestionLevel;
+use soroban_sdk::Env;
 
 /// Base fee in basis points (1% = 100 bps).
 pub const BASE_FEE_BPS: u32 = 100;

--- a/contracts/tipjar/src/futures/margin.rs
+++ b/contracts/tipjar/src/futures/margin.rs
@@ -38,11 +38,7 @@ pub fn long_is_liquidatable(fc: &FuturesContract) -> bool {
     if fc.status != FuturesStatus::Active {
         return false;
     }
-    let maint = required_maintenance_margin(
-        fc.size,
-        fc.contract_price,
-        fc.maintenance_margin_bps,
-    );
+    let maint = required_maintenance_margin(fc.size, fc.contract_price, fc.maintenance_margin_bps);
     long_effective_margin(fc) < maint
 }
 
@@ -51,11 +47,7 @@ pub fn short_is_liquidatable(fc: &FuturesContract) -> bool {
     if fc.status != FuturesStatus::Active || fc.short_party.is_none() {
         return false;
     }
-    let maint = required_maintenance_margin(
-        fc.size,
-        fc.contract_price,
-        fc.maintenance_margin_bps,
-    );
+    let maint = required_maintenance_margin(fc.size, fc.contract_price, fc.maintenance_margin_bps);
     short_effective_margin(fc) < maint
 }
 

--- a/contracts/tipjar/src/futures/mod.rs
+++ b/contracts/tipjar/src/futures/mod.rs
@@ -241,9 +241,7 @@ pub fn get_config(env: &Env) -> FuturesConfig {
 }
 
 pub fn save_config(env: &Env, cfg: &FuturesConfig) {
-    env.storage()
-        .persistent()
-        .set(&DataKey::FuturesConfig, cfg);
+    env.storage().persistent().set(&DataKey::FuturesConfig, cfg);
 }
 
 // ── Core logic ───────────────────────────────────────────────────────────────
@@ -259,11 +257,16 @@ pub fn open_long(
     settles_at: u64,
 ) -> u64 {
     let cfg = get_config(env);
-    let required_margin = margin::required_initial_margin(size, contract_price, cfg.initial_margin_bps);
+    let required_margin =
+        margin::required_initial_margin(size, contract_price, cfg.initial_margin_bps);
 
     // Transfer margin from long party to contract
     let token_client = token::Client::new(env, token);
-    token_client.transfer(long_party, &env.current_contract_address(), &required_margin);
+    token_client.transfer(
+        long_party,
+        &env.current_contract_address(),
+        &required_margin,
+    );
 
     let contract_id = next_id(env);
     let now = env.ledger().timestamp();
@@ -310,7 +313,11 @@ pub fn match_short(env: &Env, short_party: &Address, contract_id: u64) {
         margin::required_initial_margin(fc.size, fc.contract_price, fc.initial_margin_bps);
 
     let token_client = token::Client::new(env, &fc.token);
-    token_client.transfer(short_party, &env.current_contract_address(), &required_margin);
+    token_client.transfer(
+        short_party,
+        &env.current_contract_address(),
+        &required_margin,
+    );
 
     fc.short_party = Some(short_party.clone());
     fc.short_margin = required_margin;
@@ -331,8 +338,7 @@ pub fn update_mark_price(env: &Env, contract_id: u64, new_price: i128) {
     assert!(fc.status == FuturesStatus::Active, "contract not active");
 
     // Long P&L = (mark_price - contract_price) * size / PRICE_PRECISION
-    fc.long_unrealised_pnl =
-        (new_price - fc.contract_price) * fc.size / PRICE_PRECISION;
+    fc.long_unrealised_pnl = (new_price - fc.contract_price) * fc.size / PRICE_PRECISION;
     fc.mark_price = new_price;
     save_contract(env, &fc);
 }
@@ -392,7 +398,11 @@ pub fn liquidate(env: &Env, liquidator: &Address, contract_id: u64) -> i128 {
     // Return remaining margin to the liquidated party
     let remaining = liquidated_margin - penalty_actual;
     if remaining > 0 {
-        token_client.transfer(&env.current_contract_address(), &liquidated_party, &remaining);
+        token_client.transfer(
+            &env.current_contract_address(),
+            &liquidated_party,
+            &remaining,
+        );
     }
 
     // Return the other side's margin to them

--- a/contracts/tipjar/src/futures/settlement.rs
+++ b/contracts/tipjar/src/futures/settlement.rs
@@ -6,8 +6,10 @@
 
 use soroban_sdk::{token, Env};
 
-use super::{get_contract, get_position, remove_active_contract, save_contract, save_position,
-            FuturesStatus, Side, PRICE_PRECISION};
+use super::{
+    get_contract, get_position, remove_active_contract, save_contract, save_position,
+    FuturesStatus, Side, PRICE_PRECISION,
+};
 
 /// Settle a futures contract at the given final price.
 ///
@@ -50,7 +52,11 @@ pub fn settle(env: &Env, contract_id: u64, final_price: i128) -> (i128, i128) {
     let token_client = token::Client::new(env, &fc.token);
 
     if long_payout > 0 {
-        token_client.transfer(&env.current_contract_address(), &fc.long_party, &long_payout);
+        token_client.transfer(
+            &env.current_contract_address(),
+            &fc.long_party,
+            &long_payout,
+        );
     }
     if short_payout > 0 {
         token_client.transfer(&env.current_contract_address(), &short_party, &short_payout);

--- a/contracts/tipjar/src/governance/conviction.rs
+++ b/contracts/tipjar/src/governance/conviction.rs
@@ -11,9 +11,9 @@ use soroban_sdk::{contracttype, Address, Env};
 pub struct ConvictionVote {
     pub voter: Address,
     pub proposal_id: u64,
-    pub base_voting_power: i128,  // Initial voting power (token amount)
-    pub conviction_start: u64,    // When conviction started accumulating
-    pub last_updated: u64,        // Last time conviction was recalculated
+    pub base_voting_power: i128, // Initial voting power (token amount)
+    pub conviction_start: u64,   // When conviction started accumulating
+    pub last_updated: u64,       // Last time conviction was recalculated
     pub accumulated_conviction: i128, // Total conviction accumulated
 }
 
@@ -21,7 +21,7 @@ pub struct ConvictionVote {
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ConvictionConfig {
-    pub conviction_period: u64,   // Period to reach max conviction (seconds)
+    pub conviction_period: u64, // Period to reach max conviction (seconds)
     pub max_conviction_multiplier: i128, // Max voting power multiplier (e.g., 3_000_000 for 3x)
     pub conviction_decay_rate_bps: u32, // Decay rate in basis points per second when vote changes
     pub min_conviction_threshold: i128, // Minimum conviction to vote
@@ -31,10 +31,10 @@ pub struct ConvictionConfig {
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum ConvictionDataKey {
-    ConvictionVote(u64, Address),      // proposal_id, voter
+    ConvictionVote(u64, Address), // proposal_id, voter
     ConvictionConfig,
-    ConvictionHistory(u64, Address),   // proposal_id, voter - historical records
-    VoterConvictionTotal(Address),     // Total conviction across all votes
+    ConvictionHistory(u64, Address), // proposal_id, voter - historical records
+    VoterConvictionTotal(Address),   // Total conviction across all votes
 }
 
 /// Default conviction voting constants
@@ -150,10 +150,7 @@ pub fn record_conviction_vote(
 
     // Update voter's total conviction
     let total_key = ConvictionDataKey::VoterConvictionTotal(voter.clone());
-    let current_total: i128 = env.storage()
-        .persistent()
-        .get(&total_key)
-        .unwrap_or(0);
+    let current_total: i128 = env.storage().persistent().get(&total_key).unwrap_or(0);
     env.storage()
         .persistent()
         .set(&total_key, &(current_total + base_voting_power));
@@ -181,16 +178,23 @@ pub fn update_conviction_vote(
     }
 
     let vote_key = ConvictionDataKey::ConvictionVote(proposal_id, voter.clone());
-    let mut conviction_vote = env.storage()
+    let mut conviction_vote = env
+        .storage()
         .persistent()
         .get(&vote_key)
         .expect("No conviction vote found");
 
     // Apply decay to accumulated conviction when vote changes
     let decay_rate = config.conviction_decay_rate_bps as i128;
-    let time_since_vote = env.ledger().timestamp().saturating_sub(conviction_vote.last_updated);
-    let decay_amount = conviction_vote.accumulated_conviction * decay_rate * time_since_vote / 10_000 / 1_000_000;
-    conviction_vote.accumulated_conviction = conviction_vote.accumulated_conviction.saturating_sub(decay_amount);
+    let time_since_vote = env
+        .ledger()
+        .timestamp()
+        .saturating_sub(conviction_vote.last_updated);
+    let decay_amount =
+        conviction_vote.accumulated_conviction * decay_rate * time_since_vote / 10_000 / 1_000_000;
+    conviction_vote.accumulated_conviction = conviction_vote
+        .accumulated_conviction
+        .saturating_sub(decay_amount);
 
     // Update vote
     conviction_vote.base_voting_power = new_base_voting_power;
@@ -200,28 +204,21 @@ pub fn update_conviction_vote(
 
     // Update voter's total conviction
     let total_key = ConvictionDataKey::VoterConvictionTotal(voter.clone());
-    let current_total: i128 = env.storage()
-        .persistent()
-        .get(&total_key)
-        .unwrap_or(0);
-    let old_power = env.storage()
+    let current_total: i128 = env.storage().persistent().get(&total_key).unwrap_or(0);
+    let old_power = env
+        .storage()
         .persistent()
         .get(&vote_key)
         .map(|v: ConvictionVote| v.base_voting_power)
         .unwrap_or(0);
     let new_total = current_total - old_power + new_base_voting_power;
-    env.storage()
-        .persistent()
-        .set(&total_key, &new_total);
+    env.storage().persistent().set(&total_key, &new_total);
 }
 
 /// Get total conviction for a voter across all proposals
 pub fn get_voter_total_conviction(env: &Env, voter: &Address) -> i128 {
     let total_key = ConvictionDataKey::VoterConvictionTotal(voter.clone());
-    env.storage()
-        .persistent()
-        .get(&total_key)
-        .unwrap_or(0)
+    env.storage().persistent().get(&total_key).unwrap_or(0)
 }
 
 /// Check if voter meets minimum conviction threshold for a proposal
@@ -241,8 +238,9 @@ pub fn get_proposal_threshold_with_conviction(env: &Env, voter: &Address) -> i12
 
     // Threshold is reduced based on conviction: threshold = base_threshold * (1 - conviction_bonus)
     // conviction_bonus = min(total_conviction / (base_threshold * 10), 0.5)
-    let conviction_bonus = (total_conviction * 1_000_000 / (config.min_conviction_threshold * 10)).min(500_000); // Max 50% reduction
-    
+    let conviction_bonus =
+        (total_conviction * 1_000_000 / (config.min_conviction_threshold * 10)).min(500_000); // Max 50% reduction
+
     config.min_conviction_threshold * (1_000_000 - conviction_bonus) / 1_000_000
 }
 
@@ -260,7 +258,11 @@ pub fn record_conviction_history(
 }
 
 /// Get conviction vote history
-pub fn get_conviction_history(env: &Env, proposal_id: u64, voter: &Address) -> Option<ConvictionVote> {
+pub fn get_conviction_history(
+    env: &Env,
+    proposal_id: u64,
+    voter: &Address,
+) -> Option<ConvictionVote> {
     let history_key = ConvictionDataKey::ConvictionHistory(proposal_id, voter.clone());
     env.storage().persistent().get(&history_key)
 }

--- a/contracts/tipjar/src/governance/conviction_integration.rs
+++ b/contracts/tipjar/src/governance/conviction_integration.rs
@@ -4,11 +4,11 @@
 //! and integrates with the existing proposal and voting systems.
 
 use super::conviction::{
-    self, ConvictionVote, ConvictionConfig, calculate_effective_voting_power,
-    record_conviction_vote, get_conviction_vote, update_conviction_vote,
+    self, calculate_effective_voting_power, get_conviction_vote, record_conviction_vote,
+    update_conviction_vote, ConvictionConfig, ConvictionVote,
 };
 use super::voting;
-use super::{Vote, VoteChoice, DataKey};
+use super::{DataKey, Vote, VoteChoice};
 use soroban_sdk::{Address, Env};
 
 /// Cast a conviction vote on a proposal
@@ -44,8 +44,8 @@ pub fn cast_conviction_vote(
     record_conviction_vote(env, voter, proposal_id, base_voting_power);
 
     // Calculate effective voting power with conviction multiplier
-    let conviction_vote = get_conviction_vote(env, proposal_id, voter)
-        .expect("Conviction vote should exist");
+    let conviction_vote =
+        get_conviction_vote(env, proposal_id, voter).expect("Conviction vote should exist");
     let effective_voting_power = calculate_effective_voting_power(env, &conviction_vote);
 
     // Record standard vote with effective voting power
@@ -61,7 +61,8 @@ pub fn cast_conviction_vote(
 
     // Update voter's total votes
     let voter_votes_key = DataKey::VoterVotes(voter.clone());
-    let current_votes: i128 = env.storage()
+    let current_votes: i128 = env
+        .storage()
         .persistent()
         .get(&voter_votes_key)
         .unwrap_or(0);
@@ -108,21 +109,22 @@ pub fn change_conviction_vote(
 
     // Get existing vote
     let vote_key = DataKey::Vote(proposal_id, voter.clone());
-    let old_vote = env.storage()
+    let old_vote = env
+        .storage()
         .persistent()
         .get(&vote_key)
         .expect("No vote found to change");
 
     // Get existing conviction vote
-    let old_conviction = get_conviction_vote(env, proposal_id, voter)
-        .expect("No conviction vote found");
+    let old_conviction =
+        get_conviction_vote(env, proposal_id, voter).expect("No conviction vote found");
 
     // Update conviction vote (applies decay)
     update_conviction_vote(env, voter, proposal_id, new_base_voting_power);
 
     // Get updated conviction vote
-    let new_conviction = get_conviction_vote(env, proposal_id, voter)
-        .expect("Conviction vote should exist");
+    let new_conviction =
+        get_conviction_vote(env, proposal_id, voter).expect("Conviction vote should exist");
     let new_effective_voting_power = calculate_effective_voting_power(env, &new_conviction);
 
     // Update standard vote
@@ -135,7 +137,8 @@ pub fn change_conviction_vote(
 
     // Update voter's total votes
     let voter_votes_key = DataKey::VoterVotes(voter.clone());
-    let current_votes: i128 = env.storage()
+    let current_votes: i128 = env
+        .storage()
         .persistent()
         .get(&voter_votes_key)
         .unwrap_or(0);
@@ -188,7 +191,8 @@ pub fn get_conviction_voting_details(
     voter: &Address,
 ) -> Option<ConvictionVotingDetails> {
     if let Some(conviction_vote) = get_conviction_vote(env, proposal_id, voter) {
-        let multiplier = conviction::calculate_conviction_multiplier(env, conviction_vote.conviction_start);
+        let multiplier =
+            conviction::calculate_conviction_multiplier(env, conviction_vote.conviction_start);
         let accumulated = conviction::calculate_accumulated_conviction(env, &conviction_vote);
         let effective_power = calculate_effective_voting_power(env, &conviction_vote);
 
@@ -198,7 +202,10 @@ pub fn get_conviction_voting_details(
             conviction_multiplier: multiplier,
             accumulated_conviction: accumulated,
             effective_voting_power: effective_power,
-            time_locked: env.ledger().timestamp().saturating_sub(conviction_vote.conviction_start),
+            time_locked: env
+                .ledger()
+                .timestamp()
+                .saturating_sub(conviction_vote.conviction_start),
         })
     } else {
         None

--- a/contracts/tipjar/src/governance/mod.rs
+++ b/contracts/tipjar/src/governance/mod.rs
@@ -2,11 +2,11 @@
 //!
 //! This module provides on-chain governance functionality.
 
-pub mod proposals;
-pub mod voting;
-pub mod timelock;
 pub mod conviction;
 pub mod conviction_integration;
+pub mod proposals;
+pub mod timelock;
+pub mod voting;
 
 use soroban_sdk::{contracttype, Address, Env, String, Vec};
 

--- a/contracts/tipjar/src/governance/proposals.rs
+++ b/contracts/tipjar/src/governance/proposals.rs
@@ -1,6 +1,6 @@
 //! Proposal management for governance
 
-use super::{Proposal, ProposalAction, DataKey};
+use super::{DataKey, Proposal, ProposalAction};
 use soroban_sdk::{Address, Env, String, Vec};
 
 /// Create a new proposal
@@ -59,12 +59,7 @@ pub fn get_proposal_or_panic(env: &Env, proposal_id: u64) -> Proposal {
 }
 
 /// Update proposal votes
-pub fn update_proposal_votes(
-    env: &Env,
-    proposal_id: u64,
-    votes_for: i128,
-    votes_against: i128,
-) {
+pub fn update_proposal_votes(env: &Env, proposal_id: u64, votes_for: i128, votes_against: i128) {
     let mut proposal = get_proposal_or_panic(env, proposal_id);
     proposal.votes_for = votes_for;
     proposal.votes_against = votes_against;
@@ -96,7 +91,10 @@ pub fn is_proposal_active(env: &Env, proposal_id: u64) -> bool {
     let proposal = get_proposal_or_panic(env, proposal_id);
     let now = env.ledger().timestamp();
 
-    !proposal.canceled && !proposal.executed && now >= proposal.start_time && now <= proposal.end_time
+    !proposal.canceled
+        && !proposal.executed
+        && now >= proposal.start_time
+        && now <= proposal.end_time
 }
 
 /// Check if proposal has passed

--- a/contracts/tipjar/src/governance/timelock.rs
+++ b/contracts/tipjar/src/governance/timelock.rs
@@ -1,6 +1,6 @@
 //! Timelock mechanism for governance
 
-use super::{ProposalAction, DataKey};
+use super::{DataKey, ProposalAction};
 use soroban_sdk::{Address, Env, String, Vec};
 
 /// Execute a proposal after timelock
@@ -41,31 +41,23 @@ fn execute_action(env: &Env, action: &ProposalAction) {
         ProposalAction::UpdateFee(new_fee_bps) => {
             // In production, this would update the AMM fee
             // For now, we'll just log the action
-            env.events().publish(
-                (soroban_sdk::symbol_short!("fee_upd"),),
-                *new_fee_bps,
-            );
+            env.events()
+                .publish((soroban_sdk::symbol_short!("fee_upd"),), *new_fee_bps);
         }
         ProposalAction::AddToken(token) => {
             // In production, this would add token to whitelist
-            env.events().publish(
-                (soroban_sdk::symbol_short!("token_add"),),
-                token.clone(),
-            );
+            env.events()
+                .publish((soroban_sdk::symbol_short!("token_add"),), token.clone());
         }
         ProposalAction::RemoveToken(token) => {
             // In production, this would remove token from whitelist
-            env.events().publish(
-                (soroban_sdk::symbol_short!("token_rm"),),
-                token.clone(),
-            );
+            env.events()
+                .publish((soroban_sdk::symbol_short!("token_rm"),), token.clone());
         }
         ProposalAction::UpdatePauseStatus(paused) => {
             // In production, this would update pause status
-            env.events().publish(
-                (soroban_sdk::symbol_short!("pause_upd"),),
-                *paused,
-            );
+            env.events()
+                .publish((soroban_sdk::symbol_short!("pause_upd"),), *paused);
         }
         ProposalAction::UpdateTimelock(new_timelock) => {
             // Update timelock in governance config
@@ -99,10 +91,8 @@ fn execute_action(env: &Env, action: &ProposalAction) {
         }
         ProposalAction::Custom(data) => {
             // Custom action - just log it
-            env.events().publish(
-                (soroban_sdk::symbol_short!("custom"),),
-                data.clone(),
-            );
+            env.events()
+                .publish((soroban_sdk::symbol_short!("custom"),), data.clone());
         }
     }
 }

--- a/contracts/tipjar/src/governance/voting.rs
+++ b/contracts/tipjar/src/governance/voting.rs
@@ -1,6 +1,6 @@
 //! Voting mechanism for governance
 
-use super::{Vote, VoteChoice, DataKey};
+use super::{DataKey, Vote, VoteChoice};
 use soroban_sdk::{Address, Env, Vec};
 
 /// Cast a vote on a proposal
@@ -42,7 +42,11 @@ pub fn cast_vote(
 
     // Update voter's total votes
     let voter_votes_key = DataKey::VoterVotes(voter.clone());
-    let current_votes: i128 = env.storage().persistent().get(&voter_votes_key).unwrap_or(0);
+    let current_votes: i128 = env
+        .storage()
+        .persistent()
+        .get(&voter_votes_key)
+        .unwrap_or(0);
     env.storage()
         .persistent()
         .set(&voter_votes_key, &(current_votes + voting_power));
@@ -71,7 +75,10 @@ pub fn get_vote(env: &Env, proposal_id: u64, voter: &Address) -> Option<Vote> {
 /// Get total votes cast by a voter
 pub fn get_voter_total_votes(env: &Env, voter: &Address) -> i128 {
     let voter_votes_key = DataKey::VoterVotes(voter.clone());
-    env.storage().persistent().get(&voter_votes_key).unwrap_or(0)
+    env.storage()
+        .persistent()
+        .get(&voter_votes_key)
+        .unwrap_or(0)
 }
 
 /// Get all votes for a proposal
@@ -105,4 +112,3 @@ pub fn get_vote_breakdown(env: &Env, proposal_id: u64) -> (i128, i128, i128) {
     let total_votes = proposal.votes_for + proposal.votes_against;
     (proposal.votes_for, proposal.votes_against, total_votes)
 }
-

--- a/contracts/tipjar/src/index_fund/mod.rs
+++ b/contracts/tipjar/src/index_fund/mod.rs
@@ -83,9 +83,7 @@ pub const INITIAL_SHARE_PRICE: i128 = 1_000_000; // 6 decimal precision
 
 /// Get a fund by ID.
 pub fn get_fund(env: &Env, fund_id: u64) -> Option<IndexFund> {
-    env.storage()
-        .persistent()
-        .get(&DataKey::Fund(fund_id))
+    env.storage().persistent().get(&DataKey::Fund(fund_id))
 }
 
 /// Persist a fund record.
@@ -103,9 +101,7 @@ pub fn next_fund_id(env: &Env) -> u64 {
         .get(&DataKey::FundCounter)
         .unwrap_or(0)
         + 1;
-    env.storage()
-        .persistent()
-        .set(&DataKey::FundCounter, &id);
+    env.storage().persistent().set(&DataKey::FundCounter, &id);
     id
 }
 
@@ -124,9 +120,10 @@ pub fn get_share(env: &Env, fund_id: u64, holder: &Address) -> FundShare {
 
 /// Persist a user's share position.
 pub fn save_share(env: &Env, share: &FundShare) {
-    env.storage()
-        .persistent()
-        .set(&DataKey::FundShare(share.fund_id, share.holder.clone()), share);
+    env.storage().persistent().set(
+        &DataKey::FundShare(share.fund_id, share.holder.clone()),
+        share,
+    );
 }
 
 /// Get creator allocation within a fund (token amount allocated to that creator).

--- a/contracts/tipjar/src/index_fund/rebalance.rs
+++ b/contracts/tipjar/src/index_fund/rebalance.rs
@@ -32,10 +32,7 @@ pub fn rebalance(env: &Env, fund_id: u64, caller: &soroban_sdk::Address) {
 }
 
 /// Return the current allocation for each creator as a Vec of (creator, amount) pairs.
-pub fn get_allocations(
-    env: &Env,
-    fund_id: u64,
-) -> soroban_sdk::Vec<(soroban_sdk::Address, i128)> {
+pub fn get_allocations(env: &Env, fund_id: u64) -> soroban_sdk::Vec<(soroban_sdk::Address, i128)> {
     let fund = super::get_fund(env, fund_id).expect("Fund not found");
     let mut result = soroban_sdk::Vec::new(env);
     for component in fund.components.iter() {

--- a/contracts/tipjar/src/index_fund/shares.rs
+++ b/contracts/tipjar/src/index_fund/shares.rs
@@ -3,7 +3,7 @@
 use soroban_sdk::{token, Address, Env};
 
 use super::{
-    get_share, nav_per_share, save_fund, save_share, set_creator_alloc, get_creator_alloc,
+    get_creator_alloc, get_share, nav_per_share, save_fund, save_share, set_creator_alloc,
     INITIAL_SHARE_PRICE, MIN_DEPOSIT,
 };
 

--- a/contracts/tipjar/src/lib.rs
+++ b/contracts/tipjar/src/lib.rs
@@ -49,6 +49,9 @@ pub mod options;
 // Tip Index Funds
 pub mod index_fund;
 
+// Tip Time-Lock Puzzles
+pub mod time_lock_puzzle;
+
 /// A tip record that includes an optional memo and timestamp.
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -685,6 +688,14 @@ pub enum DataKey {
     IndexFundShare(u64, Address),
     /// Creator allocation within a fund keyed by (fund_id, creator).
     IndexCreatorAlloc(u64, Address),
+    /// Time-lock puzzle record by ID.
+    TimeLockPuzzle(u64),
+    /// Global time-lock puzzle counter.
+    TimeLockPuzzleCounter,
+    /// List of puzzle IDs created by an address.
+    CreatorPuzzles(Address),
+    /// List of puzzle IDs targeting a recipient.
+    RecipientPuzzles(Address),
 }
 
 #[contracterror]
@@ -877,6 +888,20 @@ pub enum TipJarError {
     IndexDepositTooSmall = 103,
     /// Attempted to unpause a contract that is not currently paused.
     NotPaused = 104,
+    /// Time-lock puzzle not found.
+    PuzzleNotFound = 105,
+    /// Puzzle is not in Active status.
+    PuzzleNotActive = 106,
+    /// Puzzle unlock time has not been reached yet.
+    PuzzleTooEarly = 107,
+    /// Supplied secret/nonce does not match the puzzle commitment.
+    PuzzleWrongSolution = 108,
+    /// Puzzle has already been solved.
+    PuzzleAlreadySolved = 109,
+    /// Puzzle has been cancelled.
+    PuzzleCancelled = 110,
+    /// Caller is not the puzzle creator.
+    PuzzleUnauthorized = 111,
 }
 
 #[contract]
@@ -5821,5 +5846,185 @@ impl TipJarContract {
         fund_id: u64,
     ) -> Vec<(Address, i128)> {
         index_fund::rebalance::get_allocations(&env, fund_id)
+    }
+
+    // ── Time-Lock Puzzles ────────────────────────────────────────────────────
+
+    /// Create a time-lock puzzle wrapping a tip.
+    ///
+    /// The caller must supply a `commitment` = SHA-256(secret XOR nonce) computed
+    /// off-chain. The `secret` and `nonce` are never stored on-chain; only the
+    /// commitment is persisted. The tip amount is transferred from `creator` to
+    /// the contract and held until the puzzle is solved.
+    ///
+    /// Returns the new puzzle ID.
+    pub fn create_time_lock_puzzle(
+        env: Env,
+        creator: Address,
+        recipient: Address,
+        token: Address,
+        amount: i128,
+        commitment: BytesN<32>,
+        unlock_time: u64,
+        difficulty: time_lock_puzzle::PuzzleDifficulty,
+        custom_iterations: Option<u64>,
+    ) -> u64 {
+        Self::require_not_paused(&env);
+        creator.require_auth();
+
+        if amount <= 0 {
+            panic_with_error!(&env, TipJarError::InvalidAmount);
+        }
+        if unlock_time <= env.ledger().timestamp() {
+            panic_with_error!(&env, TipJarError::InvalidUnlockTime);
+        }
+
+        // Transfer tip amount from creator to contract.
+        let token_client = token::Client::new(&env, &token);
+        token_client.transfer(&creator, &env.current_contract_address(), &amount);
+
+        let iterations =
+            time_lock_puzzle::puzzle::calculate_iterations(difficulty, custom_iterations);
+
+        let id = time_lock_puzzle::next_puzzle_id(&env);
+        let puzzle = time_lock_puzzle::TimeLockPuzzle {
+            id,
+            creator: creator.clone(),
+            recipient: recipient.clone(),
+            token,
+            amount,
+            commitment,
+            iterations,
+            unlock_time,
+            created_at: env.ledger().timestamp(),
+            difficulty,
+            status: time_lock_puzzle::PuzzleStatus::Active,
+        };
+
+        time_lock_puzzle::save_puzzle(&env, &puzzle);
+        time_lock_puzzle::add_creator_puzzle(&env, &creator, id);
+        time_lock_puzzle::add_recipient_puzzle(&env, &recipient, id);
+
+        env.events().publish(
+            (symbol_short!("tlp_new"),),
+            (creator, recipient, id, amount, unlock_time),
+        );
+
+        id
+    }
+
+    /// Solve a time-lock puzzle and release the tip to the recipient.
+    ///
+    /// The solver supplies the original `secret` and `nonce` used to generate
+    /// the commitment. On success the tip is transferred to the recipient.
+    pub fn solve_time_lock_puzzle(
+        env: Env,
+        puzzle_id: u64,
+        secret: BytesN<32>,
+        nonce: BytesN<32>,
+    ) {
+        Self::require_not_paused(&env);
+
+        let puzzle = time_lock_puzzle::get_puzzle(&env, puzzle_id)
+            .unwrap_or_else(|| panic_with_error!(&env, TipJarError::PuzzleNotFound));
+
+        use time_lock_puzzle::solver::{solve_puzzle, SolveResult};
+        match solve_puzzle(&env, puzzle_id, &secret, &nonce) {
+            SolveResult::Success => {}
+            SolveResult::TooEarly => panic_with_error!(&env, TipJarError::PuzzleTooEarly),
+            SolveResult::WrongSolution => {
+                panic_with_error!(&env, TipJarError::PuzzleWrongSolution)
+            }
+            SolveResult::NotActive => match puzzle.status {
+                time_lock_puzzle::PuzzleStatus::Solved => {
+                    panic_with_error!(&env, TipJarError::PuzzleAlreadySolved)
+                }
+                time_lock_puzzle::PuzzleStatus::Cancelled => {
+                    panic_with_error!(&env, TipJarError::PuzzleCancelled)
+                }
+                _ => panic_with_error!(&env, TipJarError::PuzzleNotActive),
+            },
+        }
+
+        // Release tip to recipient.
+        let token_client = token::Client::new(&env, &puzzle.token);
+        token_client.transfer(
+            &env.current_contract_address(),
+            &puzzle.recipient,
+            &puzzle.amount,
+        );
+
+        env.events().publish(
+            (symbol_short!("tlp_slv"),),
+            (puzzle_id, puzzle.recipient, puzzle.amount),
+        );
+    }
+
+    /// Cancel an active time-lock puzzle and refund the tip to the creator.
+    ///
+    /// Only the puzzle creator may cancel.
+    pub fn cancel_time_lock_puzzle(env: Env, creator: Address, puzzle_id: u64) {
+        Self::require_not_paused(&env);
+        creator.require_auth();
+
+        let puzzle = time_lock_puzzle::get_puzzle(&env, puzzle_id)
+            .unwrap_or_else(|| panic_with_error!(&env, TipJarError::PuzzleNotFound));
+
+        if puzzle.creator != creator {
+            panic_with_error!(&env, TipJarError::PuzzleUnauthorized);
+        }
+
+        if !time_lock_puzzle::solver::cancel_puzzle(&env, puzzle_id) {
+            match puzzle.status {
+                time_lock_puzzle::PuzzleStatus::Solved => {
+                    panic_with_error!(&env, TipJarError::PuzzleAlreadySolved)
+                }
+                _ => panic_with_error!(&env, TipJarError::PuzzleNotActive),
+            }
+        }
+
+        // Refund tip to creator.
+        let token_client = token::Client::new(&env, &puzzle.token);
+        token_client.transfer(
+            &env.current_contract_address(),
+            &puzzle.creator,
+            &puzzle.amount,
+        );
+
+        env.events().publish(
+            (symbol_short!("tlp_cnl"),),
+            (puzzle_id, creator, puzzle.amount),
+        );
+    }
+
+    /// Get a time-lock puzzle record by ID.
+    pub fn get_time_lock_puzzle(
+        env: Env,
+        puzzle_id: u64,
+    ) -> Option<time_lock_puzzle::TimeLockPuzzle> {
+        time_lock_puzzle::get_puzzle(&env, puzzle_id)
+    }
+
+    /// Get the status of a time-lock puzzle.
+    pub fn get_puzzle_status(
+        env: Env,
+        puzzle_id: u64,
+    ) -> Option<time_lock_puzzle::PuzzleStatus> {
+        time_lock_puzzle::solver::get_puzzle_status(&env, puzzle_id)
+    }
+
+    /// Check whether a puzzle's unlock time has been reached.
+    pub fn is_puzzle_unlocked(env: Env, puzzle_id: u64) -> bool {
+        time_lock_puzzle::solver::is_puzzle_unlocked(&env, puzzle_id)
+    }
+
+    /// List all puzzle IDs created by an address.
+    pub fn get_creator_puzzles(env: Env, creator: Address) -> Vec<u64> {
+        time_lock_puzzle::get_creator_puzzles(&env, &creator)
+    }
+
+    /// List all puzzle IDs targeting a recipient.
+    pub fn get_recipient_puzzles(env: Env, recipient: Address) -> Vec<u64> {
+        time_lock_puzzle::get_recipient_puzzles(&env, &recipient)
     }
 }

--- a/contracts/tipjar/src/lib.rs
+++ b/contracts/tipjar/src/lib.rs
@@ -2,11 +2,11 @@
 #![deny(unsafe_code)]
 #![deny(missing_docs)]
 
-pub mod interfaces;
-pub mod integrations;
-pub mod security;
 pub mod bridge;
+pub mod integrations;
+pub mod interfaces;
 pub mod privacy;
+pub mod security;
 pub mod synthetic;
 
 /// Polynomial commitment scheme for efficient tip data verification.
@@ -19,17 +19,17 @@ pub mod sidechain;
 pub mod rollup;
 
 use soroban_sdk::{
-    contract, contracterror, contractimpl, contracttype, panic_with_error, symbol_short,
-    token, Address, BytesN, Env, Map, String, Vec,
+    contract, contracterror, contractimpl, contracttype, panic_with_error, symbol_short, token,
+    Address, BytesN, Env, Map, String, Vec,
 };
 
 use circuit_breaker::{
-    EnhancedCircuitBreakerConfig, VolumeThresholds, CooldownConfig, CircuitBreakerError
+    CircuitBreakerError, CooldownConfig, EnhancedCircuitBreakerConfig, VolumeThresholds,
 };
 
-pub mod upgrade;
-pub mod storage;
 pub mod circuit_breaker;
+pub mod storage;
+pub mod upgrade;
 
 #[cfg(test)]
 extern crate std;
@@ -646,7 +646,7 @@ pub enum DataKey {
     /// Creator's currently withdrawable balance held by this contract per token.
     CreatorBalance(Address, Address), // (creator, token)
     /// Historical total tips ever received by creator per token.
-    CreatorTotal(Address, Address),   // (creator, token)
+    CreatorTotal(Address, Address), // (creator, token)
     /// List of token addresses a creator has ever received tips in.
     CreatorTokens(Address),
     /// Emergency pause state (bool).
@@ -1421,26 +1421,36 @@ impl TipJarContract {
             .get(&DataKey::Auction(AuctionKey::CreatorList(creator.clone())))
             .unwrap_or_else(|| Vec::new(env));
         auctions.push_back(auction_id);
-        env.storage()
-            .persistent()
-            .set(&DataKey::Auction(AuctionKey::CreatorList(creator.clone())), &auctions);
+        env.storage().persistent().set(
+            &DataKey::Auction(AuctionKey::CreatorList(creator.clone())),
+            &auctions,
+        );
     }
 
     fn get_auction_internal(env: &Env, auction_id: u64) -> Option<Auction> {
-        env.storage().persistent().get(&DataKey::Auction(AuctionKey::Record(auction_id)))
+        env.storage()
+            .persistent()
+            .get(&DataKey::Auction(AuctionKey::Record(auction_id)))
     }
 
     // ── leaderboard helpers ──────────────────────────────────────────────────
 
-    fn update_leaderboard_stats(
-        env: &Env,
-        tipper: &Address,
-        creator: &Address,
-        amount: i128,
-    ) {
+    fn update_leaderboard_stats(env: &Env, tipper: &Address, creator: &Address, amount: i128) {
         const BUCKET_ALL_TIME: u32 = 0;
-        Self::update_aggregate(env, tipper, amount, BUCKET_ALL_TIME, ParticipantKind::Tipper);
-        Self::update_aggregate(env, creator, amount, BUCKET_ALL_TIME, ParticipantKind::Creator);
+        Self::update_aggregate(
+            env,
+            tipper,
+            amount,
+            BUCKET_ALL_TIME,
+            ParticipantKind::Tipper,
+        );
+        Self::update_aggregate(
+            env,
+            creator,
+            amount,
+            BUCKET_ALL_TIME,
+            ParticipantKind::Creator,
+        );
     }
 
     fn update_aggregate(
@@ -1454,15 +1464,15 @@ impl TipJarContract {
             ParticipantKind::Tipper => DataKey::Stats(StatsKey::TipperAgg(addr.clone(), bucket)),
             ParticipantKind::Creator => DataKey::Stats(StatsKey::CreatorAgg(addr.clone(), bucket)),
         };
-        let mut entry: LeaderboardEntry = env
-            .storage()
-            .persistent()
-            .get(&agg_key)
-            .unwrap_or(LeaderboardEntry {
-                address: addr.clone(),
-                total_amount: 0,
-                tip_count: 0,
-            });
+        let mut entry: LeaderboardEntry =
+            env.storage()
+                .persistent()
+                .get(&agg_key)
+                .unwrap_or(LeaderboardEntry {
+                    address: addr.clone(),
+                    total_amount: 0,
+                    tip_count: 0,
+                });
         entry.total_amount += amount;
         entry.tip_count += 1;
         env.storage().persistent().set(&agg_key, &entry);
@@ -1514,8 +1524,9 @@ impl TipJarContract {
         let mut account = match env
             .storage()
             .persistent()
-            .get::<soroban_sdk::Vec<soroban_sdk::Val>, CreditAccount>(&(symbol_short!("cr_acc"), creator.clone(), token.clone()).into_val(env))
-        {
+            .get::<soroban_sdk::Vec<soroban_sdk::Val>, CreditAccount>(
+                &(symbol_short!("cr_acc"), creator.clone(), token.clone()).into_val(env),
+            ) {
             Some(acc) => acc,
             None => return amount_to_credit,
         };
@@ -1551,9 +1562,10 @@ impl TipJarContract {
 
         account.total_repaid += actual_repayment;
         account.last_update = env.ledger().timestamp();
-        env.storage()
-            .persistent()
-            .set(&(symbol_short!("cr_acc"), creator.clone(), token.clone()).into_val(env), &account);
+        env.storage().persistent().set(
+            &(symbol_short!("cr_acc"), creator.clone(), token.clone()).into_val(env),
+            &account,
+        );
 
         // Repayment goes back to PlatformFeeBalance
         let fee_key = DataKey::Fee(FeeKey::Balance(token.clone()));
@@ -1562,14 +1574,7 @@ impl TipJarContract {
             .instance()
             .set(&fee_key, &(platform_bal + actual_repayment));
 
-        Self::record_credit_event(
-            env,
-            creator,
-            token,
-            actual_repayment,
-            interest_paid,
-            true,
-        );
+        Self::record_credit_event(env, creator, token, actual_repayment, interest_paid, true);
 
         env.events().publish(
             (symbol_short!("repay_au"), creator.clone()),
@@ -1620,7 +1625,9 @@ impl TipJarContract {
             panic_with_error!(&env, TipJarError::AlreadyInitialized);
         }
         env.storage().instance().set(&DataKey::Admin, &admin);
-        env.storage().instance().set(&DataKey::Fee(FeeKey::BasisPoints), &0u32);
+        env.storage()
+            .instance()
+            .set(&DataKey::Fee(FeeKey::BasisPoints), &0u32);
         env.storage().instance().set(&DataKey::RefundWindow, &0u64);
     }
 
@@ -1643,7 +1650,9 @@ impl TipJarContract {
         if admin != stored_admin {
             panic_with_error!(&env, TipJarError::Unauthorized);
         }
-        env.storage().instance().set(&DataKey::TokenWhitelist(token), &true);
+        env.storage()
+            .instance()
+            .set(&DataKey::TokenWhitelist(token), &true);
     }
 
     /// Removes a token from the whitelist. Admin only.
@@ -1653,7 +1662,9 @@ impl TipJarContract {
         if admin != stored_admin {
             panic_with_error!(&env, TipJarError::Unauthorized);
         }
-        env.storage().instance().set(&DataKey::TokenWhitelist(token), &false);
+        env.storage()
+            .instance()
+            .set(&DataKey::TokenWhitelist(token), &false);
     }
 
     /// Returns `true` if `token` is on the whitelist.
@@ -1716,12 +1727,16 @@ impl TipJarContract {
 
     /// Returns the current circuit breaker configuration.
     pub fn get_circuit_breaker_config(env: Env) -> Option<CircuitBreakerConfig> {
-        env.storage().instance().get(&DataKey::CircuitBreaker(CircuitBreakerKey::Cfg))
+        env.storage()
+            .instance()
+            .get(&DataKey::CircuitBreaker(CircuitBreakerKey::Cfg))
     }
 
     /// Returns the current circuit breaker state.
     pub fn get_circuit_breaker_state(env: Env) -> Option<CircuitBreakerState> {
-        env.storage().instance().get(&DataKey::CircuitBreaker(CircuitBreakerKey::State))
+        env.storage()
+            .instance()
+            .get(&DataKey::CircuitBreaker(CircuitBreakerKey::State))
     }
 
     /// Manually triggers the circuit breaker. Admin only.
@@ -1776,14 +1791,10 @@ impl TipJarContract {
     // ── Enhanced Circuit Breaker Functions ──────────────────────────────────
 
     /// Sets the enhanced circuit breaker configuration. Admin only.
-    /// 
+    ///
     /// Validates all configuration parameters before storing.
     /// Emits `("enhanced_cb_config",)` with data `admin`.
-    pub fn set_enhanced_cb_config(
-        env: Env, 
-        admin: Address, 
-        config: EnhancedCircuitBreakerConfig
-    ) {
+    pub fn set_enhanced_cb_config(env: Env, admin: Address, config: EnhancedCircuitBreakerConfig) {
         admin.require_auth();
         let stored_admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
         if admin != stored_admin {
@@ -1795,9 +1806,10 @@ impl TipJarContract {
             panic_with_error!(&env, CreditError::EnhancedCircuitBreakerError);
         }
 
-        env.storage()
-            .instance()
-            .set(&DataKey::CircuitBreaker(CircuitBreakerKey::EnhancedConfig), &config);
+        env.storage().instance().set(
+            &DataKey::CircuitBreaker(CircuitBreakerKey::EnhancedConfig),
+            &config,
+        );
 
         env.events().publish((symbol_short!("cb_cfg"),), admin);
     }
@@ -1810,7 +1822,7 @@ impl TipJarContract {
     }
 
     /// Initializes enhanced circuit breaker with default configuration. Admin only.
-    /// 
+    ///
     /// Creates default configuration if not already present.
     /// Emits `("enhanced_cb_init",)` with data `admin`.
     pub fn init_enhanced_cb(env: Env, admin: Address) {
@@ -1821,16 +1833,19 @@ impl TipJarContract {
         }
 
         // Only initialize if not already configured
-        if env.storage()
+        if env
+            .storage()
             .instance()
-            .has(&DataKey::CircuitBreaker(CircuitBreakerKey::EnhancedConfig)) {
+            .has(&DataKey::CircuitBreaker(CircuitBreakerKey::EnhancedConfig))
+        {
             return;
         }
 
         let default_config = EnhancedCircuitBreakerConfig::default_config();
-        env.storage()
-            .instance()
-            .set(&DataKey::CircuitBreaker(CircuitBreakerKey::EnhancedConfig), &default_config);
+        env.storage().instance().set(
+            &DataKey::CircuitBreaker(CircuitBreakerKey::EnhancedConfig),
+            &default_config,
+        );
 
         env.events().publish((symbol_short!("cb_init"),), admin);
     }
@@ -1897,15 +1912,10 @@ impl TipJarContract {
     }
 
     /// Sets token-specific circuit breaker limits. Admin only.
-    /// 
+    ///
     /// Stores token-specific limits separately from main configuration.
     /// Emits `("token_cb_limit",)` with data `(token, limit)`.
-    pub fn set_token_circuit_breaker_limit(
-        env: Env,
-        admin: Address,
-        token: Address,
-        limit: i128,
-    ) {
+    pub fn set_token_circuit_breaker_limit(env: Env, admin: Address, token: Address, limit: i128) {
         admin.require_auth();
         let stored_admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
         if admin != stored_admin {
@@ -1917,18 +1927,17 @@ impl TipJarContract {
         }
 
         // Store token-specific limit separately
-        env.storage()
-            .persistent()
-            .set(&DataKey::CircuitBreaker(CircuitBreakerKey::TokenLimits(token.clone())), &limit);
-
-        env.events().publish(
-            (symbol_short!("tk_cb_lmt"),), 
-            (token, limit)
+        env.storage().persistent().set(
+            &DataKey::CircuitBreaker(CircuitBreakerKey::TokenLimits(token.clone())),
+            &limit,
         );
+
+        env.events()
+            .publish((symbol_short!("tk_cb_lmt"),), (token, limit));
     }
 
     /// Removes token-specific circuit breaker limits. Admin only.
-    /// 
+    ///
     /// Reverts token to using global limits.
     /// Emits `("token_cb_remove",)` with data `token`.
     pub fn remove_token_circuit_breaker_limit(env: Env, admin: Address, token: Address) {
@@ -1938,9 +1947,9 @@ impl TipJarContract {
             panic_with_error!(&env, TipJarError::Unauthorized);
         }
 
-        env.storage()
-            .persistent()
-            .remove(&DataKey::CircuitBreaker(CircuitBreakerKey::TokenLimits(token.clone())));
+        env.storage().persistent().remove(&DataKey::CircuitBreaker(
+            CircuitBreakerKey::TokenLimits(token.clone()),
+        ));
 
         env.events().publish((symbol_short!("tk_cb_rmv"),), token);
     }
@@ -1952,7 +1961,9 @@ impl TipJarContract {
         if admin != stored_admin {
             panic_with_error!(&env, TipJarError::Unauthorized);
         }
-        env.storage().instance().set(&symbol_short!("cr_cfg"), &config);
+        env.storage()
+            .instance()
+            .set(&symbol_short!("cr_cfg"), &config);
     }
 
     /// Returns the current credit system configuration.
@@ -2016,7 +2027,9 @@ impl TipJarContract {
         let mut account = env
             .storage()
             .persistent()
-            .get::<soroban_sdk::Vec<soroban_sdk::Val>, CreditAccount>(&(symbol_short!("cr_acc"), creator.clone(), token.clone()).into_val(&env))
+            .get::<soroban_sdk::Vec<soroban_sdk::Val>, CreditAccount>(
+                &(symbol_short!("cr_acc"), creator.clone(), token.clone()).into_val(&env),
+            )
             .unwrap_or(CreditAccount {
                 principal: 0,
                 interest_accrued: 0,
@@ -2054,9 +2067,10 @@ impl TipJarContract {
         account.principal += amount;
         account.total_borrowed += amount;
         account.last_update = env.ledger().timestamp();
-        env.storage()
-            .persistent()
-            .set(&(symbol_short!("cr_acc"), creator.clone(), token.clone()).into_val(&env), &account);
+        env.storage().persistent().set(
+            &(symbol_short!("cr_acc"), creator.clone(), token.clone()).into_val(&env),
+            &account,
+        );
 
         Self::record_credit_event(&env, &creator, &token, amount, 0, false);
 
@@ -2075,7 +2089,9 @@ impl TipJarContract {
         let mut account = env
             .storage()
             .persistent()
-            .get::<soroban_sdk::Vec<soroban_sdk::Val>, CreditAccount>(&(symbol_short!("cr_acc"), creator.clone(), token.clone()).into_val(&env))
+            .get::<soroban_sdk::Vec<soroban_sdk::Val>, CreditAccount>(
+                &(symbol_short!("cr_acc"), creator.clone(), token.clone()).into_val(&env),
+            )
             .unwrap_or_else(|| panic_with_error!(&env, OtherError::NoActiveCredit));
 
         let config = env
@@ -2119,9 +2135,10 @@ impl TipJarContract {
 
         account.total_repaid += actual_repayment;
         account.last_update = env.ledger().timestamp();
-        env.storage()
-            .persistent()
-            .set(&(symbol_short!("cr_acc"), creator.clone(), token.clone()).into_val(&env), &account);
+        env.storage().persistent().set(
+            &(symbol_short!("cr_acc"), creator.clone(), token.clone()).into_val(&env),
+            &account,
+        );
 
         let fee_key = DataKey::Fee(FeeKey::Balance(token.clone()));
         let platform_bal: i128 = env.storage().instance().get(&fee_key).unwrap_or(0);
@@ -2177,45 +2194,58 @@ impl TipJarContract {
             panic_with_error!(&env, TipJarError::TokenNotWhitelisted);
         }
 
-        let fee_bp: u32 = env.storage().instance().get(&DataKey::Fee(FeeKey::BasisPoints)).unwrap_or(0);
+        let fee_bp: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey::Fee(FeeKey::BasisPoints))
+            .unwrap_or(0);
         let fee: i128 = (amount * fee_bp as i128) / 10_000;
 
         // --- Insurance Premium Calculation ---
-        let ins_enabled: bool = env.storage().instance().get(&DataKey::Insurance(InsuranceKey::Enabled)).unwrap_or(true);
+        let ins_enabled: bool = env
+            .storage()
+            .instance()
+            .get(&DataKey::Insurance(InsuranceKey::Enabled))
+            .unwrap_or(true);
         let mut ins_premium: i128 = 0;
         if ins_enabled {
-            if let Some(config) = env.storage().instance().get::<DataKey, InsurancePoolConfig>(&DataKey::Insurance(InsuranceKey::Cfg)) {
+            if let Some(config) = env
+                .storage()
+                .instance()
+                .get::<DataKey, InsurancePoolConfig>(&DataKey::Insurance(InsuranceKey::Cfg))
+            {
                 ins_premium = (amount * config.tip_premium_bps as i128) / 10_000;
             }
         }
 
-        let creator_amount = amount.checked_sub(fee).and_then(|a| a.checked_sub(ins_premium)).unwrap_or(0);
+        let creator_amount = amount
+            .checked_sub(fee)
+            .and_then(|a| a.checked_sub(ins_premium))
+            .unwrap_or(0);
 
         // ── state updates before external call (CEI pattern) ─────────────────
         if fee > 0 {
             let fee_key = DataKey::Fee(FeeKey::Balance(token.clone()));
             let current_fee: i128 = env.storage().instance().get(&fee_key).unwrap_or(0);
-            let new_fee_bal: i128 = current_fee
-                .checked_add(fee)
-                .expect("fee overflow");
+            let new_fee_bal: i128 = current_fee.checked_add(fee).expect("fee overflow");
             env.storage().instance().set(&fee_key, &new_fee_bal);
         }
 
         if ins_premium > 0 {
             let pool_key = DataKey::Insurance(InsuranceKey::Token(token.clone()));
-            let mut pool: InsurancePool = env
-                .storage()
-                .persistent()
-                .get(&pool_key)
-                .unwrap_or_else(|| InsurancePool {
-                    token: token.clone(),
-                    total_reserves: 0,
-                    total_contributions: 0,
-                    total_claims_paid: 0,
-                    active_claims: 0,
-                    total_claims: 0,
-                    last_payout_time: env.ledger().timestamp(),
-                });
+            let mut pool: InsurancePool =
+                env.storage()
+                    .persistent()
+                    .get(&pool_key)
+                    .unwrap_or_else(|| InsurancePool {
+                        token: token.clone(),
+                        total_reserves: 0,
+                        total_contributions: 0,
+                        total_claims_paid: 0,
+                        active_claims: 0,
+                        total_claims: 0,
+                        last_payout_time: env.ledger().timestamp(),
+                    });
             pool.total_reserves += ins_premium;
             env.storage().persistent().set(&pool_key, &pool);
         }
@@ -2223,16 +2253,26 @@ impl TipJarContract {
         let bal_key = DataKey::CreatorBalance(creator.clone(), token.clone());
         let existing_bal: i128 = env.storage().persistent().get(&bal_key).unwrap_or(0);
         let net_amount = Self::process_repayment(&env, &creator, &token, creator_amount);
-        let new_bal: i128 = existing_bal.checked_add(net_amount).expect("balance overflow");
+        let new_bal: i128 = existing_bal
+            .checked_add(net_amount)
+            .expect("balance overflow");
         env.storage().persistent().set(&bal_key, &new_bal);
 
         let tot_key = DataKey::CreatorTotal(creator.clone(), token.clone());
         let existing_tot: i128 = env.storage().persistent().get(&tot_key).unwrap_or(0);
-        let new_tot: i128 = existing_tot.checked_add(creator_amount).expect("total overflow");
+        let new_tot: i128 = existing_tot
+            .checked_add(creator_amount)
+            .expect("total overflow");
         env.storage().persistent().set(&tot_key, &new_tot);
 
-        let tip_id: u64 = env.storage().instance().get(&DataKey::Tip(TipKey::Ctr)).unwrap_or(0);
-        env.storage().instance().set(&DataKey::Tip(TipKey::Ctr), &(tip_id + 1));
+        let tip_id: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::Tip(TipKey::Ctr))
+            .unwrap_or(0);
+        env.storage()
+            .instance()
+            .set(&DataKey::Tip(TipKey::Ctr), &(tip_id + 1));
 
         Self::update_leaderboard_stats(&env, &sender, &creator, creator_amount);
 
@@ -2243,7 +2283,11 @@ impl TipJarContract {
         Self::check_and_award_milestones(&env, &creator, &token, new_tot);
 
         // ── external call last ───────────────────────────────────────────────
-        token::Client::new(&env, &token).transfer(&sender, &env.current_contract_address(), &amount);
+        token::Client::new(&env, &token).transfer(
+            &sender,
+            &env.current_contract_address(),
+            &amount,
+        );
 
         env.events().publish(
             (symbol_short!("tip"), creator.clone()),
@@ -2260,14 +2304,21 @@ impl TipJarContract {
         Self::require_not_paused(&env);
         creator.require_auth();
         let bal_key = DataKey::CreatorBalance(creator.clone(), token.clone());
-        let amount: i128 = env.storage().persistent().get(&bal_key)
+        let amount: i128 = env
+            .storage()
+            .persistent()
+            .get(&bal_key)
             .unwrap_or_else(|| env.storage().instance().get(&bal_key).unwrap_or(0));
         if amount == 0 {
             panic_with_error!(&env, TipJarError::NothingToWithdraw);
         }
         Self::check_and_update_withdrawal_limits(&env, &creator, amount);
         env.storage().persistent().set(&bal_key, &0i128);
-        token::Client::new(&env, &token).transfer(&env.current_contract_address(), &creator, &amount);
+        token::Client::new(&env, &token).transfer(
+            &env.current_contract_address(),
+            &creator,
+            &amount,
+        );
         events::emit_withdraw_event(&env, &creator, amount, &token);
     }
 
@@ -2286,7 +2337,10 @@ impl TipJarContract {
         }
 
         let bal_key = DataKey::CreatorBalance(creator.clone(), token.clone());
-        let current_balance: i128 = env.storage().persistent().get(&bal_key)
+        let current_balance: i128 = env
+            .storage()
+            .persistent()
+            .get(&bal_key)
             .unwrap_or_else(|| env.storage().instance().get(&bal_key).unwrap_or(0));
 
         if amount > current_balance {
@@ -2298,7 +2352,11 @@ impl TipJarContract {
         let new_balance = current_balance - amount;
         env.storage().persistent().set(&bal_key, &new_balance);
 
-        token::Client::new(&env, &token).transfer(&env.current_contract_address(), &creator, &amount);
+        token::Client::new(&env, &token).transfer(
+            &env.current_contract_address(),
+            &creator,
+            &amount,
+        );
         events::emit_withdraw_event(&env, &creator, amount, &token);
     }
 
@@ -2331,8 +2389,14 @@ impl TipJarContract {
             panic_with_error!(&env, TipJarError::TokenNotWhitelisted);
         }
 
-        let auction_id: u64 = env.storage().instance().get(&DataKey::Auction(AuctionKey::Ctr)).unwrap_or(0);
-        env.storage().instance().set(&DataKey::Auction(AuctionKey::Ctr), &(auction_id + 1));
+        let auction_id: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::Auction(AuctionKey::Ctr))
+            .unwrap_or(0);
+        env.storage()
+            .instance()
+            .set(&DataKey::Auction(AuctionKey::Ctr), &(auction_id + 1));
 
         let now = env.ledger().timestamp();
         let ends_at = now.saturating_add(duration_seconds);
@@ -2348,12 +2412,20 @@ impl TipJarContract {
             settled: false,
         };
 
-        env.storage().persistent().set(&DataKey::Auction(AuctionKey::Record(auction_id)), &auction);
+        env.storage()
+            .persistent()
+            .set(&DataKey::Auction(AuctionKey::Record(auction_id)), &auction);
         Self::add_creator_auction(&env, &creator, auction_id);
 
         env.events().publish(
             (symbol_short!("auc_crt"),),
-            (auction_id, creator.clone(), token.clone(), reserve_price, ends_at),
+            (
+                auction_id,
+                creator.clone(),
+                token.clone(),
+                reserve_price,
+                ends_at,
+            ),
         );
         auction_id
     }
@@ -2397,7 +2469,9 @@ impl TipJarContract {
 
         auction.highest_bid = amount;
         auction.highest_bidder = Some(bidder.clone());
-        env.storage().persistent().set(&DataKey::Auction(AuctionKey::Record(auction_id)), &auction);
+        env.storage()
+            .persistent()
+            .set(&DataKey::Auction(AuctionKey::Record(auction_id)), &auction);
 
         token::Client::new(&env, &auction.token).transfer(
             &bidder,
@@ -2445,7 +2519,9 @@ impl TipJarContract {
         }
 
         auction.settled = true;
-        env.storage().persistent().set(&DataKey::Auction(AuctionKey::Record(auction_id)), &auction);
+        env.storage()
+            .persistent()
+            .set(&DataKey::Auction(AuctionKey::Record(auction_id)), &auction);
 
         if auction.highest_bid == 0 || auction.highest_bid < auction.reserve_price {
             if let Some(winner) = auction.highest_bidder {
@@ -2462,10 +2538,18 @@ impl TipJarContract {
             return;
         }
 
-        let fee_bp: u32 = env.storage().instance().get(&DataKey::Fee(FeeKey::BasisPoints)).unwrap_or(0);
+        let fee_bp: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey::Fee(FeeKey::BasisPoints))
+            .unwrap_or(0);
         let fee: i128 = (auction.highest_bid * fee_bp as i128) / 10_000;
         let mut ins_premium: i128 = 0;
-        let ins_enabled: bool = env.storage().instance().get(&DataKey::Insurance(InsuranceKey::Enabled)).unwrap_or(true);
+        let ins_enabled: bool = env
+            .storage()
+            .instance()
+            .get(&DataKey::Insurance(InsuranceKey::Enabled))
+            .unwrap_or(true);
         if ins_enabled {
             if let Some(config) = env
                 .storage()
@@ -2490,19 +2574,19 @@ impl TipJarContract {
 
         if ins_premium > 0 {
             let pool_key = DataKey::Insurance(InsuranceKey::Token(auction.token.clone()));
-            let mut pool: InsurancePool = env
-                .storage()
-                .persistent()
-                .get(&pool_key)
-                .unwrap_or_else(|| InsurancePool {
-                    token: auction.token.clone(),
-                    total_reserves: 0,
-                    total_contributions: 0,
-                    total_claims_paid: 0,
-                    active_claims: 0,
-                    total_claims: 0,
-                    last_payout_time: env.ledger().timestamp(),
-                });
+            let mut pool: InsurancePool =
+                env.storage()
+                    .persistent()
+                    .get(&pool_key)
+                    .unwrap_or_else(|| InsurancePool {
+                        token: auction.token.clone(),
+                        total_reserves: 0,
+                        total_contributions: 0,
+                        total_claims_paid: 0,
+                        active_claims: 0,
+                        total_claims: 0,
+                        last_payout_time: env.ledger().timestamp(),
+                    });
             pool.total_reserves = pool
                 .total_reserves
                 .checked_add(ins_premium)
@@ -2513,7 +2597,8 @@ impl TipJarContract {
         if creator_amount > 0 {
             let bal_key = DataKey::CreatorBalance(creator.clone(), auction.token.clone());
             let existing_bal: i128 = env.storage().persistent().get(&bal_key).unwrap_or(0);
-            let net_amount = Self::process_repayment(&env, &creator, &auction.token, creator_amount);
+            let net_amount =
+                Self::process_repayment(&env, &creator, &auction.token, creator_amount);
             let new_bal = existing_bal
                 .checked_add(net_amount)
                 .expect("balance overflow");
@@ -2535,13 +2620,20 @@ impl TipJarContract {
 
         env.events().publish(
             (symbol_short!("auc_sett"),),
-            (auction_id, creator.clone(), auction.highest_bid, auction.token.clone()),
+            (
+                auction_id,
+                creator.clone(),
+                auction.highest_bid,
+                auction.token.clone(),
+            ),
         );
     }
 
     /// Returns auction details by ID.
     pub fn get_auction(env: Env, auction_id: u64) -> Option<Auction> {
-        env.storage().persistent().get(&DataKey::Auction(AuctionKey::Record(auction_id)))
+        env.storage()
+            .persistent()
+            .get(&DataKey::Auction(AuctionKey::Record(auction_id)))
     }
 
     /// Returns the auction IDs created by a given creator.
@@ -2583,9 +2675,10 @@ impl TipJarContract {
             active: true,
         };
 
-        env.storage()
-            .persistent()
-            .set(&DataKey::Delegation(DelegationKey::Active(creator.clone(), delegate.clone())), &delegation);
+        env.storage().persistent().set(
+            &DataKey::Delegation(DelegationKey::Active(creator.clone(), delegate.clone())),
+            &delegation,
+        );
         Self::add_delegate(&env, &creator, &delegate);
         Self::append_delegation_history(&env, &creator, &delegation);
 
@@ -2615,7 +2708,10 @@ impl TipJarContract {
         let mut delegation: Delegation = env
             .storage()
             .persistent()
-            .get(&DataKey::Delegation(DelegationKey::Active(creator.clone(), delegate.clone())))
+            .get(&DataKey::Delegation(DelegationKey::Active(
+                creator.clone(),
+                delegate.clone(),
+            )))
             .unwrap_or_else(|| panic_with_error!(&env, FeatureError::DelegationNotFound));
 
         if !delegation.active {
@@ -2624,14 +2720,20 @@ impl TipJarContract {
         let now = env.ledger().timestamp();
         if now > delegation.expires_at {
             delegation.active = false;
-            env.storage()
-                .persistent()
-                .set(&DataKey::Delegation(DelegationKey::Active(creator.clone(), delegate.clone())), &delegation);
+            env.storage().persistent().set(
+                &DataKey::Delegation(DelegationKey::Active(creator.clone(), delegate.clone())),
+                &delegation,
+            );
             Self::remove_delegate(&env, &creator, &delegate);
             Self::append_delegation_history(&env, &creator, &delegation);
             panic_with_error!(&env, FeatureError::DelegationExpired);
         }
-        if delegation.used_amount.checked_add(amount).unwrap_or(i128::MAX) > delegation.max_amount {
+        if delegation
+            .used_amount
+            .checked_add(amount)
+            .unwrap_or(i128::MAX)
+            > delegation.max_amount
+        {
             panic_with_error!(&env, FeatureError::DelegationLimitExceeded);
         }
 
@@ -2643,15 +2745,18 @@ impl TipJarContract {
 
         Self::check_and_update_withdrawal_limits(&env, &creator, amount);
 
-        env.storage().persistent().set(&bal_key, &(balance - amount));
+        env.storage()
+            .persistent()
+            .set(&bal_key, &(balance - amount));
         delegation.used_amount += amount;
         if delegation.used_amount >= delegation.max_amount {
             delegation.active = false;
             Self::remove_delegate(&env, &creator, &delegate);
         }
-        env.storage()
-            .persistent()
-            .set(&DataKey::Delegation(DelegationKey::Active(creator.clone(), delegate.clone())), &delegation);
+        env.storage().persistent().set(
+            &DataKey::Delegation(DelegationKey::Active(creator.clone(), delegate.clone())),
+            &delegation,
+        );
         Self::append_delegation_history(&env, &creator, &delegation);
 
         token::Client::new(&env, &token).transfer(
@@ -2675,7 +2780,10 @@ impl TipJarContract {
         let mut delegation: Delegation = env
             .storage()
             .persistent()
-            .get(&DataKey::Delegation(DelegationKey::Active(creator.clone(), delegate.clone())))
+            .get(&DataKey::Delegation(DelegationKey::Active(
+                creator.clone(),
+                delegate.clone(),
+            )))
             .unwrap_or_else(|| panic_with_error!(&env, FeatureError::DelegationNotFound));
 
         if !delegation.active {
@@ -2683,27 +2791,24 @@ impl TipJarContract {
         }
 
         delegation.active = false;
-        env.storage()
-            .persistent()
-            .set(&DataKey::Delegation(DelegationKey::Active(creator.clone(), delegate.clone())), &delegation);
+        env.storage().persistent().set(
+            &DataKey::Delegation(DelegationKey::Active(creator.clone(), delegate.clone())),
+            &delegation,
+        );
         Self::remove_delegate(&env, &creator, &delegate);
         Self::append_delegation_history(&env, &creator, &delegation);
 
-        env.events().publish(
-            (symbol_short!("del_rev"),),
-            (creator, delegate),
-        );
+        env.events()
+            .publish((symbol_short!("del_rev"),), (creator, delegate));
     }
 
     /// Returns the active delegation record for `creator` and `delegate`.
-    pub fn get_delegation(
-        env: Env,
-        creator: Address,
-        delegate: Address,
-    ) -> Option<Delegation> {
+    pub fn get_delegation(env: Env, creator: Address, delegate: Address) -> Option<Delegation> {
         env.storage()
             .persistent()
-            .get(&DataKey::Delegation(DelegationKey::Active(creator, delegate)))
+            .get(&DataKey::Delegation(DelegationKey::Active(
+                creator, delegate,
+            )))
     }
 
     /// Returns the active delegate addresses for `creator`.
@@ -2718,7 +2823,9 @@ impl TipJarContract {
     pub fn get_delegation_history(env: Env, creator: Address) -> Vec<Delegation> {
         env.storage()
             .persistent()
-            .get(&DataKey::Delegation(DelegationKey::History(creator.clone())))
+            .get(&DataKey::Delegation(DelegationKey::History(
+                creator.clone(),
+            )))
             .unwrap_or_else(|| Vec::new(&env))
     }
 
@@ -2744,7 +2851,10 @@ impl TipJarContract {
             .unwrap_or_else(|| Vec::new(env));
         if !delegates.contains(delegate) {
             delegates.push_back(delegate.clone());
-            env.storage().persistent().set(&DataKey::Delegation(DelegationKey::List(creator.clone())), &delegates);
+            env.storage().persistent().set(
+                &DataKey::Delegation(DelegationKey::List(creator.clone())),
+                &delegates,
+            );
         }
     }
 
@@ -2760,37 +2870,44 @@ impl TipJarContract {
                 remaining.push_back(d);
             }
         }
-        env.storage()
-            .persistent()
-            .set(&DataKey::Delegation(DelegationKey::List(creator.clone())), &remaining);
+        env.storage().persistent().set(
+            &DataKey::Delegation(DelegationKey::List(creator.clone())),
+            &remaining,
+        );
     }
 
     fn append_delegation_history(env: &Env, creator: &Address, delegation: &Delegation) {
         let mut history: Vec<Delegation> = env
             .storage()
             .persistent()
-            .get(&DataKey::Delegation(DelegationKey::History(creator.clone())))
+            .get(&DataKey::Delegation(DelegationKey::History(
+                creator.clone(),
+            )))
             .unwrap_or_else(|| Vec::new(env));
         history.push_back(delegation.clone());
-        env.storage()
-            .persistent()
-            .set(&DataKey::Delegation(DelegationKey::History(creator.clone())), &history);
+        env.storage().persistent().set(
+            &DataKey::Delegation(DelegationKey::History(creator.clone())),
+            &history,
+        );
     }
 
     /// Returns the current withdrawable balance for `creator` in `token`.
     pub fn get_withdrawable_balance(env: Env, creator: Address, token: Address) -> i128 {
         let key = DataKey::CreatorBalance(creator.clone(), token.clone());
-        env.storage().persistent().get(&key)
+        env.storage()
+            .persistent()
+            .get(&key)
             .unwrap_or_else(|| env.storage().instance().get(&key).unwrap_or(0))
     }
 
     /// Returns the historical total tips received by `creator` in `token`.
     pub fn get_total_tips(env: Env, creator: Address, token: Address) -> i128 {
         let key = DataKey::CreatorTotal(creator.clone(), token.clone());
-        env.storage().persistent().get(&key)
+        env.storage()
+            .persistent()
+            .get(&key)
             .unwrap_or_else(|| env.storage().instance().get(&key).unwrap_or(0))
     }
-
 
     // ── vesting schedules ────────────────────────────────────────────────────
 
@@ -2838,7 +2955,11 @@ impl TipJarContract {
         }
 
         let now = env.ledger().timestamp();
-        let schedule_id: u64 = env.storage().instance().get(&DataKey::Vesting(VestingKey::Ctr)).unwrap_or(0);
+        let schedule_id: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::Vesting(VestingKey::Ctr))
+            .unwrap_or(0);
 
         let schedule = VestingSchedule {
             id: schedule_id,
@@ -2853,30 +2974,43 @@ impl TipJarContract {
             created_at: now,
         };
 
-        env.storage()
-            .persistent()
-            .set(&DataKey::Vesting(VestingKey::Schedule(schedule_id)), &schedule);
-        
+        env.storage().persistent().set(
+            &DataKey::Vesting(VestingKey::Schedule(schedule_id)),
+            &schedule,
+        );
+
         let mut schedules: Vec<u64> = env
             .storage()
             .persistent()
             .get(&DataKey::Vesting(VestingKey::CreatorList(creator.clone())))
             .unwrap_or_else(|| Vec::new(&env));
         schedules.push_back(schedule_id);
-        env.storage()
-            .persistent()
-            .set(&DataKey::Vesting(VestingKey::CreatorList(creator.clone())), &schedules);
+        env.storage().persistent().set(
+            &DataKey::Vesting(VestingKey::CreatorList(creator.clone())),
+            &schedules,
+        );
 
         env.storage()
             .instance()
             .set(&DataKey::Vesting(VestingKey::Ctr), &(schedule_id + 1));
 
         // Transfer tokens into contract for vesting
-        token::Client::new(&env, &token).transfer(&tipper, &env.current_contract_address(), &amount);
+        token::Client::new(&env, &token).transfer(
+            &tipper,
+            &env.current_contract_address(),
+            &amount,
+        );
 
         env.events().publish(
             (symbol_short!("vest_new"),),
-            (creator, tipper, amount, now, vesting_duration, cliff_duration),
+            (
+                creator,
+                tipper,
+                amount,
+                now,
+                vesting_duration,
+                cliff_duration,
+            ),
         );
 
         schedule_id
@@ -2936,11 +3070,7 @@ impl TipJarContract {
     /// Withdraws available vested amounts from a vesting schedule to the creator.
     ///
     /// Emits: `("vest_withdraw",)` with data `(creator, schedule_id, amount, token)`.
-    pub fn withdraw_vested(
-        env: Env,
-        creator: Address,
-        schedule_id: u64,
-    ) -> i128 {
+    pub fn withdraw_vested(env: Env, creator: Address, schedule_id: u64) -> i128 {
         Self::require_not_paused(&env);
         creator.require_auth();
 
@@ -2965,10 +3095,14 @@ impl TipJarContract {
             panic_with_error!(&env, TipJarError::NoVestedAmount);
         }
 
-        schedule.withdrawn = schedule.withdrawn.checked_add(available).expect("withdrawn overflow");
-        env.storage()
-            .persistent()
-            .set(&DataKey::Vesting(VestingKey::Schedule(schedule_id)), &schedule);
+        schedule.withdrawn = schedule
+            .withdrawn
+            .checked_add(available)
+            .expect("withdrawn overflow");
+        env.storage().persistent().set(
+            &DataKey::Vesting(VestingKey::Schedule(schedule_id)),
+            &schedule,
+        );
 
         let net_amount = Self::process_repayment(&env, &creator, &schedule.token, available);
         token::Client::new(&env, &schedule.token).transfer(
@@ -3038,10 +3172,18 @@ impl TipJarContract {
         let mut entries = Vec::new(&env);
         for addr in participants.iter() {
             let agg_key = match kind {
-                ParticipantKind::Tipper => DataKey::Stats(StatsKey::TipperAgg(addr.clone(), bucket)),
-                ParticipantKind::Creator => DataKey::Stats(StatsKey::CreatorAgg(addr.clone(), bucket)),
+                ParticipantKind::Tipper => {
+                    DataKey::Stats(StatsKey::TipperAgg(addr.clone(), bucket))
+                }
+                ParticipantKind::Creator => {
+                    DataKey::Stats(StatsKey::CreatorAgg(addr.clone(), bucket))
+                }
             };
-            if let Some(entry) = env.storage().persistent().get::<_, LeaderboardEntry>(&agg_key) {
+            if let Some(entry) = env
+                .storage()
+                .persistent()
+                .get::<_, LeaderboardEntry>(&agg_key)
+            {
                 entries.push_back(entry);
             }
         }
@@ -3156,17 +3298,28 @@ impl TipJarContract {
             _ => fees::CongestionLevel::Normal,
         };
         let (fee, fee_bps) = fees::compute_fee(&env, amount, level);
-        
+
         // --- Insurance Premium Calculation ---
-        let ins_enabled: bool = env.storage().instance().get(&DataKey::Insurance(InsuranceKey::Enabled)).unwrap_or(true);
+        let ins_enabled: bool = env
+            .storage()
+            .instance()
+            .get(&DataKey::Insurance(InsuranceKey::Enabled))
+            .unwrap_or(true);
         let mut ins_premium: i128 = 0;
         if ins_enabled {
-            if let Some(config) = env.storage().instance().get::<DataKey, InsurancePoolConfig>(&DataKey::Insurance(InsuranceKey::Cfg)) {
+            if let Some(config) = env
+                .storage()
+                .instance()
+                .get::<DataKey, InsurancePoolConfig>(&DataKey::Insurance(InsuranceKey::Cfg))
+            {
                 ins_premium = (amount * config.tip_premium_bps as i128) / 10_000;
             }
         }
 
-        let net = amount.checked_sub(fee).and_then(|a| a.checked_sub(ins_premium)).unwrap_or(0);
+        let net = amount
+            .checked_sub(fee)
+            .and_then(|a| a.checked_sub(ins_premium))
+            .unwrap_or(0);
 
         token::Client::new(&env, &token).transfer(
             &sender,
@@ -3176,19 +3329,19 @@ impl TipJarContract {
 
         if ins_premium > 0 {
             let pool_key = DataKey::Insurance(InsuranceKey::Token(token.clone()));
-            let mut pool: InsurancePool = env
-                .storage()
-                .persistent()
-                .get(&pool_key)
-                .unwrap_or_else(|| InsurancePool {
-                    token: token.clone(),
-                    total_reserves: 0,
-                    total_contributions: 0,
-                    total_claims_paid: 0,
-                    active_claims: 0,
-                    total_claims: 0,
-                    last_payout_time: env.ledger().timestamp(),
-                });
+            let mut pool: InsurancePool =
+                env.storage()
+                    .persistent()
+                    .get(&pool_key)
+                    .unwrap_or_else(|| InsurancePool {
+                        token: token.clone(),
+                        total_reserves: 0,
+                        total_contributions: 0,
+                        total_claims_paid: 0,
+                        active_claims: 0,
+                        total_claims: 0,
+                        last_payout_time: env.ledger().timestamp(),
+                    });
             pool.total_reserves += ins_premium;
             env.storage().persistent().set(&pool_key, &pool);
         }
@@ -3197,13 +3350,13 @@ impl TipJarContract {
         let current_bal: i128 = env.storage().persistent().get(&bal_key).unwrap_or(0);
         let net_amount = Self::process_repayment(&env, &creator, &token, net);
         let new_bal: i128 = current_bal
-            .checked_add(net_amount).expect("balance overflow");
+            .checked_add(net_amount)
+            .expect("balance overflow");
         env.storage().persistent().set(&bal_key, &new_bal);
 
         let tot_key = DataKey::CreatorTotal(creator.clone(), token.clone());
         let current_tot: i128 = env.storage().persistent().get(&tot_key).unwrap_or(0);
-        let new_tot: i128 = current_tot
-            .checked_add(net).expect("total overflow");
+        let new_tot: i128 = current_tot.checked_add(net).expect("total overflow");
         env.storage().persistent().set(&tot_key, &new_tot);
 
         env.events()
@@ -3271,9 +3424,7 @@ impl TipJarContract {
 
     /// Returns the configuration for a tier, or `None` if not configured.
     pub fn get_tier_config(env: Env, tier: SubscriptionTier) -> Option<TierConfig> {
-        env.storage()
-            .persistent()
-            .get(&DataKey::TierConfig(tier))
+        env.storage().persistent().get(&DataKey::TierConfig(tier))
     }
 
     /// Returns the benefits description for a tier, or `None` if not configured.
@@ -3322,9 +3473,10 @@ impl TipJarContract {
             tier: SubscriptionTier::Bronze,
             pending_tier: None,
         };
-        env.storage()
-            .persistent()
-            .set(&DataKey::Subscription(subscriber.clone(), creator.clone()), &sub);
+        env.storage().persistent().set(
+            &DataKey::Subscription(subscriber.clone(), creator.clone()),
+            &sub,
+        );
         env.events().publish(
             (symbol_short!("sub_new"), creator),
             (subscriber, amount, interval_seconds),
@@ -3372,9 +3524,10 @@ impl TipJarContract {
             tier: tier.clone(),
             pending_tier: None,
         };
-        env.storage()
-            .persistent()
-            .set(&DataKey::Subscription(subscriber.clone(), creator.clone()), &sub);
+        env.storage().persistent().set(
+            &DataKey::Subscription(subscriber.clone(), creator.clone()),
+            &sub,
+        );
         env.events().publish(
             (symbol_short!("sub_new"), creator),
             (subscriber, amount, interval_seconds),
@@ -3420,10 +3573,14 @@ impl TipJarContract {
         let bal_key = DataKey::CreatorBalance(creator.clone(), sub.token.clone());
         let bal: i128 = env.storage().persistent().get(&bal_key).unwrap_or(0);
         let net_amount = Self::process_repayment(&env, &creator, &sub.token, config.price);
-        env.storage().persistent().set(&bal_key, &(bal + net_amount));
+        env.storage()
+            .persistent()
+            .set(&bal_key, &(bal + net_amount));
         let tot_key = DataKey::CreatorTotal(creator.clone(), sub.token.clone());
         let tot: i128 = env.storage().persistent().get(&tot_key).unwrap_or(0);
-        env.storage().persistent().set(&tot_key, &(tot + config.price));
+        env.storage()
+            .persistent()
+            .set(&tot_key, &(tot + config.price));
 
         let now = env.ledger().timestamp();
         sub.tier = new_tier;
@@ -3521,11 +3678,15 @@ impl TipJarContract {
         let bal_key = DataKey::CreatorBalance(creator.clone(), sub.token.clone());
         let bal: i128 = env.storage().persistent().get(&bal_key).unwrap_or(0);
         let net_amount = Self::process_repayment(&env, &creator, &sub.token, sub.amount);
-        env.storage().persistent().set(&bal_key, &(bal + net_amount));
+        env.storage()
+            .persistent()
+            .set(&bal_key, &(bal + net_amount));
 
         let tot_key = DataKey::CreatorTotal(creator.clone(), sub.token.clone());
         let tot: i128 = env.storage().persistent().get(&tot_key).unwrap_or(0);
-        env.storage().persistent().set(&tot_key, &(tot + sub.amount));
+        env.storage()
+            .persistent()
+            .set(&tot_key, &(tot + sub.amount));
 
         sub.last_payment = now;
         sub.next_payment = now + sub.interval_seconds;
@@ -3668,38 +3829,48 @@ impl TipJarContract {
         let fee: i128 = (amount * fee_bp as i128) / 10_000;
 
         // --- Insurance Premium Calculation ---
-        let ins_enabled: bool = env.storage().instance().get(&DataKey::Insurance(InsuranceKey::Enabled)).unwrap_or(true);
+        let ins_enabled: bool = env
+            .storage()
+            .instance()
+            .get(&DataKey::Insurance(InsuranceKey::Enabled))
+            .unwrap_or(true);
         let mut ins_premium: i128 = 0;
         if ins_enabled {
-            if let Some(config) = env.storage().instance().get::<DataKey, InsurancePoolConfig>(&DataKey::Insurance(InsuranceKey::Cfg)) {
+            if let Some(config) = env
+                .storage()
+                .instance()
+                .get::<DataKey, InsurancePoolConfig>(&DataKey::Insurance(InsuranceKey::Cfg))
+            {
                 ins_premium = (amount * config.tip_premium_bps as i128) / 10_000;
             }
         }
 
-        let creator_amount = amount.checked_sub(fee).and_then(|a| a.checked_sub(ins_premium)).unwrap_or(0);
+        let creator_amount = amount
+            .checked_sub(fee)
+            .and_then(|a| a.checked_sub(ins_premium))
+            .unwrap_or(0);
 
         if fee > 0 {
             let fee_key = DataKey::Fee(FeeKey::Balance(token.clone()));
-            let new_fee_bal: i128 =
-                env.storage().instance().get(&fee_key).unwrap_or(0) + fee;
+            let new_fee_bal: i128 = env.storage().instance().get(&fee_key).unwrap_or(0) + fee;
             env.storage().instance().set(&fee_key, &new_fee_bal);
         }
 
         if ins_premium > 0 {
             let pool_key = DataKey::Insurance(InsuranceKey::Token(token.clone()));
-            let mut pool: InsurancePool = env
-                .storage()
-                .persistent()
-                .get(&pool_key)
-                .unwrap_or_else(|| InsurancePool {
-                    token: token.clone(),
-                    total_reserves: 0,
-                    total_contributions: 0,
-                    total_claims_paid: 0,
-                    active_claims: 0,
-                    total_claims: 0,
-                    last_payout_time: env.ledger().timestamp(),
-                });
+            let mut pool: InsurancePool =
+                env.storage()
+                    .persistent()
+                    .get(&pool_key)
+                    .unwrap_or_else(|| InsurancePool {
+                        token: token.clone(),
+                        total_reserves: 0,
+                        total_contributions: 0,
+                        total_claims_paid: 0,
+                        active_claims: 0,
+                        total_claims: 0,
+                        last_payout_time: env.ledger().timestamp(),
+                    });
             pool.total_reserves += ins_premium;
             env.storage().persistent().set(&pool_key, &pool);
         }
@@ -3729,11 +3900,7 @@ impl TipJarContract {
 
         // Store metadata and increment tip count.
         let count_key = DataKey::Tip(TipKey::Count(creator.clone()));
-        let tip_index: u64 = env
-            .storage()
-            .persistent()
-            .get(&count_key)
-            .unwrap_or(0u64);
+        let tip_index: u64 = env.storage().persistent().get(&count_key).unwrap_or(0u64);
 
         let timestamp = env.ledger().timestamp();
         let metadata = TipMetadata {
@@ -3742,12 +3909,11 @@ impl TipJarContract {
             message: message.clone(),
             timestamp,
         };
-        env.storage()
-            .persistent()
-            .set(&DataKey::Tip(TipKey::History(creator.clone(), tip_index)), &metadata);
-        env.storage()
-            .persistent()
-            .set(&count_key, &(tip_index + 1));
+        env.storage().persistent().set(
+            &DataKey::Tip(TipKey::History(creator.clone(), tip_index)),
+            &metadata,
+        );
+        env.storage().persistent().set(&count_key, &(tip_index + 1));
 
         env.events().publish(
             (symbol_short!("tip_msg"), creator.clone()),
@@ -3762,11 +3928,7 @@ impl TipJarContract {
     /// `limit` is capped at 100 to bound storage reads.
     pub fn get_tip_history(env: Env, creator: Address, limit: u32) -> Vec<TipMetadata> {
         let count_key = DataKey::Tip(TipKey::Count(creator.clone()));
-        let total: u64 = env
-            .storage()
-            .persistent()
-            .get(&count_key)
-            .unwrap_or(0u64);
+        let total: u64 = env.storage().persistent().get(&count_key).unwrap_or(0u64);
 
         let cap = if limit > 100 { 100 } else { limit } as u64;
         let mut result = Vec::new(&env);
@@ -3856,7 +4018,9 @@ impl TipJarContract {
             let bal_key = DataKey::CreatorBalance(r.creator.clone(), token.clone());
             let bal: i128 = env.storage().persistent().get(&bal_key).unwrap_or(0);
             let net_amount = Self::process_repayment(&env, &r.creator, &token, share);
-            env.storage().persistent().set(&bal_key, &(bal + net_amount));
+            env.storage()
+                .persistent()
+                .set(&bal_key, &(bal + net_amount));
 
             let tot_key = DataKey::CreatorTotal(r.creator.clone(), token.clone());
             let tot: i128 = env.storage().persistent().get(&tot_key).unwrap_or(0);
@@ -3880,7 +4044,9 @@ impl TipJarContract {
         if admin != stored_admin {
             panic_with_error!(&env, TipJarError::Unauthorized);
         }
-        env.storage().persistent().set(&DataKey::Role(RoleKey::User(user.clone())), &role);
+        env.storage()
+            .persistent()
+            .set(&DataKey::Role(RoleKey::User(user.clone())), &role);
         let mut members: Vec<Address> = env
             .storage()
             .persistent()
@@ -3888,9 +4054,12 @@ impl TipJarContract {
             .unwrap_or_else(|| Vec::new(&env));
         if !members.contains(&user) {
             members.push_back(user.clone());
-            env.storage().persistent().set(&DataKey::Role(RoleKey::Members(role.clone())), &members);
+            env.storage()
+                .persistent()
+                .set(&DataKey::Role(RoleKey::Members(role.clone())), &members);
         }
-        env.events().publish((symbol_short!("role_grt"),), (user, role));
+        env.events()
+            .publish((symbol_short!("role_grt"),), (user, role));
     }
 
     /// Revokes any role from `user`. Caller must be the stored admin.
@@ -3905,15 +4074,20 @@ impl TipJarContract {
             .persistent()
             .get::<DataKey, Role>(&DataKey::Role(RoleKey::User(user.clone())))
         {
-            env.storage().persistent().remove(&DataKey::Role(RoleKey::User(user.clone())));
+            env.storage()
+                .persistent()
+                .remove(&DataKey::Role(RoleKey::User(user.clone())));
             let mut members: Vec<Address> = env
                 .storage()
                 .persistent()
                 .get(&DataKey::Role(RoleKey::Members(role.clone())))
                 .unwrap_or_else(|| Vec::new(&env));
             members.retain(|a| a != user);
-            env.storage().persistent().set(&DataKey::Role(RoleKey::Members(role.clone())), &members);
-            env.events().publish((symbol_short!("role_rev"),), (user, role));
+            env.storage()
+                .persistent()
+                .set(&DataKey::Role(RoleKey::Members(role.clone())), &members);
+            env.events()
+                .publish((symbol_short!("role_rev"),), (user, role));
         }
     }
 
@@ -3993,8 +4167,12 @@ impl TipJarContract {
             expires_at: created_at.saturating_add(refund_window),
             cancelled: false,
         };
-        env.storage().persistent().set(&DataKey::TimeLock(lock_id), &time_lock);
-        env.storage().persistent().set(&DataKey::NextLockId, &(lock_id + 1));
+        env.storage()
+            .persistent()
+            .set(&DataKey::TimeLock(lock_id), &time_lock);
+        env.storage()
+            .persistent()
+            .set(&DataKey::NextLockId, &(lock_id + 1));
 
         let mut creator_locks: Vec<u64> = env
             .storage()
@@ -4002,12 +4180,18 @@ impl TipJarContract {
             .get(&DataKey::CreatorLocks(creator.clone()))
             .unwrap_or_else(|| Vec::new(&env));
         creator_locks.push_back(lock_id);
-        env.storage().persistent().set(&DataKey::CreatorLocks(creator.clone()), &creator_locks);
+        env.storage()
+            .persistent()
+            .set(&DataKey::CreatorLocks(creator.clone()), &creator_locks);
 
         Self::add_active_time_lock(&env, lock_id);
 
         // External call last.
-        token::Client::new(&env, &token).transfer(&sender, &env.current_contract_address(), &amount);
+        token::Client::new(&env, &token).transfer(
+            &sender,
+            &env.current_contract_address(),
+            &amount,
+        );
 
         env.events().publish(
             (symbol_short!("lock"), creator),
@@ -4052,7 +4236,9 @@ impl TipJarContract {
         }
 
         // State update before external call (CEI).
-        env.storage().persistent().remove(&DataKey::TimeLock(lock_id));
+        env.storage()
+            .persistent()
+            .remove(&DataKey::TimeLock(lock_id));
         Self::remove_active_time_lock(&env, lock_id);
 
         token::Client::new(&env, &token).transfer(
@@ -4094,7 +4280,9 @@ impl TipJarContract {
 
         // State update before external call (CEI).
         time_lock.cancelled = true;
-        env.storage().persistent().set(&DataKey::TimeLock(lock_id), &time_lock);
+        env.storage()
+            .persistent()
+            .set(&DataKey::TimeLock(lock_id), &time_lock);
         Self::remove_active_time_lock(&env, lock_id);
 
         token::Client::new(&env, &token).transfer(
@@ -4174,7 +4362,8 @@ impl TipJarContract {
         env.storage()
             .instance()
             .set(&DataKey::RefundWindow, &refund_window_seconds);
-        env.events().publish((symbol_short!("ref_wind"),), refund_window_seconds);
+        env.events()
+            .publish((symbol_short!("ref_wind"),), refund_window_seconds);
     }
 
     /// Returns all expired time-locked tips whose refund window has passed.
@@ -4252,7 +4441,9 @@ impl TipJarContract {
         if !active.contains(&lock_id) {
             active.push_back(lock_id);
         }
-        env.storage().persistent().set(&DataKey::ActiveTimeLocks, &active);
+        env.storage()
+            .persistent()
+            .set(&DataKey::ActiveTimeLocks, &active);
     }
 
     fn remove_active_time_lock(env: &Env, lock_id: u64) {
@@ -4267,11 +4458,15 @@ impl TipJarContract {
                 remaining.push_back(id);
             }
         }
-        env.storage().persistent().set(&DataKey::ActiveTimeLocks, &remaining);
+        env.storage()
+            .persistent()
+            .set(&DataKey::ActiveTimeLocks, &remaining);
     }
 
     fn refund_time_lock(env: &Env, lock_id: u64, time_lock: &TimeLock) {
-        env.storage().persistent().remove(&DataKey::TimeLock(lock_id));
+        env.storage()
+            .persistent()
+            .remove(&DataKey::TimeLock(lock_id));
         Self::remove_active_time_lock(env, lock_id);
         token::Client::new(&env, &time_lock.token).transfer(
             &env.current_contract_address(),
@@ -4280,7 +4475,12 @@ impl TipJarContract {
         );
         env.events().publish(
             (symbol_short!("tip_exp"), time_lock.creator.clone()),
-            (time_lock.sender.clone(), time_lock.amount, time_lock.expires_at, lock_id),
+            (
+                time_lock.sender.clone(),
+                time_lock.amount,
+                time_lock.expires_at,
+                lock_id,
+            ),
         );
     }
 
@@ -4297,7 +4497,11 @@ impl TipJarContract {
             .storage()
             .persistent()
             .get(&DataKey::Limit(LimitKey::Withdrawal(creator.clone())))
-            .or_else(|| env.storage().instance().get(&DataKey::Limit(LimitKey::Default)))
+            .or_else(|| {
+                env.storage()
+                    .instance()
+                    .get(&DataKey::Limit(LimitKey::Default))
+            })
             .unwrap_or(WithdrawalLimits {
                 daily_limit: 0,
                 cooldown_seconds: 0,
@@ -4330,9 +4534,10 @@ impl TipJarContract {
 
         limits.withdrawn_today += amount;
         limits.last_withdrawal = now;
-        env.storage()
-            .persistent()
-            .set(&DataKey::Limit(LimitKey::Withdrawal(creator.clone())), &limits);
+        env.storage().persistent().set(
+            &DataKey::Limit(LimitKey::Withdrawal(creator.clone())),
+            &limits,
+        );
     }
 
     /// Sets per-creator withdrawal limits. Admin only.
@@ -4371,9 +4576,10 @@ impl TipJarContract {
             withdrawn_today: existing.withdrawn_today,
             day_start: existing.day_start,
         };
-        env.storage()
-            .persistent()
-            .set(&DataKey::Limit(LimitKey::Withdrawal(creator.clone())), &limits);
+        env.storage().persistent().set(
+            &DataKey::Limit(LimitKey::Withdrawal(creator.clone())),
+            &limits,
+        );
 
         env.events().publish(
             (symbol_short!("wl_set"), creator),
@@ -4447,7 +4653,11 @@ impl TipJarContract {
         env.storage()
             .persistent()
             .get(&DataKey::Limit(LimitKey::Withdrawal(creator)))
-            .or_else(|| env.storage().instance().get(&DataKey::Limit(LimitKey::Default)))
+            .or_else(|| {
+                env.storage()
+                    .instance()
+                    .get(&DataKey::Limit(LimitKey::Default))
+            })
             .unwrap_or(WithdrawalLimits {
                 daily_limit: 0,
                 cooldown_seconds: 0,
@@ -4479,8 +4689,15 @@ impl TipJarContract {
         if required_approvals == 0 || required_approvals as u32 > signers.len() {
             panic_with_error!(&env, TipJarError::Unauthorized);
         }
-        let cfg = MultiSigConfig { threshold, required_approvals, expiry_seconds, signers };
-        env.storage().instance().set(&DataKey::MultiSig(MultiSigKey::Config), &cfg);
+        let cfg = MultiSigConfig {
+            threshold,
+            required_approvals,
+            expiry_seconds,
+            signers,
+        };
+        env.storage()
+            .instance()
+            .set(&DataKey::MultiSig(MultiSigKey::Config), &cfg);
         env.events().publish(
             (symbol_short!("ms_cfg"),),
             (threshold, required_approvals, expiry_seconds),
@@ -4518,7 +4735,9 @@ impl TipJarContract {
         // Below-or-at threshold: process immediately.
         if cfg.threshold > 0 && amount <= cfg.threshold {
             Self::check_and_update_withdrawal_limits(&env, &creator, amount);
-            env.storage().persistent().set(&bal_key, &(balance - amount));
+            env.storage()
+                .persistent()
+                .set(&bal_key, &(balance - amount));
             token::Client::new(&env, &token).transfer(
                 &env.current_contract_address(),
                 &creator,
@@ -4534,7 +4753,9 @@ impl TipJarContract {
             .instance()
             .get(&DataKey::MultiSig(MultiSigKey::Ctr))
             .unwrap_or(0);
-        env.storage().instance().set(&DataKey::MultiSig(MultiSigKey::Ctr), &(request_id + 1));
+        env.storage()
+            .instance()
+            .set(&DataKey::MultiSig(MultiSigKey::Ctr), &(request_id + 1));
 
         let expires_at = env.ledger().timestamp() + cfg.expiry_seconds;
         let request = MultiSigWithdrawal {
@@ -4548,7 +4769,10 @@ impl TipJarContract {
             executed: false,
             cancelled: false,
         };
-        env.storage().persistent().set(&DataKey::MultiSig(MultiSigKey::Request(request_id)), &request);
+        env.storage().persistent().set(
+            &DataKey::MultiSig(MultiSigKey::Request(request_id)),
+            &request,
+        );
 
         env.events().publish(
             (symbol_short!("ms_req"), creator),
@@ -4593,7 +4817,8 @@ impl TipJarContract {
         }
 
         request.approvals.push_back(approver.clone());
-        env.events().publish((symbol_short!("ms_apr"), approver), request_id);
+        env.events()
+            .publish((symbol_short!("ms_apr"), approver), request_id);
 
         if request.approvals.len() >= request.required_approvals {
             // Execute withdrawal.
@@ -4602,9 +4827,14 @@ impl TipJarContract {
             if balance < request.amount {
                 panic_with_error!(&env, TipJarError::InsufficientBalance);
             }
-            env.storage().persistent().set(&bal_key, &(balance - request.amount));
+            env.storage()
+                .persistent()
+                .set(&bal_key, &(balance - request.amount));
             request.executed = true;
-            env.storage().persistent().set(&DataKey::MultiSig(MultiSigKey::Request(request_id)), &request);
+            env.storage().persistent().set(
+                &DataKey::MultiSig(MultiSigKey::Request(request_id)),
+                &request,
+            );
 
             token::Client::new(&env, &request.token).transfer(
                 &env.current_contract_address(),
@@ -4616,7 +4846,10 @@ impl TipJarContract {
                 (request_id, request.amount),
             );
         } else {
-            env.storage().persistent().set(&DataKey::MultiSig(MultiSigKey::Request(request_id)), &request);
+            env.storage().persistent().set(
+                &DataKey::MultiSig(MultiSigKey::Request(request_id)),
+                &request,
+            );
         }
     }
 
@@ -4643,8 +4876,12 @@ impl TipJarContract {
         }
 
         request.cancelled = true;
-        env.storage().persistent().set(&DataKey::MultiSig(MultiSigKey::Request(request_id)), &request);
-        env.events().publish((symbol_short!("ms_cncl"), request.creator), request_id);
+        env.storage().persistent().set(
+            &DataKey::MultiSig(MultiSigKey::Request(request_id)),
+            &request,
+        );
+        env.events()
+            .publish((symbol_short!("ms_cncl"), request.creator), request_id);
     }
 
     /// Returns a multi-sig withdrawal request by ID.
@@ -4686,17 +4923,18 @@ impl TipJarContract {
     /// Creates a dispute for a tip. Only the tipper or creator can initiate.
     ///
     /// Emits `("dispute_created",)` with data `(dispute_id, tip_id, initiator)`.
-    pub fn create_dispute(
-        env: Env,
-        tip_id: u64,
-        initiator: Address,
-        reason: String,
-    ) -> u64 {
+    pub fn create_dispute(env: Env, tip_id: u64, initiator: Address, reason: String) -> u64 {
         Self::require_not_paused(&env);
         initiator.require_auth();
 
-        let dispute_id: u64 = env.storage().instance().get(&DataKey::Dispute(DisputeKey::Ctr)).unwrap_or(0);
-        env.storage().instance().set(&DataKey::Dispute(DisputeKey::Ctr), &(dispute_id + 1));
+        let dispute_id: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::Dispute(DisputeKey::Ctr))
+            .unwrap_or(0);
+        env.storage()
+            .instance()
+            .set(&DataKey::Dispute(DisputeKey::Ctr), &(dispute_id + 1));
 
         let created_at = env.ledger().timestamp();
         let dispute = dispute::Dispute {
@@ -4710,17 +4948,22 @@ impl TipJarContract {
             created_at,
         };
 
-        env.storage().persistent().set(&DataKey::Dispute(DisputeKey::Record(dispute_id)), &dispute);
+        env.storage()
+            .persistent()
+            .set(&DataKey::Dispute(DisputeKey::Record(dispute_id)), &dispute);
 
         let mut creator_disputes: Vec<u64> = env
             .storage()
             .persistent()
-            .get(&DataKey::Dispute(DisputeKey::CreatorList(initiator.clone())))
+            .get(&DataKey::Dispute(DisputeKey::CreatorList(
+                initiator.clone(),
+            )))
             .unwrap_or_else(|| Vec::new(&env));
         creator_disputes.push_back(dispute_id);
-        env.storage()
-            .persistent()
-            .set(&DataKey::Dispute(DisputeKey::CreatorList(initiator.clone())), &creator_disputes);
+        env.storage().persistent().set(
+            &DataKey::Dispute(DisputeKey::CreatorList(initiator.clone())),
+            &creator_disputes,
+        );
 
         env.events().publish(
             (symbol_short!("disp_crt"),),
@@ -4748,23 +4991,18 @@ impl TipJarContract {
 
         dispute.arbitrator = Some(arbitrator.clone());
         dispute.status = dispute::DisputeStatus::UnderReview;
-        env.storage().persistent().set(&DataKey::Dispute(DisputeKey::Record(dispute_id)), &dispute);
+        env.storage()
+            .persistent()
+            .set(&DataKey::Dispute(DisputeKey::Record(dispute_id)), &dispute);
 
-        env.events().publish(
-            (symbol_short!("disp_asgn"),),
-            (dispute_id, arbitrator),
-        );
+        env.events()
+            .publish((symbol_short!("disp_asgn"),), (dispute_id, arbitrator));
     }
 
     /// Submits evidence for a dispute.
     ///
     /// Emits `("evidence_submitted",)` with data `(dispute_id, submitter)`.
-    pub fn submit_evidence(
-        env: Env,
-        dispute_id: u64,
-        submitter: Address,
-        evidence: String,
-    ) {
+    pub fn submit_evidence(env: Env, dispute_id: u64, submitter: Address, evidence: String) {
         Self::require_not_paused(&env);
         submitter.require_auth();
 
@@ -4774,7 +5012,9 @@ impl TipJarContract {
             .get(&DataKey::Dispute(DisputeKey::Record(dispute_id)))
             .unwrap_or_else(|| panic_with_error!(&env, FeatureError::DisputeNotFound));
 
-        if dispute.status != dispute::DisputeStatus::Open && dispute.status != dispute::DisputeStatus::UnderReview {
+        if dispute.status != dispute::DisputeStatus::Open
+            && dispute.status != dispute::DisputeStatus::UnderReview
+        {
             panic_with_error!(&env, FeatureError::DisputeNotOpen);
         }
 
@@ -4792,17 +5032,17 @@ impl TipJarContract {
             submitted_at,
         };
 
-        env.storage()
-            .persistent()
-            .set(&DataKey::Dispute(DisputeKey::Evidence(dispute_id, evidence_idx)), &evidence_record);
-        env.storage()
-            .persistent()
-            .set(&DataKey::Dispute(DisputeKey::EvidenceCtr(dispute_id)), &(evidence_idx + 1));
-
-        env.events().publish(
-            (symbol_short!("evid_sub"),),
-            (dispute_id, submitter),
+        env.storage().persistent().set(
+            &DataKey::Dispute(DisputeKey::Evidence(dispute_id, evidence_idx)),
+            &evidence_record,
         );
+        env.storage().persistent().set(
+            &DataKey::Dispute(DisputeKey::EvidenceCtr(dispute_id)),
+            &(evidence_idx + 1),
+        );
+
+        env.events()
+            .publish((symbol_short!("evid_sub"),), (dispute_id, submitter));
     }
 
     /// Resolves a dispute. Only the arbitrator can resolve.
@@ -4835,12 +5075,12 @@ impl TipJarContract {
             dispute::DisputeStatus::Rejected
         };
 
-        env.storage().persistent().set(&DataKey::Dispute(DisputeKey::Record(dispute_id)), &dispute);
+        env.storage()
+            .persistent()
+            .set(&DataKey::Dispute(DisputeKey::Record(dispute_id)), &dispute);
 
-        env.events().publish(
-            (symbol_short!("disp_res"),),
-            (dispute_id, resolution),
-        );
+        env.events()
+            .publish((symbol_short!("disp_res"),), (dispute_id, resolution));
     }
 
     /// Returns a dispute by ID.
@@ -4860,10 +5100,17 @@ impl TipJarContract {
     }
 
     /// Returns evidence for a dispute.
-    pub fn get_dispute_evidence(env: Env, dispute_id: u64, evidence_idx: u64) -> dispute::DisputeEvidence {
+    pub fn get_dispute_evidence(
+        env: Env,
+        dispute_id: u64,
+        evidence_idx: u64,
+    ) -> dispute::DisputeEvidence {
         env.storage()
             .persistent()
-            .get(&DataKey::Dispute(DisputeKey::Evidence(dispute_id, evidence_idx)))
+            .get(&DataKey::Dispute(DisputeKey::Evidence(
+                dispute_id,
+                evidence_idx,
+            )))
             .unwrap_or_else(|| panic_with_error!(&env, FeatureError::DisputeNotFound))
     }
 
@@ -4873,12 +5120,7 @@ impl TipJarContract {
     ///
     /// `tips` is a vector of (creator, amount) pairs. Returns the number of successful tips.
     /// Emits `("batch_tip",)` with data `(tipper, count, total_amount)`.
-    pub fn batch_tip(
-        env: Env,
-        tipper: Address,
-        token: Address,
-        tips: Vec<BatchTip>,
-    ) -> u32 {
+    pub fn batch_tip(env: Env, tipper: Address, token: Address, tips: Vec<BatchTip>) -> u32 {
         Self::require_not_paused(&env);
         tipper.require_auth();
 
@@ -4900,15 +5142,25 @@ impl TipJarContract {
             if tip.amount <= 0 {
                 panic_with_error!(&env, TipJarError::InvalidAmount);
             }
-            total_amount = total_amount.checked_add(tip.amount).expect("total overflow");
+            total_amount = total_amount
+                .checked_add(tip.amount)
+                .expect("total overflow");
         }
 
         Self::check_circuit_breaker(&env, total_amount);
 
         // Transfer all tokens at once
-        token::Client::new(&env, &token).transfer(&tipper, &env.current_contract_address(), &total_amount);
+        token::Client::new(&env, &token).transfer(
+            &tipper,
+            &env.current_contract_address(),
+            &total_amount,
+        );
 
-        let fee_bp: u32 = env.storage().instance().get(&DataKey::Fee(FeeKey::BasisPoints)).unwrap_or(0);
+        let fee_bp: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey::Fee(FeeKey::BasisPoints))
+            .unwrap_or(0);
         let mut successful_tips: u32 = 0;
 
         for tip in tips.iter() {
@@ -4930,12 +5182,16 @@ impl TipJarContract {
             let bal_key = DataKey::CreatorBalance(tip.creator.clone(), token.clone());
             let existing_bal: i128 = env.storage().persistent().get(&bal_key).unwrap_or(0);
             let net_amount = Self::process_repayment(&env, &tip.creator, &token, creator_amount);
-            let new_bal: i128 = existing_bal.checked_add(net_amount).expect("balance overflow");
+            let new_bal: i128 = existing_bal
+                .checked_add(net_amount)
+                .expect("balance overflow");
             env.storage().persistent().set(&bal_key, &new_bal);
 
             let tot_key = DataKey::CreatorTotal(tip.creator.clone(), token.clone());
             let existing_tot: i128 = env.storage().persistent().get(&tot_key).unwrap_or(0);
-            let new_tot: i128 = existing_tot.checked_add(creator_amount).expect("total overflow");
+            let new_tot: i128 = existing_tot
+                .checked_add(creator_amount)
+                .expect("total overflow");
             env.storage().persistent().set(&tot_key, &new_tot);
 
             Self::update_leaderboard_stats(&env, &tipper, &tip.creator, creator_amount);
@@ -5011,11 +5267,7 @@ impl TipJarContract {
         let contract_address = env.current_contract_address();
 
         for (index, op) in operations.iter().enumerate() {
-            token::Client::new(&env, &op.token).transfer(
-                &contract_address,
-                &creator,
-                &op.amount,
-            );
+            token::Client::new(&env, &op.token).transfer(&contract_address, &creator, &op.amount);
 
             env.events().publish(
                 (symbol_short!("btch_wdr"),),
@@ -5028,10 +5280,8 @@ impl TipJarContract {
             });
         }
 
-        env.events().publish(
-            (symbol_short!("batch_wdr"),),
-            (creator.clone(), op_count),
-        );
+        env.events()
+            .publish((symbol_short!("batch_wdr"),), (creator.clone(), op_count));
 
         results
     }
@@ -5119,21 +5369,33 @@ impl TipJarContract {
 
             let bal_key = DataKey::CreatorBalance(op.creator.clone(), op.token.clone());
             let existing_bal: i128 = env.storage().persistent().get(&bal_key).unwrap_or(0);
-            env.storage()
-                .persistent()
-                .set(&bal_key, &existing_bal.checked_add(creator_amount).expect("balance overflow"));
+            env.storage().persistent().set(
+                &bal_key,
+                &existing_bal
+                    .checked_add(creator_amount)
+                    .expect("balance overflow"),
+            );
 
             let tot_key = DataKey::CreatorTotal(op.creator.clone(), op.token.clone());
             let existing_tot: i128 = env.storage().persistent().get(&tot_key).unwrap_or(0);
-            env.storage()
-                .persistent()
-                .set(&tot_key, &existing_tot.checked_add(creator_amount).expect("total overflow"));
+            env.storage().persistent().set(
+                &tot_key,
+                &existing_tot
+                    .checked_add(creator_amount)
+                    .expect("total overflow"),
+            );
 
             Self::update_leaderboard_stats(&env, &tipper, &op.creator, creator_amount);
 
             env.events().publish(
                 (symbol_short!("btp_op"),),
-                (tipper.clone(), op.creator.clone(), op.token.clone(), creator_amount, index as u32),
+                (
+                    tipper.clone(),
+                    op.creator.clone(),
+                    op.token.clone(),
+                    creator_amount,
+                    index as u32,
+                ),
             );
 
             results.push_back(BatchResult {
@@ -5141,7 +5403,9 @@ impl TipJarContract {
                 index: index as u32,
             });
 
-            grand_total = grand_total.checked_add(op.amount).expect("grand total overflow");
+            grand_total = grand_total
+                .checked_add(op.amount)
+                .expect("grand total overflow");
         }
 
         env.events().publish(
@@ -5193,12 +5457,7 @@ impl TipJarContract {
     /// Stakes `amount` LP tokens into a liquidity mining program.
     ///
     /// Emits `("lm_stake",)` with `(provider, program_id, amount, new_total_staked)`.
-    pub fn lm_stake(
-        env: Env,
-        provider: Address,
-        program_id: u64,
-        amount: i128,
-    ) {
+    pub fn lm_stake(env: Env, provider: Address, program_id: u64, amount: i128) {
         Self::require_not_paused(&env);
         liquidity_mining::stake(&env, &provider, program_id, amount);
     }
@@ -5207,12 +5466,7 @@ impl TipJarContract {
     ///
     /// Accrues pending rewards before reducing the position.
     /// Emits `("lm_unstk",)` with `(provider, program_id, amount, remaining_staked)`.
-    pub fn lm_unstake(
-        env: Env,
-        provider: Address,
-        program_id: u64,
-        amount: i128,
-    ) {
+    pub fn lm_unstake(env: Env, provider: Address, program_id: u64, amount: i128) {
         Self::require_not_paused(&env);
         liquidity_mining::unstake(&env, &provider, program_id, amount);
     }
@@ -5220,11 +5474,7 @@ impl TipJarContract {
     /// Claims all vested mining rewards for a provider. Returns the amount claimed.
     ///
     /// Emits `("lm_claim",)` with `(provider, program_id, amount_claimed)`.
-    pub fn lm_claim_rewards(
-        env: Env,
-        provider: Address,
-        program_id: u64,
-    ) -> i128 {
+    pub fn lm_claim_rewards(env: Env, provider: Address, program_id: u64) -> i128 {
         Self::require_not_paused(&env);
         liquidity_mining::claim_rewards(&env, &provider, program_id)
     }
@@ -5234,12 +5484,7 @@ impl TipJarContract {
     /// Boost scales linearly from 1× (no lock) to 3× (lock = 1 year).
     /// Only increasing boosts are accepted.
     /// Emits `("lm_boost",)` with `(provider, program_id, new_boost, lock_until)`.
-    pub fn lm_apply_boost(
-        env: Env,
-        provider: Address,
-        program_id: u64,
-        lock_duration: u64,
-    ) {
+    pub fn lm_apply_boost(env: Env, provider: Address, program_id: u64, lock_duration: u64) {
         Self::require_not_paused(&env);
         liquidity_mining::apply_boost(&env, &provider, program_id, lock_duration);
     }
@@ -5500,12 +5745,7 @@ impl TipJarContract {
     /// Checks and awards milestones when a creator reaches specific tip thresholds.
     ///
     /// Called internally after tips are processed. Emits milestone events.
-    fn check_and_award_milestones(
-        env: &Env,
-        creator: &Address,
-        token: &Address,
-        new_total: i128,
-    ) {
+    fn check_and_award_milestones(env: &Env, creator: &Address, token: &Address, new_total: i128) {
         let milestones = Self::get_creator_milestones(env, creator);
 
         for (idx, milestone) in milestones.iter().enumerate() {
@@ -5519,9 +5759,10 @@ impl TipJarContract {
 
                 let mut updated_milestone = milestone.clone();
                 updated_milestone.completed = true;
-                env.storage()
-                    .persistent()
-                    .set(&DataKey::Milestone(MilestoneKey::Record(creator.clone(), idx as u64)), &updated_milestone);
+                env.storage().persistent().set(
+                    &DataKey::Milestone(MilestoneKey::Record(creator.clone(), idx as u64)),
+                    &updated_milestone,
+                );
 
                 env.events().publish(
                     (symbol_short!("milestone"),),
@@ -5564,9 +5805,10 @@ impl TipJarContract {
             completed: false,
         };
 
-        env.storage()
-            .persistent()
-            .set(&DataKey::Milestone(MilestoneKey::Record(creator.clone(), milestone_id)), &milestone);
+        env.storage().persistent().set(
+            &DataKey::Milestone(MilestoneKey::Record(creator.clone(), milestone_id)),
+            &milestone,
+        );
         env.storage()
             .persistent()
             .set(&counter_key, &(milestone_id + 1));
@@ -5577,14 +5819,13 @@ impl TipJarContract {
             .get(&DataKey::Milestone(MilestoneKey::Active(creator.clone())))
             .unwrap_or_else(|| Vec::new(&env));
         active.push_back(milestone_id);
-        env.storage()
-            .persistent()
-            .set(&DataKey::Milestone(MilestoneKey::Active(creator.clone())), &active);
-
-        env.events().publish(
-            (symbol_short!("ms_crt"),),
-            (creator, goal_amount),
+        env.storage().persistent().set(
+            &DataKey::Milestone(MilestoneKey::Active(creator.clone())),
+            &active,
         );
+
+        env.events()
+            .publish((symbol_short!("ms_crt"),), (creator, goal_amount));
 
         milestone_id
     }
@@ -5599,10 +5840,13 @@ impl TipJarContract {
 
         let mut milestones = Vec::new(&env);
         for id in milestone_ids.iter() {
-            if let Some(milestone) = env
-                .storage()
-                .persistent()
-                .get::<_, Milestone>(&DataKey::Milestone(MilestoneKey::Record(creator.clone(), id)))
+            if let Some(milestone) =
+                env.storage()
+                    .persistent()
+                    .get::<_, Milestone>(&DataKey::Milestone(MilestoneKey::Record(
+                        creator.clone(),
+                        id,
+                    )))
             {
                 milestones.push_back(milestone);
             }
@@ -5614,7 +5858,10 @@ impl TipJarContract {
     pub fn get_milestone(env: Env, creator: Address, milestone_id: u64) -> Milestone {
         env.storage()
             .persistent()
-            .get(&DataKey::Milestone(MilestoneKey::Record(creator, milestone_id)))
+            .get(&DataKey::Milestone(MilestoneKey::Record(
+                creator,
+                milestone_id,
+            )))
             .unwrap_or_else(|| panic_with_error!(&env, TipJarError::MilestoneNotFound))
     }
 
@@ -5646,8 +5893,14 @@ impl TipJarContract {
             panic_with_error!(&env, TipJarError::TokenNotWhitelisted);
         }
 
-        let tip_id: u64 = env.storage().instance().get(&DataKey::PrivateTip(PrivateTipKey::Ctr)).unwrap_or(0);
-        env.storage().instance().set(&DataKey::PrivateTip(PrivateTipKey::Ctr), &(tip_id + 1));
+        let tip_id: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::PrivateTip(PrivateTipKey::Ctr))
+            .unwrap_or(0);
+        env.storage()
+            .instance()
+            .set(&DataKey::PrivateTip(PrivateTipKey::Ctr), &(tip_id + 1));
 
         let amount_bytes = amount.to_le_bytes();
         let amount_hash = env.crypto().sha256(&amount_bytes);
@@ -5669,7 +5922,10 @@ impl TipJarContract {
             revealed: false,
         };
 
-        env.storage().persistent().set(&DataKey::PrivateTip(PrivateTipKey::Record(tip_id)), &private_tip);
+        env.storage().persistent().set(
+            &DataKey::PrivateTip(PrivateTipKey::Record(tip_id)),
+            &private_tip,
+        );
 
         env.events().publish(
             (symbol_short!("priv_tip"),),
@@ -5684,13 +5940,7 @@ impl TipJarContract {
     /// The amount is hashed and compared with the stored hash. If it matches,
     /// the tip is credited to the creator and marked as revealed.
     /// Emits `("tip_revealed",)` with data `(tip_id, amount)`.
-    pub fn reveal_tip(
-        env: Env,
-        sender: Address,
-        token: Address,
-        tip_id: u64,
-        amount: i128,
-    ) {
+    pub fn reveal_tip(env: Env, sender: Address, token: Address, tip_id: u64, amount: i128) {
         Self::require_not_paused(&env);
         sender.require_auth();
 
@@ -5721,39 +5971,52 @@ impl TipJarContract {
         }
 
         // Transfer tokens
-        token::Client::new(&env, &token).transfer(&sender, &env.current_contract_address(), &amount);
+        token::Client::new(&env, &token).transfer(
+            &sender,
+            &env.current_contract_address(),
+            &amount,
+        );
 
-        let fee_bp: u32 = env.storage().instance().get(&DataKey::Fee(FeeKey::BasisPoints)).unwrap_or(0);
+        let fee_bp: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey::Fee(FeeKey::BasisPoints))
+            .unwrap_or(0);
         let fee: i128 = (amount * fee_bp as i128) / 10_000;
         let creator_amount = amount - fee;
 
         if fee > 0 {
             let fee_key = DataKey::Fee(FeeKey::Balance(token.clone()));
             let current_fee: i128 = env.storage().instance().get(&fee_key).unwrap_or(0);
-            let new_fee_bal: i128 = current_fee
-                .checked_add(fee)
-                .expect("fee overflow");
+            let new_fee_bal: i128 = current_fee.checked_add(fee).expect("fee overflow");
             env.storage().instance().set(&fee_key, &new_fee_bal);
         }
 
         let bal_key = DataKey::CreatorBalance(private_tip.creator.clone(), token.clone());
         let existing_bal: i128 = env.storage().persistent().get(&bal_key).unwrap_or(0);
-        let new_bal: i128 = existing_bal.checked_add(creator_amount).expect("balance overflow");
+        let new_bal: i128 = existing_bal
+            .checked_add(creator_amount)
+            .expect("balance overflow");
         env.storage().persistent().set(&bal_key, &new_bal);
 
         let tot_key = DataKey::CreatorTotal(private_tip.creator.clone(), token.clone());
         let existing_tot: i128 = env.storage().persistent().get(&tot_key).unwrap_or(0);
-        let new_tot: i128 = existing_tot.checked_add(creator_amount).expect("total overflow");
+        let new_tot: i128 = existing_tot
+            .checked_add(creator_amount)
+            .expect("total overflow");
         env.storage().persistent().set(&tot_key, &new_tot);
 
         private_tip.revealed = true;
-        env.storage().persistent().set(&DataKey::PrivateTip(PrivateTipKey::Record(tip_id)), &private_tip);
-        env.storage().persistent().set(&DataKey::PrivateTip(PrivateTipKey::Amount(tip_id)), &amount);
-
-        env.events().publish(
-            (symbol_short!("tip_rev"),),
-            (tip_id, amount),
+        env.storage().persistent().set(
+            &DataKey::PrivateTip(PrivateTipKey::Record(tip_id)),
+            &private_tip,
         );
+        env.storage()
+            .persistent()
+            .set(&DataKey::PrivateTip(PrivateTipKey::Amount(tip_id)), &amount);
+
+        env.events()
+            .publish((symbol_short!("tip_rev"),), (tip_id, amount));
     }
 
     /// Returns a private tip record by ID.
@@ -5812,7 +6075,11 @@ impl TipJarContract {
             panic_with_error!(&env, TipJarError::TokenNotWhitelisted);
         }
 
-        let stream_id: u64 = env.storage().instance().get(&DataKey::Stream(StreamKey::Ctr)).unwrap_or(0);
+        let stream_id: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::Stream(StreamKey::Ctr))
+            .unwrap_or(0);
         let now = env.ledger().timestamp();
         let total_amount = amount_per_second * duration as i128;
 
@@ -5830,8 +6097,12 @@ impl TipJarContract {
             updated_at: now,
         };
 
-        env.storage().persistent().set(&DataKey::Stream(StreamKey::Record(stream_id)), &stream);
-        env.storage().instance().set(&DataKey::Stream(StreamKey::Ctr), &(stream_id + 1));
+        env.storage()
+            .persistent()
+            .set(&DataKey::Stream(StreamKey::Record(stream_id)), &stream);
+        env.storage()
+            .instance()
+            .set(&DataKey::Stream(StreamKey::Ctr), &(stream_id + 1));
 
         // Add to sender's stream list
         let mut sender_streams: Vec<u64> = env
@@ -5840,7 +6111,10 @@ impl TipJarContract {
             .get(&DataKey::Stream(StreamKey::SenderStreams(sender.clone())))
             .unwrap_or_else(|| Vec::new(&env));
         sender_streams.push_back(stream_id);
-        env.storage().persistent().set(&DataKey::Stream(StreamKey::SenderStreams(sender.clone())), &sender_streams);
+        env.storage().persistent().set(
+            &DataKey::Stream(StreamKey::SenderStreams(sender.clone())),
+            &sender_streams,
+        );
 
         // Add to creator's stream list
         let mut creator_streams: Vec<u64> = env
@@ -5849,10 +6123,17 @@ impl TipJarContract {
             .get(&DataKey::Stream(StreamKey::CreatorStreams(creator.clone())))
             .unwrap_or_else(|| Vec::new(&env));
         creator_streams.push_back(stream_id);
-        env.storage().persistent().set(&DataKey::Stream(StreamKey::CreatorStreams(creator.clone())), &creator_streams);
+        env.storage().persistent().set(
+            &DataKey::Stream(StreamKey::CreatorStreams(creator.clone())),
+            &creator_streams,
+        );
 
         // Transfer total amount into escrow
-        token::Client::new(&env, &token).transfer(&sender, &env.current_contract_address(), &total_amount);
+        token::Client::new(&env, &token).transfer(
+            &sender,
+            &env.current_contract_address(),
+            &total_amount,
+        );
 
         env.events().publish(
             (symbol_short!("strm_cre"),),
@@ -5878,9 +6159,8 @@ impl TipJarContract {
             current_time - stream.start_time
         };
 
-        (stream.amount_per_second * elapsed as i128).min(
-            stream.amount_per_second * (stream.end_time - stream.start_time) as i128
-        )
+        (stream.amount_per_second * elapsed as i128)
+            .min(stream.amount_per_second * (stream.end_time - stream.start_time) as i128)
     }
 
     /// Starts a stream (or resumes a paused stream).
@@ -5922,12 +6202,12 @@ impl TipJarContract {
         stream.status = StreamStatus::Active;
         stream.updated_at = now;
 
-        env.storage().persistent().set(&DataKey::Stream(StreamKey::Record(stream_id)), &stream);
+        env.storage()
+            .persistent()
+            .set(&DataKey::Stream(StreamKey::Record(stream_id)), &stream);
 
-        env.events().publish(
-            (symbol_short!("strm_sta"),),
-            stream_id,
-        );
+        env.events()
+            .publish((symbol_short!("strm_sta"),), stream_id);
     }
 
     /// Stops (pauses) an active stream.
@@ -5961,12 +6241,12 @@ impl TipJarContract {
         stream.withdrawn = streamed_amount;
         stream.updated_at = env.ledger().timestamp();
 
-        env.storage().persistent().set(&DataKey::Stream(StreamKey::Record(stream_id)), &stream);
+        env.storage()
+            .persistent()
+            .set(&DataKey::Stream(StreamKey::Record(stream_id)), &stream);
 
-        env.events().publish(
-            (symbol_short!("strm_sto"),),
-            (stream_id, streamed_amount),
-        );
+        env.events()
+            .publish((symbol_short!("strm_sto"),), (stream_id, streamed_amount));
     }
 
     /// Withdraws the currently streamed amount for a stream.
@@ -5997,7 +6277,8 @@ impl TipJarContract {
             panic_with_error!(&env, InsuranceError::StreamNotStarted);
         }
 
-        let total_streamable = stream.amount_per_second * (stream.end_time - stream.start_time) as i128;
+        let total_streamable =
+            stream.amount_per_second * (stream.end_time - stream.start_time) as i128;
         let streamed_amount = Self::calculate_streamed_amount(&env, &stream);
         let available_to_withdraw = streamed_amount - stream.withdrawn;
 
@@ -6015,7 +6296,9 @@ impl TipJarContract {
 
         stream.updated_at = current_time;
 
-        env.storage().persistent().set(&DataKey::Stream(StreamKey::Record(stream_id)), &stream);
+        env.storage()
+            .persistent()
+            .set(&DataKey::Stream(StreamKey::Record(stream_id)), &stream);
 
         // Transfer tokens to creator
         token::Client::new(&env, &stream.token).transfer(
@@ -6067,7 +6350,9 @@ impl TipJarContract {
         stream.status = StreamStatus::Cancelled;
         stream.updated_at = current_time;
 
-        env.storage().persistent().set(&DataKey::Stream(StreamKey::Record(stream_id)), &stream);
+        env.storage()
+            .persistent()
+            .set(&DataKey::Stream(StreamKey::Record(stream_id)), &stream);
 
         // Refund remaining tokens to sender
         if remaining_amount > 0 {
@@ -6081,15 +6366,15 @@ impl TipJarContract {
         // If there's any withdrawn amount not yet claimed, it's already in the creator's balance
         // (handled by the periodic withdraw_streamed calls)
 
-        env.events().publish(
-            (symbol_short!("strm_can"),),
-            (stream_id, remaining_amount),
-        );
+        env.events()
+            .publish((symbol_short!("strm_can"),), (stream_id, remaining_amount));
     }
 
     /// Returns the current stream details.
     pub fn get_stream(env: Env, stream_id: u64) -> Option<Stream> {
-        env.storage().persistent().get(&DataKey::Stream(StreamKey::Record(stream_id)))
+        env.storage()
+            .persistent()
+            .get(&DataKey::Stream(StreamKey::Record(stream_id)))
     }
 
     /// Returns all stream IDs for a creator.
@@ -6183,11 +6468,19 @@ impl TipJarContract {
             admin_fee_bps,
             tip_premium_bps,
         };
-        env.storage().instance().set(&DataKey::Insurance(InsuranceKey::Cfg), &config);
+        env.storage()
+            .instance()
+            .set(&DataKey::Insurance(InsuranceKey::Cfg), &config);
 
         env.events().publish(
             (symbol_short!("ins_cfg"),),
-            (min_contribution, max_contribution, premium_rate_bps, payout_ratio_bps, tip_premium_bps),
+            (
+                min_contribution,
+                max_contribution,
+                premium_rate_bps,
+                payout_ratio_bps,
+                tip_premium_bps,
+            ),
         );
     }
 
@@ -6200,7 +6493,9 @@ impl TipJarContract {
         if admin != stored_admin {
             panic_with_error!(&env, TipJarError::Unauthorized);
         }
-        env.storage().instance().set(&DataKey::Insurance(InsuranceKey::Enabled), &enabled);
+        env.storage()
+            .instance()
+            .set(&DataKey::Insurance(InsuranceKey::Enabled), &enabled);
         env.events().publish((symbol_short!("ins_en"),), enabled);
     }
 
@@ -6216,8 +6511,11 @@ impl TipJarContract {
         if max_claims == 0 {
             panic_with_error!(&env, TipJarError::InvalidAmount);
         }
-        env.storage().instance().set(&DataKey::Insurance(InsuranceKey::MaxClms), &max_claims);
-        env.events().publish((symbol_short!("ins_max"),), max_claims);
+        env.storage()
+            .instance()
+            .set(&DataKey::Insurance(InsuranceKey::MaxClms), &max_claims);
+        env.events()
+            .publish((symbol_short!("ins_max"),), max_claims);
     }
 
     /// Set the insurance admin address.
@@ -6229,8 +6527,11 @@ impl TipJarContract {
         if admin != stored_admin {
             panic_with_error!(&env, TipJarError::Unauthorized);
         }
-        env.storage().instance().set(&DataKey::Insurance(InsuranceKey::Admin), &insurance_admin);
-        env.events().publish((symbol_short!("ins_adm"),), insurance_admin);
+        env.storage()
+            .instance()
+            .set(&DataKey::Insurance(InsuranceKey::Admin), &insurance_admin);
+        env.events()
+            .publish((symbol_short!("ins_adm"),), insurance_admin);
     }
 
     /// Contribute to the insurance pool for a specific token.
@@ -6239,17 +6540,16 @@ impl TipJarContract {
     /// must be within configured limits. The sender must transfer the tokens to this contract.
     ///
     /// Emits `("insurance_contribution",)` with data `(creator, token, amount, coverage_amount)`.
-    pub fn insurance_contribute(
-        env: Env,
-        creator: Address,
-        token: Address,
-        amount: i128,
-    ) {
+    pub fn insurance_contribute(env: Env, creator: Address, token: Address, amount: i128) {
         Self::require_not_paused(&env);
         creator.require_auth();
 
         // Check if insurance is enabled
-        let enabled: bool = env.storage().instance().get(&DataKey::Insurance(InsuranceKey::Enabled)).unwrap_or(true);
+        let enabled: bool = env
+            .storage()
+            .instance()
+            .get(&DataKey::Insurance(InsuranceKey::Enabled))
+            .unwrap_or(true);
         if !enabled {
             panic_with_error!(&env, InsuranceError::InsuranceDisabled);
         }
@@ -6278,26 +6578,30 @@ impl TipJarContract {
         }
 
         // Transfer tokens from creator to contract
-        token::Client::new(&env, &token).transfer(&creator, &env.current_contract_address(), &amount);
+        token::Client::new(&env, &token).transfer(
+            &creator,
+            &env.current_contract_address(),
+            &amount,
+        );
 
         // Calculate premium for this contribution period
         let premium_amount = (amount * config.premium_rate_bps as i128) / 10_000;
 
         // Update pool state
         let pool_key = DataKey::Insurance(InsuranceKey::Token(token.clone()));
-        let mut pool: InsurancePool = env
-            .storage()
-            .persistent()
-            .get(&pool_key)
-            .unwrap_or_else(|| InsurancePool {
-                token: token.clone(),
-                total_reserves: 0,
-                total_contributions: 0,
-                total_claims_paid: 0,
-                active_claims: 0,
-                total_claims: 0,
-                last_payout_time: env.ledger().timestamp(),
-            });
+        let mut pool: InsurancePool =
+            env.storage()
+                .persistent()
+                .get(&pool_key)
+                .unwrap_or_else(|| InsurancePool {
+                    token: token.clone(),
+                    total_reserves: 0,
+                    total_contributions: 0,
+                    total_claims_paid: 0,
+                    active_claims: 0,
+                    total_claims: 0,
+                    last_payout_time: env.ledger().timestamp(),
+                });
 
         pool.total_reserves += amount - premium_amount;
         pool.total_contributions += amount;
@@ -6306,11 +6610,17 @@ impl TipJarContract {
         // Update creator contribution
         let contrib_key = DataKey::Insurance(InsuranceKey::Contrib(creator.clone(), token.clone()));
         let current_contrib: i128 = env.storage().persistent().get(&contrib_key).unwrap_or(0);
-        env.storage().persistent().set(&contrib_key, &(current_contrib + amount));
+        env.storage()
+            .persistent()
+            .set(&contrib_key, &(current_contrib + amount));
 
         // Add to creator's token list
         let tokens_key = DataKey::CreatorTokens(creator.clone());
-        let mut tokens: Vec<Address> = env.storage().persistent().get(&tokens_key).unwrap_or_else(|| Vec::new(&env));
+        let mut tokens: Vec<Address> = env
+            .storage()
+            .persistent()
+            .get(&tokens_key)
+            .unwrap_or_else(|| Vec::new(&env));
         if !tokens.contains(&token) {
             tokens.push_back(token.clone());
             env.storage().persistent().set(&tokens_key, &tokens);
@@ -6320,7 +6630,9 @@ impl TipJarContract {
         if premium_amount > 0 {
             let fee_key = DataKey::Fee(FeeKey::Balance(token.clone()));
             let current_fee: i128 = env.storage().instance().get(&fee_key).unwrap_or(0);
-            env.storage().instance().set(&fee_key, &(current_fee + premium_amount));
+            env.storage()
+                .instance()
+                .set(&fee_key, &(current_fee + premium_amount));
         }
 
         env.events().publish(
@@ -6351,7 +6663,11 @@ impl TipJarContract {
         }
 
         // Check if insurance is enabled
-        let enabled: bool = env.storage().instance().get(&DataKey::Insurance(InsuranceKey::Enabled)).unwrap_or(true);
+        let enabled: bool = env
+            .storage()
+            .instance()
+            .get(&DataKey::Insurance(InsuranceKey::Enabled))
+            .unwrap_or(true);
         if !enabled {
             panic_with_error!(&env, InsuranceError::InsuranceDisabled);
         }
@@ -6370,15 +6686,21 @@ impl TipJarContract {
         }
 
         // Check active claim limit
-        let max_active: u32 = env.storage().instance().get(&DataKey::Insurance(InsuranceKey::MaxClms)).unwrap_or(3);
-        let active_key = DataKey::Insurance(InsuranceKey::ActiveClms(creator.clone(), token.clone()));
+        let max_active: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey::Insurance(InsuranceKey::MaxClms))
+            .unwrap_or(3);
+        let active_key =
+            DataKey::Insurance(InsuranceKey::ActiveClms(creator.clone(), token.clone()));
         let active_claims: u32 = env.storage().persistent().get(&active_key).unwrap_or(0);
         if active_claims >= max_active {
             panic_with_error!(&env, InsuranceError::TooManyActiveClaims);
         }
 
         // Check last claim cooldown
-        let last_claim_key = DataKey::Insurance(InsuranceKey::LastClm(creator.clone(), token.clone()));
+        let last_claim_key =
+            DataKey::Insurance(InsuranceKey::LastClm(creator.clone(), token.clone()));
         let last_claim: u64 = env.storage().persistent().get(&last_claim_key).unwrap_or(0);
         let now = env.ledger().timestamp();
         if last_claim > 0 && now < last_claim + config.claim_cooldown {
@@ -6402,8 +6724,14 @@ impl TipJarContract {
         }
 
         // Create claim
-        let claim_id: u64 = env.storage().instance().get(&DataKey::Insurance(InsuranceKey::Ctr)).unwrap_or(0);
-        env.storage().instance().set(&DataKey::Insurance(InsuranceKey::Ctr), &(claim_id + 1));
+        let claim_id: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::Insurance(InsuranceKey::Ctr))
+            .unwrap_or(0);
+        env.storage()
+            .instance()
+            .set(&DataKey::Insurance(InsuranceKey::Ctr), &(claim_id + 1));
 
         let claim = InsuranceClaim {
             claim_id,
@@ -6416,21 +6744,39 @@ impl TipJarContract {
             updated_at: now,
             last_claim_at: last_claim,
         };
-        env.storage().persistent().set(&DataKey::Insurance(InsuranceKey::Claim(claim_id)), &claim);
+        env.storage()
+            .persistent()
+            .set(&DataKey::Insurance(InsuranceKey::Claim(claim_id)), &claim);
 
         // Add to creator's claims list
-        let creator_claims_key = DataKey::Insurance(InsuranceKey::Clms(creator.clone(), token.clone()));
-        let mut creator_claims: Vec<u64> = env.storage().persistent().get(&creator_claims_key).unwrap_or_else(|| Vec::new(&env));
+        let creator_claims_key =
+            DataKey::Insurance(InsuranceKey::Clms(creator.clone(), token.clone()));
+        let mut creator_claims: Vec<u64> = env
+            .storage()
+            .persistent()
+            .get(&creator_claims_key)
+            .unwrap_or_else(|| Vec::new(&env));
         creator_claims.push_back(claim_id);
-        env.storage().persistent().set(&creator_claims_key, &creator_claims);
+        env.storage()
+            .persistent()
+            .set(&creator_claims_key, &creator_claims);
 
         // Update active claim count
-        env.storage().persistent().set(&active_key, &(active_claims + 1));
+        env.storage()
+            .persistent()
+            .set(&active_key, &(active_claims + 1));
 
         // Update total claims count
-        let total_claims_key = DataKey::Insurance(InsuranceKey::TotalClms(creator.clone(), token.clone()));
-        let total_claims: u32 = env.storage().persistent().get(&total_claims_key).unwrap_or(0);
-        env.storage().persistent().set(&total_claims_key, &(total_claims + 1));
+        let total_claims_key =
+            DataKey::Insurance(InsuranceKey::TotalClms(creator.clone(), token.clone()));
+        let total_claims: u32 = env
+            .storage()
+            .persistent()
+            .get(&total_claims_key)
+            .unwrap_or(0);
+        env.storage()
+            .persistent()
+            .set(&total_claims_key, &(total_claims + 1));
 
         // Update pool
         let mut updated_pool = pool.clone();
@@ -6452,16 +6798,16 @@ impl TipJarContract {
     /// Once approved, the claim can be paid out.
     ///
     /// Emits `("claim_approved",)` with data `(claim_id, approver)`.
-    pub fn insurance_approve_claim(
-        env: Env,
-        approver: Address,
-        claim_id: u64,
-    ) {
+    pub fn insurance_approve_claim(env: Env, approver: Address, claim_id: u64) {
         approver.require_auth();
 
         // Check if caller is admin or insurance admin
         let stored_admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
-        let insurance_admin: Address = env.storage().instance().get(&DataKey::Insurance(InsuranceKey::Admin)).unwrap_or(stored_admin.clone());
+        let insurance_admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Insurance(InsuranceKey::Admin))
+            .unwrap_or(stored_admin.clone());
         if approver != stored_admin && approver != insurance_admin {
             panic_with_error!(&env, InsuranceError::AdmAppReq);
         }
@@ -6479,7 +6825,9 @@ impl TipJarContract {
         let mut updated_claim = claim.clone();
         updated_claim.status = ClaimStatus::Approved;
         updated_claim.updated_at = env.ledger().timestamp();
-        env.storage().persistent().set(&DataKey::Insurance(InsuranceKey::Claim(claim_id)), &claim);
+        env.storage()
+            .persistent()
+            .set(&DataKey::Insurance(InsuranceKey::Claim(claim_id)), &claim);
 
         // Update pool
         let pool_key = DataKey::Insurance(InsuranceKey::Token(claim.token.clone()));
@@ -6489,14 +6837,17 @@ impl TipJarContract {
         env.storage().persistent().set(&pool_key, &updated_pool);
 
         // Update creator active claims
-        let active_key = DataKey::Insurance(InsuranceKey::ActiveClms(claim.creator.clone(), claim.token.clone()));
+        let active_key = DataKey::Insurance(InsuranceKey::ActiveClms(
+            claim.creator.clone(),
+            claim.token.clone(),
+        ));
         let active_claims: u32 = env.storage().persistent().get(&active_key).unwrap_or(1);
-        env.storage().persistent().set(&active_key, &(active_claims - 1));
+        env.storage()
+            .persistent()
+            .set(&active_key, &(active_claims - 1));
 
-        env.events().publish(
-            (symbol_short!("clm_app"),),
-            (claim_id, approver),
-        );
+        env.events()
+            .publish((symbol_short!("clm_app"),), (claim_id, approver));
     }
 
     /// Reject an insurance claim (admin or insurance admin).
@@ -6504,16 +6855,16 @@ impl TipJarContract {
     /// Only the contract admin or insurance admin can reject claims.
     ///
     /// Emits `("claim_rejected",)` with data `(claim_id, rejector)`.
-    pub fn insurance_reject_claim(
-        env: Env,
-        rejector: Address,
-        claim_id: u64,
-    ) {
+    pub fn insurance_reject_claim(env: Env, rejector: Address, claim_id: u64) {
         rejector.require_auth();
 
         // Check if caller is admin or insurance admin
         let stored_admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
-        let insurance_admin: Address = env.storage().instance().get(&DataKey::Insurance(InsuranceKey::Admin)).unwrap_or(stored_admin.clone());
+        let insurance_admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Insurance(InsuranceKey::Admin))
+            .unwrap_or(stored_admin.clone());
         if rejector != stored_admin && rejector != insurance_admin {
             panic_with_error!(&env, InsuranceError::AdmAppReq);
         }
@@ -6531,7 +6882,9 @@ impl TipJarContract {
         let mut updated_claim = claim.clone();
         updated_claim.status = ClaimStatus::Rejected;
         updated_claim.updated_at = env.ledger().timestamp();
-        env.storage().persistent().set(&DataKey::Insurance(InsuranceKey::Claim(claim_id)), &claim);
+        env.storage()
+            .persistent()
+            .set(&DataKey::Insurance(InsuranceKey::Claim(claim_id)), &claim);
 
         if claim.status == ClaimStatus::Approved {
             // Update pool
@@ -6542,15 +6895,18 @@ impl TipJarContract {
             env.storage().persistent().set(&pool_key, &updated_pool);
 
             // Update creator active claims
-            let active_key = DataKey::Insurance(InsuranceKey::ActiveClms(claim.creator.clone(), claim.token.clone()));
+            let active_key = DataKey::Insurance(InsuranceKey::ActiveClms(
+                claim.creator.clone(),
+                claim.token.clone(),
+            ));
             let active_claims: u32 = env.storage().persistent().get(&active_key).unwrap_or(1);
-            env.storage().persistent().set(&active_key, &(active_claims - 1));
+            env.storage()
+                .persistent()
+                .set(&active_key, &(active_claims - 1));
         }
 
-        env.events().publish(
-            (symbol_short!("clm_rej"),),
-            (claim_id, rejector),
-        );
+        env.events()
+            .publish((symbol_short!("clm_rej"),), (claim_id, rejector));
     }
 
     /// Pay out an approved insurance claim.
@@ -6559,16 +6915,16 @@ impl TipJarContract {
     /// Can only be called for approved claims that haven't been paid yet.
     ///
     /// Emits `("claim_paid",)` with data `(claim_id, amount, creator)`.
-    pub fn insurance_pay_claim(
-        env: Env,
-        caller: Address,
-        claim_id: u64,
-    ) {
+    pub fn insurance_pay_claim(env: Env, caller: Address, claim_id: u64) {
         caller.require_auth();
 
         // Check if caller is admin or insurance admin
         let stored_admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
-        let insurance_admin: Address = env.storage().instance().get(&DataKey::Insurance(InsuranceKey::Admin)).unwrap_or(stored_admin.clone());
+        let insurance_admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Insurance(InsuranceKey::Admin))
+            .unwrap_or(stored_admin.clone());
         if caller != stored_admin && caller != insurance_admin {
             panic_with_error!(&env, InsuranceError::AdmAppReq);
         }
@@ -6596,10 +6952,15 @@ impl TipJarContract {
         }
 
         // Update creator's contribution (deduct claim amount)
-        let contrib_key = DataKey::Insurance(InsuranceKey::Contrib(claim.creator.clone(), claim.token.clone()));
+        let contrib_key = DataKey::Insurance(InsuranceKey::Contrib(
+            claim.creator.clone(),
+            claim.token.clone(),
+        ));
         let current_contrib: i128 = env.storage().persistent().get(&contrib_key).unwrap_or(0);
         let new_contrib = current_contrib - claim.amount;
-        env.storage().persistent().set(&contrib_key, &new_contrib.max(0));
+        env.storage()
+            .persistent()
+            .set(&contrib_key, &new_contrib.max(0));
 
         // Update pool reserves
         let mut updated_pool = pool.clone();
@@ -6613,15 +6974,27 @@ impl TipJarContract {
         let mut updated_claim = claim.clone();
         updated_claim.status = ClaimStatus::Paid;
         updated_claim.updated_at = env.ledger().timestamp();
-        env.storage().persistent().set(&DataKey::Insurance(InsuranceKey::Claim(claim_id)), &claim);
+        env.storage()
+            .persistent()
+            .set(&DataKey::Insurance(InsuranceKey::Claim(claim_id)), &claim);
 
         // Update creator's last claim time and active claims
-        let last_claim_key = DataKey::Insurance(InsuranceKey::LastClm(claim.creator.clone(), claim.token.clone()));
-        env.storage().persistent().set(&last_claim_key, &env.ledger().timestamp());
+        let last_claim_key = DataKey::Insurance(InsuranceKey::LastClm(
+            claim.creator.clone(),
+            claim.token.clone(),
+        ));
+        env.storage()
+            .persistent()
+            .set(&last_claim_key, &env.ledger().timestamp());
 
-        let active_key = DataKey::Insurance(InsuranceKey::ActiveClms(claim.creator.clone(), claim.token.clone()));
+        let active_key = DataKey::Insurance(InsuranceKey::ActiveClms(
+            claim.creator.clone(),
+            claim.token.clone(),
+        ));
         let active_claims: u32 = env.storage().persistent().get(&active_key).unwrap_or(1);
-        env.storage().persistent().set(&active_key, &(active_claims - 1));
+        env.storage()
+            .persistent()
+            .set(&active_key, &(active_claims - 1));
 
         // Transfer funds to creator
         token::Client::new(&env, &claim.token).transfer(
@@ -6646,12 +7019,17 @@ impl TipJarContract {
 
     /// Check if the insurance feature is enabled.
     pub fn insurance_is_enabled(env: Env) -> bool {
-        env.storage().instance().get(&DataKey::Insurance(InsuranceKey::Enabled)).unwrap_or(true)
+        env.storage()
+            .instance()
+            .get(&DataKey::Insurance(InsuranceKey::Enabled))
+            .unwrap_or(true)
     }
 
     /// Get the insurance pool state for a specific token.
     pub fn insurance_get_pool(env: Env, token: Address) -> Option<InsurancePool> {
-        env.storage().persistent().get(&DataKey::Insurance(InsuranceKey::Token(token)))
+        env.storage()
+            .persistent()
+            .get(&DataKey::Insurance(InsuranceKey::Token(token)))
     }
 
     /// Get a specific insurance claim by ID.
@@ -6682,7 +7060,10 @@ impl TipJarContract {
         let contrib: i128 = env
             .storage()
             .persistent()
-            .get(&DataKey::Insurance(InsuranceKey::Contrib(creator.clone(), token.clone())))
+            .get(&DataKey::Insurance(InsuranceKey::Contrib(
+                creator.clone(),
+                token.clone(),
+            )))
             .unwrap_or(0);
 
         // Automatic premium coverage estimate from tips received
@@ -6691,8 +7072,8 @@ impl TipJarContract {
             .persistent()
             .get(&DataKey::CreatorTotal(creator, token))
             .unwrap_or(0);
-        
-        // Since CreatorTotal is net of fees and premiums, we approximate the original gross 
+
+        // Since CreatorTotal is net of fees and premiums, we approximate the original gross
         // to find the premium paid. Gross = Net / (1 - fee_bps - premium_bps)
         // For simplicity, we use Net * premium_bps as a conservative estimate of coverage earned.
         let premium_earned = (total_received * config.tip_premium_bps as i128) / 10_000;
@@ -6704,7 +7085,9 @@ impl TipJarContract {
     pub fn insurance_get_active_claims(env: Env, creator: Address, token: Address) -> u32 {
         env.storage()
             .persistent()
-            .get(&DataKey::Insurance(InsuranceKey::ActiveClms(creator, token)))
+            .get(&DataKey::Insurance(InsuranceKey::ActiveClms(
+                creator, token,
+            )))
             .unwrap_or(0)
     }
 
@@ -6730,12 +7113,7 @@ impl TipJarContract {
     ///
     /// Allows admin to withdraw funds beyond a minimum reserve threshold.
     /// Emits `("pool_withdraw",)` with data `(token, amount)`.
-    pub fn insurance_withdraw_excess(
-        env: Env,
-        admin: Address,
-        token: Address,
-        amount: i128,
-    ) {
+    pub fn insurance_withdraw_excess(env: Env, admin: Address, token: Address, amount: i128) {
         admin.require_auth();
         let stored_admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
         if admin != stored_admin {
@@ -6764,28 +7142,26 @@ impl TipJarContract {
         env.storage().persistent().set(&pool_key, &updated_pool);
 
         // Transfer to admin
-        token::Client::new(&env, &token).transfer(
-            &env.current_contract_address(),
-            &admin,
-            &amount,
-        );
+        token::Client::new(&env, &token).transfer(&env.current_contract_address(), &admin, &amount);
 
-        env.events().publish(
-            (symbol_short!("pol_wit"),),
-            (token, amount),
-        );
+        env.events()
+            .publish((symbol_short!("pol_wit"),), (token, amount));
     }
 
     /// Get the insurance admin address.
     pub fn insurance_get_admin(env: Env) -> Address {
-        env.storage().instance()
+        env.storage()
+            .instance()
             .get(&DataKey::Insurance(InsuranceKey::Admin))
             .unwrap_or_else(|| env.storage().instance().get(&DataKey::Admin).unwrap())
     }
 
     /// Get the maximum active claims per creator.
     pub fn insurance_get_max_active_claims(env: Env) -> u32 {
-        env.storage().instance().get(&DataKey::Insurance(InsuranceKey::MaxClms)).unwrap_or(3)
+        env.storage()
+            .instance()
+            .get(&DataKey::Insurance(InsuranceKey::MaxClms))
+            .unwrap_or(3)
     }
 
     /// Process multiple insurance claims in batch (admin only).
@@ -6820,7 +7196,9 @@ impl TipJarContract {
                     let mut updated_claim = claim.clone();
                     updated_claim.status = ClaimStatus::Approved;
                     updated_claim.updated_at = env.ledger().timestamp();
-                    env.storage().persistent().set(&DataKey::Insurance(InsuranceKey::Claim(claim_id)), &claim);
+                    env.storage()
+                        .persistent()
+                        .set(&DataKey::Insurance(InsuranceKey::Claim(claim_id)), &claim);
 
                     // Update pool active claims
                     let pool_key = DataKey::Insurance(InsuranceKey::Token(claim.token.clone()));
@@ -6830,9 +7208,15 @@ impl TipJarContract {
                     env.storage().persistent().set(&pool_key, &updated_pool);
 
                     // Update creator active claims
-                    let active_key = DataKey::Insurance(InsuranceKey::ActiveClms(claim.creator.clone(), claim.token.clone()));
-                    let active_claims: u32 = env.storage().persistent().get(&active_key).unwrap_or(1);
-                    env.storage().persistent().set(&active_key, &(active_claims - 1));
+                    let active_key = DataKey::Insurance(InsuranceKey::ActiveClms(
+                        claim.creator.clone(),
+                        claim.token.clone(),
+                    ));
+                    let active_claims: u32 =
+                        env.storage().persistent().get(&active_key).unwrap_or(1);
+                    env.storage()
+                        .persistent()
+                        .set(&active_key, &(active_claims - 1));
 
                     approved_count += 1;
                 }
@@ -6852,16 +7236,29 @@ impl TipJarContract {
                         let mut updated_claim = claim.clone();
                         updated_claim.status = ClaimStatus::Paid;
                         updated_claim.updated_at = env.ledger().timestamp();
-                        env.storage().persistent().set(&DataKey::Insurance(InsuranceKey::Claim(claim_id)), &claim);
+                        env.storage()
+                            .persistent()
+                            .set(&DataKey::Insurance(InsuranceKey::Claim(claim_id)), &claim);
 
                         // Update creator last claim time
-                        let last_claim_key = DataKey::Insurance(InsuranceKey::LastClm(claim.creator.clone(), claim.token.clone()));
-                        env.storage().persistent().set(&last_claim_key, &env.ledger().timestamp());
+                        let last_claim_key = DataKey::Insurance(InsuranceKey::LastClm(
+                            claim.creator.clone(),
+                            claim.token.clone(),
+                        ));
+                        env.storage()
+                            .persistent()
+                            .set(&last_claim_key, &env.ledger().timestamp());
 
                         // Update creator active claims
-                        let active_key = DataKey::Insurance(InsuranceKey::ActiveClms(claim.creator.clone(), claim.token.clone()));
-                        let active_claims: u32 = env.storage().persistent().get(&active_key).unwrap_or(1);
-                        env.storage().persistent().set(&active_key, &(active_claims - 1));
+                        let active_key = DataKey::Insurance(InsuranceKey::ActiveClms(
+                            claim.creator.clone(),
+                            claim.token.clone(),
+                        ));
+                        let active_claims: u32 =
+                            env.storage().persistent().get(&active_key).unwrap_or(1);
+                        env.storage()
+                            .persistent()
+                            .set(&active_key, &(active_claims - 1));
 
                         // Transfer funds
                         token::Client::new(&env, &claim.token).transfer(
@@ -6876,20 +7273,14 @@ impl TipJarContract {
             }
         }
 
-        env.events().publish(
-            (symbol_short!("clm_pro"),),
-            (approved_count, paid_count),
-        );
+        env.events()
+            .publish((symbol_short!("clm_pro"),), (approved_count, paid_count));
     }
 
     /// Get all insurance claims for a specific creator and token.
     ///
     /// Returns a vector of claim IDs for the creator's claims.
-    pub fn insurance_get_claims_by_creator(
-        env: Env,
-        creator: Address,
-        token: Address,
-    ) -> Vec<u64> {
+    pub fn insurance_get_claims_by_creator(env: Env, creator: Address, token: Address) -> Vec<u64> {
         env.storage()
             .persistent()
             .get(&DataKey::Insurance(InsuranceKey::Clms(creator, token)))
@@ -6907,13 +7298,17 @@ impl TipJarContract {
         if admin != stored_admin {
             panic_with_error!(&env, TipJarError::Unauthorized);
         }
-        env.storage().instance().set(&DataKey::Bridge(BridgeKey::Relayer), &relayer);
-        env.storage().instance().set(&DataKey::Bridge(BridgeKey::Token), &token);
-        env.storage().instance().set(&DataKey::Bridge(BridgeKey::Enabled), &true);
-        env.events().publish(
-            (symbol_short!("br_cfg"),),
-            (relayer, token),
-        );
+        env.storage()
+            .instance()
+            .set(&DataKey::Bridge(BridgeKey::Relayer), &relayer);
+        env.storage()
+            .instance()
+            .set(&DataKey::Bridge(BridgeKey::Token), &token);
+        env.storage()
+            .instance()
+            .set(&DataKey::Bridge(BridgeKey::Enabled), &true);
+        env.events()
+            .publish((symbol_short!("br_cfg"),), (relayer, token));
     }
 
     /// Processes a bridged tip submitted by an authorized relayer.
@@ -6941,7 +7336,9 @@ impl TipJarContract {
         if fee_bps > 500 {
             panic_with_error!(&env, AuctionError::InvalidBridgeFee);
         }
-        env.storage().instance().set(&DataKey::Bridge(BridgeKey::FeeBps), &fee_bps);
+        env.storage()
+            .instance()
+            .set(&DataKey::Bridge(BridgeKey::FeeBps), &fee_bps);
         env.events().publish((symbol_short!("br_fee"),), fee_bps);
     }
 
@@ -6962,7 +7359,9 @@ impl TipJarContract {
         if admin != stored_admin {
             panic_with_error!(&env, TipJarError::Unauthorized);
         }
-        env.storage().instance().set(&DataKey::Bridge(BridgeKey::Enabled), &enabled);
+        env.storage()
+            .instance()
+            .set(&DataKey::Bridge(BridgeKey::Enabled), &enabled);
         env.events().publish((symbol_short!("br_en"),), enabled);
     }
 
@@ -6973,7 +7372,7 @@ impl TipJarContract {
             .get(&DataKey::Bridge(BridgeKey::Enabled))
             .unwrap_or(false)
     }
-a
+
     // ── options trading ──────────────────────────────────────────────────────
 
     /// Initialize options trading system with default pricing parameters.
@@ -6996,7 +7395,7 @@ a
         env.storage()
             .persistent()
             .set(&DataKey::Option(OptionKey::PricingParams), &params);
-        
+
         env.storage()
             .instance()
             .set(&DataKey::Option(OptionKey::Ctr), &0u64);
@@ -7045,8 +7444,14 @@ a
         let collateral = options::calculate_collateral(option_type, strike_price, amount);
 
         // Generate option ID
-        let option_id: u64 = env.storage().instance().get(&DataKey::Option(OptionKey::Ctr)).unwrap_or(0);
-        env.storage().instance().set(&DataKey::Option(OptionKey::Ctr), &(option_id + 1));
+        let option_id: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::Option(OptionKey::Ctr))
+            .unwrap_or(0);
+        env.storage()
+            .instance()
+            .set(&DataKey::Option(OptionKey::Ctr), &(option_id + 1));
 
         // Create option contract
         let option = options::OptionContract {
@@ -7075,7 +7480,7 @@ a
         env.storage()
             .persistent()
             .set(&DataKey::Option(OptionKey::Record(option_id)), &option);
-        
+
         options::add_written_option(&env, &writer, option_id);
         options::add_active_option(&env, option_id);
 
@@ -7091,7 +7496,14 @@ a
 
         env.events().publish(
             (symbol_short!("opt_wrt"),),
-            (option_id, writer, option_type, strike_price, amount, expiration),
+            (
+                option_id,
+                writer,
+                option_type,
+                strike_price,
+                amount,
+                expiration,
+            ),
         );
 
         option_id
@@ -7101,12 +7513,7 @@ a
     ///
     /// Premium is calculated based on current pricing parameters.
     /// Emits `("opt_buy",)` with data `(option_id, buyer, premium)`.
-    pub fn buy_option(
-        env: Env,
-        buyer: Address,
-        option_id: u64,
-        spot_price: i128,
-    ) {
+    pub fn buy_option(env: Env, buyer: Address, option_id: u64, spot_price: i128) {
         Self::require_not_paused(&env);
         buyer.require_auth();
 
@@ -7145,11 +7552,7 @@ a
         );
 
         // Transfer premium from buyer to writer
-        token::Client::new(&env, &option.token).transfer(
-            &buyer,
-            &option.writer,
-            &premium,
-        );
+        token::Client::new(&env, &option.token).transfer(&buyer, &option.writer, &premium);
 
         // Update option
         option.holder = Some(buyer.clone());
@@ -7171,10 +7574,8 @@ a
         // Add to buyer's held options
         options::add_held_option(&env, &buyer, option_id);
 
-        env.events().publish(
-            (symbol_short!("opt_buy"),),
-            (option_id, buyer, premium),
-        );
+        env.events()
+            .publish((symbol_short!("opt_buy"),), (option_id, buyer, premium));
     }
 
     /// Exercise an option contract.
@@ -7182,21 +7583,14 @@ a
     /// Only the holder can exercise. Option must be in the money.
     /// Returns the payoff amount.
     /// Emits `("opt_exer",)` with data `(option_id, holder, payoff)`.
-    pub fn exercise_option(
-        env: Env,
-        holder: Address,
-        option_id: u64,
-        spot_price: i128,
-    ) -> i128 {
+    pub fn exercise_option(env: Env, holder: Address, option_id: u64, spot_price: i128) -> i128 {
         Self::require_not_paused(&env);
         holder.require_auth();
 
         let payoff = options::exercise::exercise_option(&env, &holder, option_id, spot_price);
 
-        env.events().publish(
-            (symbol_short!("opt_exer"),),
-            (option_id, holder, payoff),
-        );
+        env.events()
+            .publish((symbol_short!("opt_exer"),), (option_id, holder, payoff));
 
         payoff
     }
@@ -7208,10 +7602,7 @@ a
     pub fn expire_option(env: Env, option_id: u64) {
         options::exercise::expire_option(&env, option_id);
 
-        env.events().publish(
-            (symbol_short!("opt_exp"),),
-            option_id,
-        );
+        env.events().publish((symbol_short!("opt_exp"),), option_id);
     }
 
     /// Cancel an unsold option (writer only).
@@ -7224,10 +7615,8 @@ a
 
         options::exercise::cancel_option(&env, &writer, option_id);
 
-        env.events().publish(
-            (symbol_short!("opt_canc"),),
-            option_id,
-        );
+        env.events()
+            .publish((symbol_short!("opt_canc"),), option_id);
     }
 
     /// Get option contract details by ID.
@@ -7290,11 +7679,7 @@ a
     /// Update option pricing parameters (admin only).
     ///
     /// Emits `("opt_prm",)` with data `params`.
-    pub fn update_option_pricing(
-        env: Env,
-        admin: Address,
-        params: options::PricingParams,
-    ) {
+    pub fn update_option_pricing(env: Env, admin: Address, params: options::PricingParams) {
         admin.require_auth();
         let stored_admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
         if admin != stored_admin {
@@ -7303,10 +7688,7 @@ a
 
         options::update_pricing_params(&env, &params);
 
-        env.events().publish(
-            (symbol_short!("opt_prm"),),
-            params,
-        );
+        env.events().publish((symbol_short!("opt_prm"),), params);
     }
 
     /// Get current option pricing parameters.
@@ -7323,7 +7705,7 @@ a
         for i in 0..option_ids.len() {
             ids_vec.push_back(option_ids.get(i).unwrap());
         }
-        
+
         let mut expired_count = 0u32;
         for i in 0..ids_vec.len() {
             let option_id = ids_vec.get(i).unwrap();
@@ -7338,10 +7720,8 @@ a
             }
         }
 
-        env.events().publish(
-            (symbol_short!("opt_bexp"),),
-            expired_count,
-        );
+        env.events()
+            .publish((symbol_short!("opt_bexp"),), expired_count);
 
         expired_count
     }
@@ -7367,14 +7747,11 @@ a
             panic_with_error!(&env, TipJarError::InvalidIndexWeights);
         }
 
-        let fund_id = index_fund::composition::create_index_fund(
-            &env, &manager, &token, name, components,
-        );
+        let fund_id =
+            index_fund::composition::create_index_fund(&env, &manager, &token, name, components);
 
-        env.events().publish(
-            (symbol_short!("idx_new"),),
-            (manager, fund_id),
-        );
+        env.events()
+            .publish((symbol_short!("idx_new"),), (manager, fund_id));
 
         fund_id
     }
@@ -7398,10 +7775,8 @@ a
 
         index_fund::composition::update_composition(&env, fund_id, &caller, new_components);
 
-        env.events().publish(
-            (symbol_short!("idx_upd"),),
-            (caller, fund_id),
-        );
+        env.events()
+            .publish((symbol_short!("idx_upd"),), (caller, fund_id));
     }
 
     /// Rebalance a fund's creator allocations to match current target weights.
@@ -7411,20 +7786,13 @@ a
 
         index_fund::rebalance::rebalance(&env, fund_id, &caller);
 
-        env.events().publish(
-            (symbol_short!("idx_reb"),),
-            (caller, fund_id),
-        );
+        env.events()
+            .publish((symbol_short!("idx_reb"),), (caller, fund_id));
     }
 
     /// Deposit tokens into an index fund and receive shares.
     /// Returns the number of shares minted.
-    pub fn deposit_index_fund(
-        env: Env,
-        depositor: Address,
-        fund_id: u64,
-        amount: i128,
-    ) -> i128 {
+    pub fn deposit_index_fund(env: Env, depositor: Address, fund_id: u64, amount: i128) -> i128 {
         Self::require_not_paused(&env);
 
         if amount < index_fund::MIN_DEPOSIT {
@@ -7443,12 +7811,7 @@ a
 
     /// Withdraw from an index fund by redeeming shares.
     /// Returns the token amount returned to the holder.
-    pub fn withdraw_index_fund(
-        env: Env,
-        holder: Address,
-        fund_id: u64,
-        shares: i128,
-    ) -> i128 {
+    pub fn withdraw_index_fund(env: Env, holder: Address, fund_id: u64, shares: i128) -> i128 {
         Self::require_not_paused(&env);
 
         if shares <= 0 {
@@ -7476,10 +7839,7 @@ a
     }
 
     /// Get the current creator allocations for a fund.
-    pub fn get_index_fund_allocations(
-        env: Env,
-        fund_id: u64,
-    ) -> Vec<(Address, i128)> {
+    pub fn get_index_fund_allocations(env: Env, fund_id: u64) -> Vec<(Address, i128)> {
         index_fund::rebalance::get_allocations(&env, fund_id)
     }
 
@@ -7609,7 +7969,8 @@ a
 
         prediction_market::close_market(&env, &caller, market_id);
 
-        env.events().publish((symbol_short!("pm_close"),), market_id);
+        env.events()
+            .publish((symbol_short!("pm_close"),), market_id);
     }
 
     /// Resolve a prediction market with the winning outcome.
@@ -7637,10 +7998,8 @@ a
 
         prediction_market::resolve_market(&env, &resolver, market_id, winning_outcome);
 
-        env.events().publish(
-            (symbol_short!("pm_res"),),
-            (market_id, winning_outcome),
-        );
+        env.events()
+            .publish((symbol_short!("pm_res"),), (market_id, winning_outcome));
     }
 
     /// Cancel a prediction market and enable full refunds.
@@ -7661,7 +8020,8 @@ a
         let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
         prediction_market::cancel_market(&env, &caller, market_id, &admin);
 
-        env.events().publish((symbol_short!("pm_cancel"),), market_id);
+        env.events()
+            .publish((symbol_short!("pm_cancel"),), market_id);
     }
 
     /// Claim winnings (or a refund for a cancelled market).
@@ -7689,10 +8049,8 @@ a
 
         let payout = prediction_market::claim_winnings(&env, &bettor, market_id);
 
-        env.events().publish(
-            (symbol_short!("pm_claim"),),
-            (market_id, bettor, payout),
-        );
+        env.events()
+            .publish((symbol_short!("pm_claim"),), (market_id, bettor, payout));
 
         payout
     }
@@ -7777,7 +8135,10 @@ a
             liquidation_penalty_bps,
         };
         futures::save_config(&env, &cfg);
-        env.events().publish((symbol_short!("ft_cfg"),), (initial_margin_bps, maintenance_margin_bps));
+        env.events().publish(
+            (symbol_short!("ft_cfg"),),
+            (initial_margin_bps, maintenance_margin_bps),
+        );
     }
 
     /// Open a new futures contract (long side).
@@ -7819,7 +8180,14 @@ a
 
         env.events().publish(
             (symbol_short!("ft_open"),),
-            (contract_id, long_party, token, contract_price, size, settles_at),
+            (
+                contract_id,
+                long_party,
+                token,
+                contract_price,
+                size,
+                settles_at,
+            ),
         );
 
         contract_id
@@ -7845,22 +8213,15 @@ a
 
         futures::match_short(&env, &short_party, contract_id);
 
-        env.events().publish(
-            (symbol_short!("ft_match"),),
-            (contract_id, short_party),
-        );
+        env.events()
+            .publish((symbol_short!("ft_match"),), (contract_id, short_party));
     }
 
     /// Update the mark price for a futures contract (oracle / admin only).
     ///
     /// Recalculates unrealised P&L for both sides.
     /// Emits `("ft_mark",)`.
-    pub fn update_futures_mark_price(
-        env: Env,
-        admin: Address,
-        contract_id: u64,
-        new_price: i128,
-    ) {
+    pub fn update_futures_mark_price(env: Env, admin: Address, contract_id: u64, new_price: i128) {
         admin.require_auth();
         let stored_admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
         if admin != stored_admin {
@@ -7878,10 +8239,8 @@ a
 
         futures::update_mark_price(&env, contract_id, new_price);
 
-        env.events().publish(
-            (symbol_short!("ft_mark"),),
-            (contract_id, new_price),
-        );
+        env.events()
+            .publish((symbol_short!("ft_mark"),), (contract_id, new_price));
     }
 
     /// Add margin to a futures position to avoid liquidation.
@@ -7910,10 +8269,8 @@ a
 
         futures::add_margin(&env, &trader, contract_id, side, amount);
 
-        env.events().publish(
-            (symbol_short!("ft_margin"),),
-            (contract_id, trader, amount),
-        );
+        env.events()
+            .publish((symbol_short!("ft_margin"),), (contract_id, trader, amount));
     }
 
     /// Liquidate an under-margined futures position.
@@ -7968,7 +8325,8 @@ a
 
         futures::settlement::mark_pending(&env, contract_id);
 
-        env.events().publish((symbol_short!("ft_pend"),), contract_id);
+        env.events()
+            .publish((symbol_short!("ft_pend"),), contract_id);
     }
 
     /// Settle a futures contract at the given final price.
@@ -8040,16 +8398,14 @@ a
 
         futures::cancel_contract(&env, &caller, contract_id);
 
-        env.events().publish((symbol_short!("ft_cancel"),), contract_id);
+        env.events()
+            .publish((symbol_short!("ft_cancel"),), contract_id);
     }
 
     // ── futures queries ──────────────────────────────────────────────────────
 
     /// Get a futures contract by ID.
-    pub fn get_futures_contract(
-        env: Env,
-        contract_id: u64,
-    ) -> Option<futures::FuturesContract> {
+    pub fn get_futures_contract(env: Env, contract_id: u64) -> Option<futures::FuturesContract> {
         futures::get_contract(&env, contract_id)
     }
 
@@ -8171,11 +8527,7 @@ a
     ///
     /// Recomputes rolling mean, variance, and volatility in basis points.
     /// Stores a history snapshot. Emits `("tvi_upd",)`.
-    pub fn record_volatility_observation(
-        env: Env,
-        index_id: u64,
-        amount: i128,
-    ) {
+    pub fn record_volatility_observation(env: Env, index_id: u64, amount: i128) {
         if amount <= 0 {
             panic_with_error!(&env, TipJarError::InvalidAmount);
         }
@@ -8231,10 +8583,7 @@ a
     // ── volatility queries ───────────────────────────────────────────────────
 
     /// Get the current state of a volatility index.
-    pub fn get_volatility_index(
-        env: Env,
-        index_id: u64,
-    ) -> Option<volatility::VolatilityIndex> {
+    pub fn get_volatility_index(env: Env, index_id: u64) -> Option<volatility::VolatilityIndex> {
         volatility::get_index(&env, index_id)
     }
 
@@ -8272,10 +8621,7 @@ a
     }
 
     /// Get the current observations in the rolling window for an index.
-    pub fn get_volatility_window(
-        env: Env,
-        index_id: u64,
-    ) -> Vec<volatility::VolObservation> {
+    pub fn get_volatility_window(env: Env, index_id: u64) -> Vec<volatility::VolObservation> {
         let idx = volatility::get_index(&env, index_id)
             .unwrap_or_else(|| panic_with_error!(&env, TipJarError::VolIndexNotFound));
         volatility::collect_window(&env, &idx)
@@ -8315,22 +8661,37 @@ a
         Self::require_not_paused(&env);
         creator.require_auth();
 
-        if !env.storage().instance()
+        if !env
+            .storage()
+            .instance()
             .get::<DataKey, bool>(&DataKey::TokenWhitelist(token_a.clone()))
             .unwrap_or(false)
         {
             panic_with_error!(&env, TipJarError::TokenNotWhitelisted);
         }
-        if !env.storage().instance()
+        if !env
+            .storage()
+            .instance()
             .get::<DataKey, bool>(&DataKey::TokenWhitelist(token_b.clone()))
             .unwrap_or(false)
         {
             panic_with_error!(&env, TipJarError::TokenNotWhitelisted);
         }
 
-        let fee = if fee_bps == 0 { amm::DEFAULT_FEE_BPS } else { fee_bps };
-        let (pool_id, shares) =
-            amm::pool::create_pool(&env, &creator, &token_a, &token_b, amount_a, amount_b, Some(fee));
+        let fee = if fee_bps == 0 {
+            amm::DEFAULT_FEE_BPS
+        } else {
+            fee_bps
+        };
+        let (pool_id, shares) = amm::pool::create_pool(
+            &env,
+            &creator,
+            &token_a,
+            &token_b,
+            amount_a,
+            amount_b,
+            Some(fee),
+        );
 
         env.events().publish(
             (symbol_short!("amm_new"),),
@@ -8361,14 +8722,24 @@ a
             .unwrap_or_else(|| panic_with_error!(&env, TipJarError::AmmPoolNotFound));
 
         let result = amm::pool::add_liquidity(
-            &env, pool_id, &provider,
-            amount_a_desired, amount_b_desired,
-            amount_a_min, amount_b_min,
+            &env,
+            pool_id,
+            &provider,
+            amount_a_desired,
+            amount_b_desired,
+            amount_a_min,
+            amount_b_min,
         );
 
         env.events().publish(
             (symbol_short!("amm_add"),),
-            (pool_id, provider, result.amount_a, result.amount_b, result.shares_minted),
+            (
+                pool_id,
+                provider,
+                result.amount_a,
+                result.amount_b,
+                result.shares_minted,
+            ),
         );
 
         result
@@ -8390,12 +8761,23 @@ a
         provider.require_auth();
 
         let result = amm::pool::remove_liquidity(
-            &env, pool_id, &provider, shares, amount_a_min, amount_b_min,
+            &env,
+            pool_id,
+            &provider,
+            shares,
+            amount_a_min,
+            amount_b_min,
         );
 
         env.events().publish(
             (symbol_short!("amm_rem"),),
-            (pool_id, provider, result.amount_a, result.amount_b, result.rewards_claimed),
+            (
+                pool_id,
+                provider,
+                result.amount_a,
+                result.amount_b,
+                result.rewards_claimed,
+            ),
         );
 
         result
@@ -8426,7 +8808,14 @@ a
 
         env.events().publish(
             (symbol_short!("amm_swap"),),
-            (pool_id, sender, token_in, amount_in, result.amount_out, result.fee_amount),
+            (
+                pool_id,
+                sender,
+                token_in,
+                amount_in,
+                result.amount_out,
+                result.fee_amount,
+            ),
         );
 
         result
@@ -8445,10 +8834,8 @@ a
 
         let claimed = amm::pool::claim_rewards(&env, pool_id, &provider);
 
-        env.events().publish(
-            (symbol_short!("amm_clm"),),
-            (pool_id, provider, claimed),
-        );
+        env.events()
+            .publish((symbol_short!("amm_clm"),), (pool_id, provider, claimed));
 
         claimed
     }
@@ -8464,7 +8851,8 @@ a
             panic_with_error!(&env, TipJarError::AmmFeeTooHigh);
         }
         amm::pool::set_pool_fee(&env, pool_id, fee_bps);
-        env.events().publish((symbol_short!("amm_fee"),), (pool_id, fee_bps));
+        env.events()
+            .publish((symbol_short!("amm_fee"),), (pool_id, fee_bps));
     }
 
     // ── AMM: queries ─────────────────────────────────────────────────────────
@@ -8480,22 +8868,12 @@ a
     }
 
     /// Get the expected output for a swap (view, no state change).
-    pub fn amm_get_amount_out(
-        env: Env,
-        pool_id: u64,
-        token_in: Address,
-        amount_in: i128,
-    ) -> i128 {
+    pub fn amm_get_amount_out(env: Env, pool_id: u64, token_in: Address, amount_in: i128) -> i128 {
         amm::swap::get_amount_out(&env, pool_id, &token_in, amount_in)
     }
 
     /// Get the required input for a desired output (view, no state change).
-    pub fn amm_get_amount_in(
-        env: Env,
-        pool_id: u64,
-        token_in: Address,
-        amount_out: i128,
-    ) -> i128 {
+    pub fn amm_get_amount_in(env: Env, pool_id: u64, token_in: Address, amount_out: i128) -> i128 {
         amm::swap::get_amount_in(&env, pool_id, &token_in, amount_out)
     }
 
@@ -8665,11 +9043,7 @@ a
     }
 
     /// Get effective voting power for a voter on a proposal (includes conviction multiplier).
-    pub fn get_conviction_voting_power(
-        env: Env,
-        proposal_id: u64,
-        voter: Address,
-    ) -> i128 {
+    pub fn get_conviction_voting_power(env: Env, proposal_id: u64, voter: Address) -> i128 {
         governance::conviction_integration::get_effective_voting_power(&env, proposal_id, &voter)
     }
 
@@ -8693,10 +9067,7 @@ a
     }
 
     /// Update conviction voting configuration (admin only).
-    pub fn update_conviction_config(
-        env: Env,
-        config: governance::conviction::ConvictionConfig,
-    ) {
+    pub fn update_conviction_config(env: Env, config: governance::conviction::ConvictionConfig) {
         Self::require_admin(&env);
         governance::conviction::update_conviction_config(&env, &config);
     }
@@ -8755,7 +9126,13 @@ a
         }
 
         let channel = payment_channel::open(
-            &env, &party_a, &party_b, &token, deposit_a, deposit_b, dispute_window,
+            &env,
+            &party_a,
+            &party_b,
+            &token,
+            deposit_a,
+            deposit_b,
+            dispute_window,
         );
 
         // CEI: state before external calls
@@ -8820,12 +9197,7 @@ a
     ///
     /// Distributes funds according to the latest agreed state and marks the channel closed.
     /// Emits `("ch_coop",)` with data `(party_a, party_b, token, balance_a, balance_b)`.
-    pub fn cooperative_close(
-        env: Env,
-        party_a: Address,
-        party_b: Address,
-        token: Address,
-    ) {
+    pub fn cooperative_close(env: Env, party_a: Address, party_b: Address, token: Address) {
         Self::require_not_paused(&env);
         party_a.require_auth();
         party_b.require_auth();
@@ -9061,12 +9433,7 @@ a
     ///
     /// Distributes `tipped_amount` to creator and remainder to tipper.
     /// Emits `("tch_setl",)` with `(tipper, creator, token, to_creator, to_tipper)`.
-    pub fn settle_tip_channel(
-        env: Env,
-        tipper: Address,
-        creator: Address,
-        token: Address,
-    ) {
+    pub fn settle_tip_channel(env: Env, tipper: Address, creator: Address, token: Address) {
         Self::require_not_paused(&env);
         tipper.require_auth();
         creator.require_auth();
@@ -9169,10 +9536,8 @@ a
 
         meta_tx::register_relayer(&env, &relayer);
 
-        env.events().publish(
-            (symbol_short!("mtx_reg"),),
-            (relayer,),
-        );
+        env.events()
+            .publish((symbol_short!("mtx_reg"),), (relayer,));
     }
 
     /// Removes a trusted relayer. Admin only.
@@ -9191,10 +9556,8 @@ a
 
         meta_tx::remove_relayer(&env, &relayer);
 
-        env.events().publish(
-            (symbol_short!("mtx_rem"),),
-            (relayer,),
-        );
+        env.events()
+            .publish((symbol_short!("mtx_rem"),), (relayer,));
     }
 
     /// Executes a meta-transaction tip on behalf of a user.
@@ -9210,11 +9573,7 @@ a
     /// Returns the meta-tx record ID.
     ///
     /// Emits `("mtx_exec",)` with `(record_id, from, relayer, to, amount, nonce)`.
-    pub fn execute_meta_tip(
-        env: Env,
-        relayer: Address,
-        request: meta_tx::MetaTipRequest,
-    ) -> u64 {
+    pub fn execute_meta_tip(env: Env, relayer: Address, request: meta_tx::MetaTipRequest) -> u64 {
         Self::require_not_paused(&env);
         relayer.require_auth();
 
@@ -9263,7 +9622,12 @@ a
                 // Emit tip event
                 env.events().publish(
                     (symbol_short!("tip"),),
-                    (request.from.clone(), request.to.clone(), request.token.clone(), request.amount),
+                    (
+                        request.from.clone(),
+                        request.to.clone(),
+                        request.token.clone(),
+                        request.amount,
+                    ),
                 );
             }
             meta_tx::MetaTipAction::OpenChannel => {
@@ -9623,7 +9987,12 @@ a
         }
 
         let nullifier_key = DataKey::ZkNullifier(nullifier.clone());
-        if env.storage().persistent().get(&nullifier_key).unwrap_or(false) {
+        if env
+            .storage()
+            .persistent()
+            .get(&nullifier_key)
+            .unwrap_or(false)
+        {
             panic_with_error!(&env, ZkProofError::NullifierUsed);
         }
 
@@ -9782,13 +10151,25 @@ a
         if admin != stored_admin {
             panic_with_error!(&env, TipJarError::Unauthorized);
         }
-        env.storage().instance().set(&DataKey::RollupSequencer, &sequencer);
+        env.storage()
+            .instance()
+            .set(&DataKey::RollupSequencer, &sequencer);
         env.storage().instance().set(&DataKey::RollupEnabled, &true);
-        env.storage().instance().set(&DataKey::RollupChallengePeriod, &rollup::CHALLENGE_PERIOD);
-        env.storage().instance().set(&DataKey::RollupBatchCounter, &0u64);
-        env.storage().instance().set(&DataKey::RollupPendingCount, &0u64);
-        env.storage().instance().set(&DataKey::RollupFinalizedCount, &0u64);
-        env.storage().instance().set(&DataKey::RollupChallengedCount, &0u64);
+        env.storage()
+            .instance()
+            .set(&DataKey::RollupChallengePeriod, &rollup::CHALLENGE_PERIOD);
+        env.storage()
+            .instance()
+            .set(&DataKey::RollupBatchCounter, &0u64);
+        env.storage()
+            .instance()
+            .set(&DataKey::RollupPendingCount, &0u64);
+        env.storage()
+            .instance()
+            .set(&DataKey::RollupFinalizedCount, &0u64);
+        env.storage()
+            .instance()
+            .set(&DataKey::RollupChallengedCount, &0u64);
         env.events().publish((symbol_short!("rl_init"),), sequencer);
     }
 
@@ -9805,14 +10186,26 @@ a
         total_amount: i128,
         tip_count: u32,
     ) -> u64 {
-        let enabled: bool = env.storage().instance().get(&DataKey::RollupEnabled).unwrap_or(false);
+        let enabled: bool = env
+            .storage()
+            .instance()
+            .get(&DataKey::RollupEnabled)
+            .unwrap_or(false);
         if !enabled {
             panic_with_error!(&env, TipJarError::Unauthorized);
         }
         if total_amount <= 0 {
             panic_with_error!(&env, TipJarError::InvalidAmount);
         }
-        rollup::batch::submit_batch(&env, &sequencer, state_root, creator, token, total_amount, tip_count)
+        rollup::batch::submit_batch(
+            &env,
+            &sequencer,
+            state_root,
+            creator,
+            token,
+            total_amount,
+            tip_count,
+        )
     }
 
     /// Finalize a rollup batch after the challenge period. Permissionless.
@@ -9839,20 +10232,51 @@ a
 
     /// Returns a rollup batch by ID.
     pub fn get_rollup_batch(env: Env, batch_id: u64) -> Option<rollup::RollupBatch> {
-        env.storage().persistent().get(&DataKey::RollupBatch(batch_id))
+        env.storage()
+            .persistent()
+            .get(&DataKey::RollupBatch(batch_id))
     }
 
     /// Returns the current rollup state summary.
     pub fn get_rollup_state(env: Env) -> rollup::RollupState {
-        let enabled: bool = env.storage().instance().get(&DataKey::RollupEnabled).unwrap_or(false);
-        let sequencer: Address = env.storage().instance().get(&DataKey::RollupSequencer)
+        let enabled: bool = env
+            .storage()
+            .instance()
+            .get(&DataKey::RollupEnabled)
+            .unwrap_or(false);
+        let sequencer: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::RollupSequencer)
             .unwrap_or_else(|| panic_with_error!(&env, TipJarError::Unauthorized));
-        let challenge_period: u64 = env.storage().instance()
-            .get(&DataKey::RollupChallengePeriod).unwrap_or(rollup::CHALLENGE_PERIOD);
-        let pending_batches: u64 = env.storage().instance().get(&DataKey::RollupPendingCount).unwrap_or(0);
-        let finalized_batches: u64 = env.storage().instance().get(&DataKey::RollupFinalizedCount).unwrap_or(0);
-        let challenged_batches: u64 = env.storage().instance().get(&DataKey::RollupChallengedCount).unwrap_or(0);
-        rollup::RollupState { enabled, sequencer, challenge_period, pending_batches, finalized_batches, challenged_batches }
+        let challenge_period: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::RollupChallengePeriod)
+            .unwrap_or(rollup::CHALLENGE_PERIOD);
+        let pending_batches: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::RollupPendingCount)
+            .unwrap_or(0);
+        let finalized_batches: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::RollupFinalizedCount)
+            .unwrap_or(0);
+        let challenged_batches: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::RollupChallengedCount)
+            .unwrap_or(0);
+        rollup::RollupState {
+            enabled,
+            sequencer,
+            challenge_period,
+            pending_batches,
+            finalized_batches,
+            challenged_batches,
+        }
     }
 
     // ── fractional ownership ─────────────────────────────────────────────────
@@ -9864,7 +10288,12 @@ a
         total_supply: u64,
         buyout_price_per_fraction: i128,
     ) {
-        fractional_ownership::mint_fractions(&env, &creator, total_supply, buyout_price_per_fraction);
+        fractional_ownership::mint_fractions(
+            &env,
+            &creator,
+            total_supply,
+            buyout_price_per_fraction,
+        );
     }
 
     /// Record `amount` of revenue for `creator`'s fraction pool.
@@ -9878,13 +10307,7 @@ a
     }
 
     /// Transfer `amount` fractions from `from` to `to`.
-    pub fn transfer_fractions(
-        env: Env,
-        creator: Address,
-        from: Address,
-        to: Address,
-        amount: u64,
-    ) {
+    pub fn transfer_fractions(env: Env, creator: Address, from: Address, to: Address, amount: u64) {
         fractional_ownership::transfer_fractions(&env, &creator, &from, &to, amount);
     }
 
@@ -10030,12 +10453,7 @@ a
     ///
     /// The solver supplies the original `secret` and `nonce` used to generate
     /// the commitment. On success the tip is transferred to the recipient.
-    pub fn solve_time_lock_puzzle(
-        env: Env,
-        puzzle_id: u64,
-        secret: BytesN<32>,
-        nonce: BytesN<32>,
-    ) {
+    pub fn solve_time_lock_puzzle(env: Env, puzzle_id: u64, secret: BytesN<32>, nonce: BytesN<32>) {
         Self::require_not_paused(&env);
 
         let puzzle = time_lock_puzzle::get_puzzle(&env, puzzle_id)
@@ -10119,10 +10537,7 @@ a
     }
 
     /// Get the status of a time-lock puzzle.
-    pub fn get_puzzle_status(
-        env: Env,
-        puzzle_id: u64,
-    ) -> Option<time_lock_puzzle::PuzzleStatus> {
+    pub fn get_puzzle_status(env: Env, puzzle_id: u64) -> Option<time_lock_puzzle::PuzzleStatus> {
         time_lock_puzzle::solver::get_puzzle_status(&env, puzzle_id)
     }
 
@@ -10141,50 +10556,3 @@ a
         time_lock_puzzle::get_recipient_puzzles(&env, &recipient)
     }
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/contracts/tipjar/src/meta_tx/mod.rs
+++ b/contracts/tipjar/src/meta_tx/mod.rs
@@ -17,7 +17,7 @@
 //! A request is only valid when `request.nonce == stored_nonce`, after which
 //! the stored nonce is incremented.
 
-use soroban_sdk::{contracttype, symbol_short, Address, BytesN, Bytes, Env, String};
+use soroban_sdk::{contracttype, symbol_short, Address, Bytes, BytesN, Env, String};
 
 use crate::DataKey;
 
@@ -198,11 +198,7 @@ pub fn canonical_hash(env: &Env, req: &MetaTipRequest) -> BytesN<32> {
 ///   3. Nonce matches the stored per-sender nonce.
 ///   4. Nullifier (hash) has not been consumed.
 ///   5. Ed25519 signature is valid over the canonical hash.
-pub fn verify(
-    env: &Env,
-    relayer: &Address,
-    req: &MetaTipRequest,
-) -> BytesN<32> {
+pub fn verify(env: &Env, relayer: &Address, req: &MetaTipRequest) -> BytesN<32> {
     assert!(is_trusted_relayer(env, relayer), "Untrusted relayer");
 
     let now = env.ledger().timestamp();
@@ -229,12 +225,7 @@ pub fn verify(
 ///
 /// Must be called *after* the tip/channel action has been applied so that
 /// state changes follow the CEI pattern.
-pub fn finalize(
-    env: &Env,
-    relayer: &Address,
-    req: &MetaTipRequest,
-    hash: &BytesN<32>,
-) -> u64 {
+pub fn finalize(env: &Env, relayer: &Address, req: &MetaTipRequest, hash: &BytesN<32>) -> u64 {
     mark_consumed(env, hash);
     bump_nonce(env, &req.from);
 
@@ -257,7 +248,14 @@ pub fn finalize(
 
     env.events().publish(
         (symbol_short!("mtx_exec"),),
-        (id, req.from.clone(), relayer.clone(), req.to.clone(), req.amount, req.nonce),
+        (
+            id,
+            req.from.clone(),
+            relayer.clone(),
+            req.to.clone(),
+            req.amount,
+            req.nonce,
+        ),
     );
 
     id

--- a/contracts/tipjar/src/options/exercise.rs
+++ b/contracts/tipjar/src/options/exercise.rs
@@ -4,12 +4,12 @@
 
 use soroban_sdk::{token, Address, Env};
 
+use super::pricing::calculate_payoff;
 use super::{
     get_locked_collateral, get_option_or_panic, get_position, remove_active_option,
-    remove_held_option, update_locked_collateral, update_option, update_position, OptionStatus,
-    OptionType, OptionContract,
+    remove_held_option, update_locked_collateral, update_option, update_position, OptionContract,
+    OptionStatus, OptionType,
 };
-use super::pricing::calculate_payoff;
 
 /// Exercise an option contract
 ///
@@ -21,12 +21,7 @@ use super::pricing::calculate_payoff;
 ///
 /// # Returns
 /// Payoff amount transferred to holder
-pub fn exercise_option(
-    env: &Env,
-    holder: &Address,
-    option_id: u64,
-    spot_price: i128,
-) -> i128 {
+pub fn exercise_option(env: &Env, holder: &Address, option_id: u64, spot_price: i128) -> i128 {
     // Get and validate option
     let mut option = get_option_or_panic(env, option_id);
 
@@ -89,11 +84,11 @@ fn settle_option(env: &Env, option: &OptionContract, payoff: i128) {
         OptionType::Call => {
             // Call option: writer delivers tokens to holder
             // Holder pays strike price to writer
-            
+
             // Transfer tokens from contract (writer's collateral) to holder
             if let Some(ref holder) = option.holder {
                 token_client.transfer(&contract_addr, holder, &option.amount);
-                
+
                 // Holder pays strike price to writer
                 let strike_payment = (option.strike_price * option.amount) / 1_000_000;
                 token_client.transfer(holder, &option.writer, &strike_payment);
@@ -102,11 +97,11 @@ fn settle_option(env: &Env, option: &OptionContract, payoff: i128) {
         OptionType::Put => {
             // Put option: holder delivers tokens to writer
             // Writer pays strike price to holder
-            
+
             if let Some(ref holder) = option.holder {
                 // Holder delivers tokens to writer
                 token_client.transfer(holder, &option.writer, &option.amount);
-                
+
                 // Writer pays strike price from collateral
                 let strike_payment = (option.strike_price * option.amount) / 1_000_000;
                 token_client.transfer(&contract_addr, holder, &strike_payment);
@@ -115,7 +110,13 @@ fn settle_option(env: &Env, option: &OptionContract, payoff: i128) {
     }
 
     // Release remaining collateral to writer
-    release_collateral(env, &option.writer, &option.token, option.collateral, payoff);
+    release_collateral(
+        env,
+        &option.writer,
+        &option.token,
+        option.collateral,
+        payoff,
+    );
 }
 
 /// Release collateral back to writer after exercise
@@ -127,7 +128,7 @@ fn release_collateral(
     payoff: i128,
 ) {
     let remaining = collateral.saturating_sub(payoff);
-    
+
     if remaining > 0 {
         let token_client = token::Client::new(env, token);
         token_client.transfer(&env.current_contract_address(), writer, &remaining);
@@ -147,12 +148,7 @@ fn update_holder_position_on_exercise(env: &Env, holder: &Address, payoff: i128)
 }
 
 /// Update writer's position after exercise
-fn update_writer_position_on_exercise(
-    env: &Env,
-    writer: &Address,
-    payoff: i128,
-    collateral: i128,
-) {
+fn update_writer_position_on_exercise(env: &Env, writer: &Address, payoff: i128, collateral: i128) {
     let mut position = get_position(env, writer);
     position.total_collateral = position.total_collateral.saturating_sub(collateral);
     update_position(env, &position);
@@ -234,11 +230,7 @@ pub fn cancel_option(env: &Env, writer: &Address, option_id: u64) {
 
     // Return collateral to writer
     let token_client = token::Client::new(env, &option.token);
-    token_client.transfer(
-        &env.current_contract_address(),
-        writer,
-        &option.collateral,
-    );
+    token_client.transfer(&env.current_contract_address(), writer, &option.collateral);
 
     // Update writer's position
     let mut writer_position = get_position(env, writer);
@@ -263,19 +255,14 @@ mod tests {
         // Call option in the money
         let payoff = calculate_payoff(
             OptionType::Call,
-            1_200_000, // spot
-            1_000_000, // strike
+            1_200_000,  // spot
+            1_000_000,  // strike
             10_000_000, // amount
         );
         assert!(payoff > 0);
 
         // Put option in the money
-        let payoff = calculate_payoff(
-            OptionType::Put,
-            800_000,
-            1_000_000,
-            10_000_000,
-        );
+        let payoff = calculate_payoff(OptionType::Put, 800_000, 1_000_000, 10_000_000);
         assert!(payoff > 0);
     }
 }

--- a/contracts/tipjar/src/options/mod.rs
+++ b/contracts/tipjar/src/options/mod.rs
@@ -4,8 +4,8 @@
 //! allowing users to trade call and put options with automated pricing
 //! and exercise mechanisms.
 
-pub mod pricing;
 pub mod exercise;
+pub mod pricing;
 
 use soroban_sdk::{contracttype, Address, Env};
 
@@ -135,7 +135,7 @@ pub fn init_options(env: &Env) {
     env.storage()
         .persistent()
         .set(&DataKey::PricingParams, &params);
-    
+
     env.storage()
         .instance()
         .set(&DataKey::Option(OptionKey::OptionCounter), &0u64);
@@ -163,9 +163,7 @@ pub fn update_pricing_params(env: &Env, params: &PricingParams) {
 
 /// Get option contract by ID
 pub fn get_option(env: &Env, option_id: u64) -> Option<OptionContract> {
-    env.storage()
-        .persistent()
-        .get(&DataKey::Option(option_id))
+    env.storage().persistent().get(&DataKey::Option(option_id))
 }
 
 /// Get option contract or panic
@@ -203,11 +201,7 @@ pub fn update_position(env: &Env, position: &OptionPosition) {
 }
 
 /// Calculate required collateral for an option
-pub fn calculate_collateral(
-    option_type: OptionType,
-    strike_price: i128,
-    amount: i128,
-) -> i128 {
+pub fn calculate_collateral(option_type: OptionType, strike_price: i128, amount: i128) -> i128 {
     match option_type {
         OptionType::Call => {
             // For calls, collateral is the full amount of tokens
@@ -230,7 +224,7 @@ pub fn add_written_option(env: &Env, writer: &Address, option_id: u64) {
         .persistent()
         .get(&DataKey::WrittenOptions(writer.clone()))
         .unwrap_or_else(|| soroban_sdk::Vec::new(env));
-    
+
     if !options.contains(&option_id) {
         options.push_back(option_id);
         env.storage()
@@ -246,7 +240,7 @@ pub fn add_held_option(env: &Env, holder: &Address, option_id: u64) {
         .persistent()
         .get(&DataKey::HeldOptions(holder.clone()))
         .unwrap_or_else(|| soroban_sdk::Vec::new(env));
-    
+
     if !options.contains(&option_id) {
         options.push_back(option_id);
         env.storage()
@@ -262,7 +256,7 @@ pub fn remove_held_option(env: &Env, holder: &Address, option_id: u64) {
         .persistent()
         .get(&DataKey::HeldOptions(holder.clone()))
         .unwrap_or_else(|| soroban_sdk::Vec::new(env));
-    
+
     if let Some(index) = options.iter().position(|&id| id == option_id) {
         options.remove(index as u32);
         env.storage()
@@ -278,7 +272,7 @@ pub fn add_active_option(env: &Env, option_id: u64) {
         .persistent()
         .get(&DataKey::ActiveOptions)
         .unwrap_or_else(|| soroban_sdk::Vec::new(env));
-    
+
     if !options.contains(&option_id) {
         options.push_back(option_id);
         env.storage()
@@ -294,7 +288,7 @@ pub fn remove_active_option(env: &Env, option_id: u64) {
         .persistent()
         .get(&DataKey::ActiveOptions)
         .unwrap_or_else(|| soroban_sdk::Vec::new(env));
-    
+
     if let Some(index) = options.iter().position(|&id| id == option_id) {
         options.remove(index as u32);
         env.storage()
@@ -313,8 +307,8 @@ pub fn get_locked_collateral(env: &Env, address: &Address, token: &Address) -> i
 
 /// Update locked collateral
 pub fn update_locked_collateral(env: &Env, address: &Address, token: &Address, amount: i128) {
-    env.storage()
-        .persistent()
-        .set(&DataKey::Collateral(address.clone(), token.clone()), &amount);
+    env.storage().persistent().set(
+        &DataKey::Collateral(address.clone(), token.clone()),
+        &amount,
+    );
 }
-

--- a/contracts/tipjar/src/options/pricing.rs
+++ b/contracts/tipjar/src/options/pricing.rs
@@ -51,9 +51,7 @@ pub fn calculate_premium(
     );
 
     // Total premium is intrinsic + time value
-    let total_premium = intrinsic_value
-        .checked_add(time_value)
-        .unwrap_or(i128::MAX);
+    let total_premium = intrinsic_value.checked_add(time_value).unwrap_or(i128::MAX);
 
     // Apply min/max bounds
     let min_premium = (strike_price * amount * params.min_premium_bps as i128) / 10_000_000_000;
@@ -90,10 +88,7 @@ fn calculate_intrinsic_value(
         }
     };
 
-    value_per_unit
-        .checked_mul(amount)
-        .unwrap_or(i128::MAX)
-        / 1_000_000 // Normalize for precision
+    value_per_unit.checked_mul(amount).unwrap_or(i128::MAX) / 1_000_000 // Normalize for precision
 }
 
 /// Calculate time value of an option
@@ -139,11 +134,8 @@ fn calculate_time_value(
     // Base time value calculation
     // time_value = spot * amount * volatility * sqrt(time) * atm_adjustment
     // Simplified: time_value = spot * amount * volatility * time_factor * atm_adjustment / 100_000_000
-    
-    let base_value = spot_price
-        .checked_mul(amount)
-        .unwrap_or(i128::MAX)
-        / 1_000_000; // Normalize
+
+    let base_value = spot_price.checked_mul(amount).unwrap_or(i128::MAX) / 1_000_000; // Normalize
 
     let volatility_adjusted = base_value
         .checked_mul(params.volatility_bps as i128)
@@ -186,10 +178,7 @@ pub fn calculate_payoff(
 ///
 /// This is a simplified estimation that could be enhanced with
 /// more sophisticated algorithms in the future.
-pub fn estimate_volatility(
-    recent_prices: &[i128],
-    window_seconds: u64,
-) -> u32 {
+pub fn estimate_volatility(recent_prices: &[i128], window_seconds: u64) -> u32 {
     if recent_prices.len() < 2 {
         return DEFAULT_VOLATILITY_BPS;
     }
@@ -201,7 +190,7 @@ pub fn estimate_volatility(
     for i in 1..recent_prices.len() {
         let prev = recent_prices[i - 1];
         let curr = recent_prices[i];
-        
+
         if prev > 0 {
             // Calculate return as (curr - prev) / prev
             let return_val = ((curr - prev) * 10_000) / prev;
@@ -217,7 +206,7 @@ pub fn estimate_volatility(
 
     // Variance = average of squared returns
     let variance = sum_squared_returns / count;
-    
+
     // Annualize the variance
     let periods_per_year = 31_557_600 / window_seconds.max(1);
     let annualized_variance = variance.saturating_mul(periods_per_year as i128);
@@ -270,40 +259,25 @@ mod tests {
         // Call option: spot > strike
         let value = calculate_intrinsic_value(
             OptionType::Call,
-            1_200_000, // spot
-            1_000_000, // strike
+            1_200_000,  // spot
+            1_000_000,  // strike
             10_000_000, // amount
         );
         assert!(value > 0);
 
         // Call option: spot < strike (out of money)
-        let value = calculate_intrinsic_value(
-            OptionType::Call,
-            800_000,
-            1_000_000,
-            10_000_000,
-        );
+        let value = calculate_intrinsic_value(OptionType::Call, 800_000, 1_000_000, 10_000_000);
         assert_eq!(value, 0);
     }
 
     #[test]
     fn test_intrinsic_value_put() {
         // Put option: strike > spot
-        let value = calculate_intrinsic_value(
-            OptionType::Put,
-            800_000,
-            1_000_000,
-            10_000_000,
-        );
+        let value = calculate_intrinsic_value(OptionType::Put, 800_000, 1_000_000, 10_000_000);
         assert!(value > 0);
 
         // Put option: strike < spot (out of money)
-        let value = calculate_intrinsic_value(
-            OptionType::Put,
-            1_200_000,
-            1_000_000,
-            10_000_000,
-        );
+        let value = calculate_intrinsic_value(OptionType::Put, 1_200_000, 1_000_000, 10_000_000);
         assert_eq!(value, 0);
     }
 
@@ -311,7 +285,7 @@ mod tests {
     fn test_approximate_sqrt() {
         assert_eq!(approximate_sqrt(0), 0);
         assert_eq!(approximate_sqrt(1), 10_000);
-        
+
         let sqrt_4 = approximate_sqrt(4);
         assert!(sqrt_4 >= 1 && sqrt_4 <= 3);
     }

--- a/contracts/tipjar/src/poly_commit/batch.rs
+++ b/contracts/tipjar/src/poly_commit/batch.rs
@@ -42,18 +42,18 @@ pub fn batch_open(
         proofs_out.push_back(individual[i].clone());
     }
 
-    BatchProof { proofs: proofs_out, gamma, agg_eval }
+    BatchProof {
+        proofs: proofs_out,
+        gamma,
+        agg_eval,
+    }
 }
 
 /// Verifies a BatchProof against a list of (polynomial, commitment) pairs.
 ///
 /// Returns true iff every individual proof is valid AND the aggregated
 /// evaluation matches the claimed agg_eval.
-pub fn batch_verify(
-    env: &Env,
-    polys: &[(Polynomial, PolyCommitment)],
-    batch: &BatchProof,
-) -> bool {
+pub fn batch_verify(env: &Env, polys: &[(Polynomial, PolyCommitment)], batch: &BatchProof) -> bool {
     let n = polys.len().min(batch.proofs.len() as usize);
     let mut agg_eval = 0u64;
     let mut gamma_pow = 1u64;

--- a/contracts/tipjar/src/poly_commit/commitment.rs
+++ b/contracts/tipjar/src/poly_commit/commitment.rs
@@ -18,13 +18,21 @@ pub fn open(poly: &Polynomial, z: u64) -> OpeningProof {
     for i in 0..len.min(64) {
         buf[i] = poly.coeffs.get(i as u32).unwrap_or(0);
     }
-    OpeningProof { z, y: poly_eval(&buf[..len.min(64)], z) }
+    OpeningProof {
+        z,
+        y: poly_eval(&buf[..len.min(64)], z),
+    }
 }
 
 /// Verifies an opening proof against a commitment.
 ///
 /// Re-hashes the polynomial to check the commitment, then re-evaluates at z.
-pub fn verify(env: &Env, commitment: &PolyCommitment, poly: &Polynomial, proof: &OpeningProof) -> bool {
+pub fn verify(
+    env: &Env,
+    commitment: &PolyCommitment,
+    poly: &Polynomial,
+    proof: &OpeningProof,
+) -> bool {
     commit(env, poly).digest == commitment.digest && {
         let len = poly.coeffs.len() as usize;
         let mut buf = [0u64; 64];

--- a/contracts/tipjar/src/poly_commit/mod.rs
+++ b/contracts/tipjar/src/poly_commit/mod.rs
@@ -1,10 +1,10 @@
+pub mod batch;
 /// Polynomial commitment scheme for tip data verification.
 ///
 /// Uses a hash-based univariate polynomial commitment over F_p where
 /// p = 2^61 - 1 (Mersenne prime). Commitment = SHA256(coefficients).
 /// Opening proof = polynomial evaluation at a challenge point.
 pub mod commitment;
-pub mod batch;
 
 use soroban_sdk::{contracttype, BytesN, Vec};
 
@@ -58,20 +58,32 @@ pub fn fp_reduce(x: u128) -> u64 {
     let lo = (x & (FIELD_PRIME as u128)) as u64;
     let hi = (x >> 61) as u64;
     let sum = lo + hi;
-    if sum >= FIELD_PRIME { sum - FIELD_PRIME } else { sum }
+    if sum >= FIELD_PRIME {
+        sum - FIELD_PRIME
+    } else {
+        sum
+    }
 }
 
 /// Addition in F_p.
 #[inline]
 pub fn fp_add(a: u64, b: u64) -> u64 {
     let s = a + b;
-    if s >= FIELD_PRIME { s - FIELD_PRIME } else { s }
+    if s >= FIELD_PRIME {
+        s - FIELD_PRIME
+    } else {
+        s
+    }
 }
 
 /// Subtraction in F_p.
 #[inline]
 pub fn fp_sub(a: u64, b: u64) -> u64 {
-    if a >= b { a - b } else { a + FIELD_PRIME - b }
+    if a >= b {
+        a - b
+    } else {
+        a + FIELD_PRIME - b
+    }
 }
 
 /// Multiplication in F_p.

--- a/contracts/tipjar/src/prediction_market/mod.rs
+++ b/contracts/tipjar/src/prediction_market/mod.rs
@@ -268,13 +268,7 @@ pub fn create_market(
 }
 
 /// Place a bet on a market outcome. Transfers tokens from bettor to contract.
-pub fn place_bet(
-    env: &Env,
-    bettor: &Address,
-    market_id: u64,
-    outcome: Outcome,
-    amount: i128,
-) {
+pub fn place_bet(env: &Env, bettor: &Address, market_id: u64, outcome: Outcome, amount: i128) {
     let mut market = get_market(env, market_id).expect("market not found");
 
     let now = env.ledger().timestamp();

--- a/contracts/tipjar/src/prediction_market/settlement.rs
+++ b/contracts/tipjar/src/prediction_market/settlement.rs
@@ -8,11 +8,7 @@ use super::{BettorPosition, Outcome, PredictionMarket, BPS_DENOM};
 ///
 /// Payout = (bettor's winning-side stake / total winning-side pool) × total pool × (1 - fee).
 /// Returns 0 if the bettor had no stake on the winning side.
-pub fn calculate_payout(
-    _env: &Env,
-    market: &PredictionMarket,
-    position: &BettorPosition,
-) -> i128 {
+pub fn calculate_payout(_env: &Env, market: &PredictionMarket, position: &BettorPosition) -> i128 {
     let winning = match market.winning_outcome {
         Some(o) => o,
         None => return 0,

--- a/contracts/tipjar/src/privacy/commitment.rs
+++ b/contracts/tipjar/src/privacy/commitment.rs
@@ -18,6 +18,10 @@ pub fn compute_commitment(
 
 /// Returns true if the opening's preimage matches the stored commitment.
 pub fn verify_opening(env: &Env, commitment: &BytesN<32>, opening: &CommitmentOpening) -> bool {
-    compute_commitment(env, &opening.creator, opening.amount, &opening.blinding_factor)
-        == *commitment
+    compute_commitment(
+        env,
+        &opening.creator,
+        opening.amount,
+        &opening.blinding_factor,
+    ) == *commitment
 }

--- a/contracts/tipjar/src/privacy/contract_interface.rs
+++ b/contracts/tipjar/src/privacy/contract_interface.rs
@@ -9,18 +9,16 @@
 
 use soroban_sdk::{contract, contractimpl, Address, BytesN, Env, Symbol, Vec};
 
-use crate::DataKey;
-use super::homomorphic::{
-    EncryptedAmount, HomomorphicPublicKey, RangeProof,
+use super::encrypted_operations::{
+    aggregate_encrypted_tips, compute_encrypted_fee, create_encrypted_tip, get_encrypted_balance,
+    reveal_encrypted_tip,
 };
+use super::homomorphic::{EncryptedAmount, HomomorphicPublicKey, RangeProof};
 use super::key_management::{
-    initialize_homomorphic, rotate_key, get_current_public_key, is_homomorphic_enabled,
+    get_current_public_key, initialize_homomorphic, is_homomorphic_enabled, rotate_key,
     KeyManagementConfig,
 };
-use super::encrypted_operations::{
-    create_encrypted_tip, get_encrypted_balance, reveal_encrypted_tip,
-    aggregate_encrypted_tips, compute_encrypted_fee,
-};
+use crate::DataKey;
 
 /// Initialize homomorphic encryption for the contract.
 ///
@@ -57,8 +55,7 @@ pub fn init_homomorphic(
         rotation_requires_approval: true,
     };
 
-    initialize_homomorphic(&env, &admin, public_key, config)
-        .map_err(|e| Symbol::new(&env, e))
+    initialize_homomorphic(&env, &admin, public_key, config).map_err(|e| Symbol::new(&env, e))
 }
 
 /// Create an encrypted tip.
@@ -132,8 +129,7 @@ pub fn reveal_encrypted_tip_amount(
     decrypted_amount: i128,
     creator: Address,
 ) -> Result<(), Symbol> {
-    reveal_encrypted_tip(&env, tip_id, decrypted_amount, &creator)
-        .map_err(|e| Symbol::new(&env, e))
+    reveal_encrypted_tip(&env, tip_id, decrypted_amount, &creator).map_err(|e| Symbol::new(&env, e))
 }
 
 /// Rotate to a new encryption key.
@@ -162,8 +158,7 @@ pub fn rotate_encryption_key(
         version: new_version,
     };
 
-    rotate_key(&env, &admin, new_key, reason)
-        .map_err(|e| Symbol::new(&env, e))
+    rotate_key(&env, &admin, new_key, reason).map_err(|e| Symbol::new(&env, e))
 }
 
 /// Get current public key.
@@ -174,8 +169,7 @@ pub fn rotate_encryption_key(
 /// # Returns
 /// Current public key
 pub fn get_public_key(env: Env) -> Result<HomomorphicPublicKey, Symbol> {
-    get_current_public_key(&env)
-        .map_err(|e| Symbol::new(&env, e))
+    get_current_public_key(&env).map_err(|e| Symbol::new(&env, e))
 }
 
 /// Check if homomorphic encryption is enabled.
@@ -201,8 +195,7 @@ pub fn aggregate_tips_encrypted(
     env: Env,
     encrypted_tips: Vec<EncryptedAmount>,
 ) -> Result<EncryptedAmount, Symbol> {
-    aggregate_encrypted_tips(&env, &encrypted_tips)
-        .map_err(|e| Symbol::new(&env, e))
+    aggregate_encrypted_tips(&env, &encrypted_tips).map_err(|e| Symbol::new(&env, e))
 }
 
 /// Compute encrypted fee on encrypted amount.
@@ -219,6 +212,5 @@ pub fn compute_fee_encrypted(
     encrypted_amount: EncryptedAmount,
     fee_basis_points: u32,
 ) -> Result<EncryptedAmount, Symbol> {
-    compute_encrypted_fee(&encrypted_amount, fee_basis_points)
-        .map_err(|e| Symbol::new(&env, e))
+    compute_encrypted_fee(&encrypted_amount, fee_basis_points).map_err(|e| Symbol::new(&env, e))
 }

--- a/contracts/tipjar/src/privacy/encrypted_operations.rs
+++ b/contracts/tipjar/src/privacy/encrypted_operations.rs
@@ -8,12 +8,12 @@
 
 use soroban_sdk::{token, Address, BytesN, Env, Vec};
 
-use crate::DataKey;
 use super::homomorphic::{
     aggregate_encrypted_amounts, encrypt_amount, scalar_multiply_encrypted, verify_range_proof,
     EncryptedAmount, EncryptedBalance, RangeProof,
 };
 use super::key_management::{get_current_public_key, is_homomorphic_enabled};
+use crate::DataKey;
 
 /// Create an encrypted tip.
 ///

--- a/contracts/tipjar/src/privacy/homomorphic.rs
+++ b/contracts/tipjar/src/privacy/homomorphic.rs
@@ -217,7 +217,9 @@ pub fn verify_range_proof(
     // Fiat-Shamir verification: recompute challenge
     let mut challenge_data = soroban_sdk::Bytes::new(env);
     challenge_data.append(&soroban_sdk::Bytes::from(encrypted.ciphertext.clone()));
-    challenge_data.append(&soroban_sdk::Bytes::from(encrypted.randomness_commitment.clone()));
+    challenge_data.append(&soroban_sdk::Bytes::from(
+        encrypted.randomness_commitment.clone(),
+    ));
 
     let recomputed_challenge = env.crypto().sha256(&challenge_data);
 
@@ -250,7 +252,9 @@ pub fn verify_decryption_proof(
 ) -> Result<(), &'static str> {
     // Verify value commitment matches decrypted value
     let mut commitment_data = soroban_sdk::Bytes::new(env);
-    commitment_data.append(&soroban_sdk::Bytes::from(decrypted_value.to_le_bytes().to_vec()));
+    commitment_data.append(&soroban_sdk::Bytes::from(
+        decrypted_value.to_le_bytes().to_vec(),
+    ));
 
     let recomputed_commitment = env.crypto().sha256(&commitment_data);
 

--- a/contracts/tipjar/src/privacy/key_management.rs
+++ b/contracts/tipjar/src/privacy/key_management.rs
@@ -9,8 +9,8 @@
 
 use soroban_sdk::{contracttype, Address, BytesN, Env, Symbol};
 
-use crate::DataKey;
 use super::homomorphic::{HomomorphicConfig, HomomorphicPublicKey};
+use crate::DataKey;
 
 /// Key management configuration.
 #[contracttype]
@@ -88,9 +88,7 @@ pub fn initialize_homomorphic(
     // Initialize key history
     let mut history: Vec<HomomorphicPublicKey> = Vec::new(env);
     history.push_back(public_key);
-    env.storage()
-        .instance()
-        .set(&DataKey::KeyHistory, &history);
+    env.storage().instance().set(&DataKey::KeyHistory, &history);
 
     // Emit initialization event
     env.events().publish(
@@ -148,9 +146,7 @@ pub fn rotate_key(
         history.pop_front();
     }
 
-    env.storage()
-        .instance()
-        .set(&DataKey::KeyHistory, &history);
+    env.storage().instance().set(&DataKey::KeyHistory, &history);
 
     // Record rotation event
     let event = KeyRotationEvent {
@@ -234,10 +230,8 @@ pub fn enable_homomorphic(env: &Env, admin: &Address) -> Result<(), &'static str
         .instance()
         .set(&DataKey::HomomorphicConfig, &config);
 
-    env.events().publish(
-        (Symbol::new(env, "homomorphic_enabled"),),
-        (admin.clone(),),
-    );
+    env.events()
+        .publish((Symbol::new(env, "homomorphic_enabled"),), (admin.clone(),));
 
     Ok(())
 }

--- a/contracts/tipjar/src/privacy/mod.rs
+++ b/contracts/tipjar/src/privacy/mod.rs
@@ -1,9 +1,9 @@
 pub mod commitment;
-pub mod zk_proof;
+pub mod contract_interface;
+pub mod encrypted_operations;
 pub mod homomorphic;
 pub mod key_management;
-pub mod encrypted_operations;
-pub mod contract_interface;
+pub mod zk_proof;
 
 use soroban_sdk::{contracttype, Address, BytesN};
 

--- a/contracts/tipjar/src/privacy_tip.rs
+++ b/contracts/tipjar/src/privacy_tip.rs
@@ -1,4 +1,4 @@
-use soroban_sdk::{Address, BytesN, Env, contracttype};
+use soroban_sdk::{contracttype, Address, BytesN, Env};
 
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/contracts/tipjar/src/quadratic_funding.rs
+++ b/contracts/tipjar/src/quadratic_funding.rs
@@ -117,11 +117,7 @@ pub fn create_round(
         panic_with_error!(env, QFError::InvalidAmount);
     }
 
-    let round_id: u64 = env
-        .storage()
-        .instance()
-        .get(&QFKey::RoundCtr)
-        .unwrap_or(0);
+    let round_id: u64 = env.storage().instance().get(&QFKey::RoundCtr).unwrap_or(0);
     env.storage()
         .instance()
         .set(&QFKey::RoundCtr, &(round_id + 1));
@@ -226,7 +222,9 @@ pub fn contribute(
 
     // Update round totals.
     round.total_contributions = round.total_contributions.saturating_add(amount);
-    env.storage().persistent().set(&QFKey::Round(round_id), &round);
+    env.storage()
+        .persistent()
+        .set(&QFKey::Round(round_id), &round);
 
     // Transfer contribution into contract escrow.
     token::Client::new(env, &round.token).transfer(
@@ -260,7 +258,9 @@ pub fn finalize_round(env: &Env, admin: &Address, round_id: u64) {
     }
 
     round.status = RoundStatus::Finalized;
-    env.storage().persistent().set(&QFKey::Round(round_id), &round);
+    env.storage()
+        .persistent()
+        .set(&QFKey::Round(round_id), &round);
 
     env.events()
         .publish((symbol_short!("qf_fin"),), (round_id,));
@@ -357,7 +357,9 @@ pub fn distribute_matching(env: &Env, admin: &Address, round_id: u64) {
     }
 
     round.status = RoundStatus::Distributed;
-    env.storage().persistent().set(&QFKey::Round(round_id), &round);
+    env.storage()
+        .persistent()
+        .set(&QFKey::Round(round_id), &round);
 
     env.events()
         .publish((symbol_short!("qf_done"),), (round_id, distributed));
@@ -375,9 +377,11 @@ pub fn get_contribution(
     project: &Address,
     contributor: &Address,
 ) -> Option<Contribution> {
-    env.storage()
-        .persistent()
-        .get(&QFKey::Contribution(round_id, project.clone(), contributor.clone()))
+    env.storage().persistent().get(&QFKey::Contribution(
+        round_id,
+        project.clone(),
+        contributor.clone(),
+    ))
 }
 
 /// Returns the quadratic match estimate for a project in an active round.

--- a/contracts/tipjar/src/rollup/batch.rs
+++ b/contracts/tipjar/src/rollup/batch.rs
@@ -135,6 +135,10 @@ pub fn finalize_batch(env: &Env, batch_id: u64) {
 
     env.events().publish(
         (symbol_short!("rl_fin"), batch_id),
-        (batch.creator.clone(), batch.token.clone(), batch.total_amount),
+        (
+            batch.creator.clone(),
+            batch.token.clone(),
+            batch.total_amount,
+        ),
     );
 }

--- a/contracts/tipjar/src/royalty/mod.rs
+++ b/contracts/tipjar/src/royalty/mod.rs
@@ -84,10 +84,7 @@ fn append_history(env: &Env, split_id: &Address, entry: &SplitHistoryEntry) {
 
 fn validate_recipients(recipients: &Vec<SplitRecipient>) {
     assert!(!recipients.is_empty(), "no recipients");
-    assert!(
-        recipients.len() <= MAX_RECIPIENTS,
-        "too many recipients"
-    );
+    assert!(recipients.len() <= MAX_RECIPIENTS, "too many recipients");
     let total: u32 = (0..recipients.len())
         .map(|i| recipients.get(i).unwrap().share_bps)
         .sum();
@@ -102,16 +99,35 @@ fn validate_recipients(recipients: &Vec<SplitRecipient>) {
 pub fn set_split(env: &Env, split_id: &Address, owner: &Address, recipients: Vec<SplitRecipient>) {
     owner.require_auth();
     validate_recipients(&recipients);
-    save_config(env, split_id, &SplitConfig { owner: owner.clone(), recipients });
+    save_config(
+        env,
+        split_id,
+        &SplitConfig {
+            owner: owner.clone(),
+            recipients,
+        },
+    );
 }
 
 /// Modify an existing split configuration. Only the original owner may do this.
-pub fn modify_split(env: &Env, split_id: &Address, owner: &Address, recipients: Vec<SplitRecipient>) {
+pub fn modify_split(
+    env: &Env,
+    split_id: &Address,
+    owner: &Address,
+    recipients: Vec<SplitRecipient>,
+) {
     owner.require_auth();
     let cfg = load_config(env, split_id).expect("split not found");
     assert!(cfg.owner == *owner, "not split owner");
     validate_recipients(&recipients);
-    save_config(env, split_id, &SplitConfig { owner: owner.clone(), recipients });
+    save_config(
+        env,
+        split_id,
+        &SplitConfig {
+            owner: owner.clone(),
+            recipients,
+        },
+    );
 }
 
 /// Distribute `amount` according to the split config for `split_id`.
@@ -168,10 +184,8 @@ fn distribute_inner(env: &Env, split_id: &Address, amount: i128, depth: u32) -> 
                 timestamp: env.ledger().timestamp(),
             },
         );
-        env.events().publish(
-            (symbol_short!("split_dst"), split_id.clone()),
-            distributed,
-        );
+        env.events()
+            .publish((symbol_short!("split_dst"), split_id.clone()), distributed);
     }
 
     distributed
@@ -226,35 +240,78 @@ pub const MAX_DEPTH: u32 = 5;
 pub const MAX_ROYALTY_BPS: u32 = 3_000;
 
 /// Register a royalty configuration for a creator's content (legacy).
-pub fn register_royalty(env: &Env, creator: &Address, original_creator: &Address, rate_bps: u32, max_depth: u32) {
-    let depth = if max_depth == 0 { MAX_DEPTH } else { max_depth.min(MAX_DEPTH) };
-    let config = RoyaltyConfig { original_creator: original_creator.clone(), rate_bps, max_depth: depth };
-    env.storage().persistent().set(&DataKey::RoyaltyConfig(creator.clone()), &config);
+pub fn register_royalty(
+    env: &Env,
+    creator: &Address,
+    original_creator: &Address,
+    rate_bps: u32,
+    max_depth: u32,
+) {
+    let depth = if max_depth == 0 {
+        MAX_DEPTH
+    } else {
+        max_depth.min(MAX_DEPTH)
+    };
+    let config = RoyaltyConfig {
+        original_creator: original_creator.clone(),
+        rate_bps,
+        max_depth: depth,
+    };
+    env.storage()
+        .persistent()
+        .set(&DataKey::RoyaltyConfig(creator.clone()), &config);
     let lineage = ContentLineage {
         creator: creator.clone(),
         parent_creator: original_creator.clone(),
         royalty_config: config,
     };
-    env.storage().persistent().set(&DataKey::ContentLineage(creator.clone()), &lineage);
+    env.storage()
+        .persistent()
+        .set(&DataKey::ContentLineage(creator.clone()), &lineage);
 }
 
 /// Distribute royalties along the lineage chain (legacy).
-pub fn distribute_royalties(env: &Env, creator: &Address, token_addr: &Address, tip_amount: i128) -> i128 {
+pub fn distribute_royalties(
+    env: &Env,
+    creator: &Address,
+    token_addr: &Address,
+    tip_amount: i128,
+) -> i128 {
     let mut remaining = tip_amount;
     let mut current = creator.clone();
     let mut depth = 0u32;
     loop {
-        let lineage: Option<ContentLineage> = env.storage().persistent().get(&DataKey::ContentLineage(current.clone()));
-        let lineage = match lineage { Some(l) => l, None => break };
-        if depth >= lineage.royalty_config.max_depth { break; }
+        let lineage: Option<ContentLineage> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::ContentLineage(current.clone()));
+        let lineage = match lineage {
+            Some(l) => l,
+            None => break,
+        };
+        if depth >= lineage.royalty_config.max_depth {
+            break;
+        }
         let royalty = (remaining * lineage.royalty_config.rate_bps as i128) / 10_000;
-        if royalty <= 0 { break; }
-        let bal_key = DataKey::RoyaltyBalance(lineage.royalty_config.original_creator.clone(), token_addr.clone());
+        if royalty <= 0 {
+            break;
+        }
+        let bal_key = DataKey::RoyaltyBalance(
+            lineage.royalty_config.original_creator.clone(),
+            token_addr.clone(),
+        );
         let current_bal: i128 = env.storage().persistent().get(&bal_key).unwrap_or(0);
-        env.storage().persistent().set(&bal_key, &(current_bal + royalty));
+        env.storage()
+            .persistent()
+            .set(&bal_key, &(current_bal + royalty));
         env.events().publish(
             (symbol_short!("royalty"),),
-            (lineage.royalty_config.original_creator.clone(), creator.clone(), royalty, depth),
+            (
+                lineage.royalty_config.original_creator.clone(),
+                creator.clone(),
+                royalty,
+                depth,
+            ),
         );
         remaining -= royalty;
         current = lineage.royalty_config.original_creator.clone();

--- a/contracts/tipjar/src/sidechain/state.rs
+++ b/contracts/tipjar/src/sidechain/state.rs
@@ -45,7 +45,10 @@ pub fn get_state(env: &Env) -> SidechainState {
 pub fn get_finalized_total(env: &Env, creator: &Address, token: &Address) -> i128 {
     env.storage()
         .persistent()
-        .get(&DataKey::SidechainFinalizedTotal(creator.clone(), token.clone()))
+        .get(&DataKey::SidechainFinalizedTotal(
+            creator.clone(),
+            token.clone(),
+        ))
         .unwrap_or(0)
 }
 

--- a/contracts/tipjar/src/staking/mod.rs
+++ b/contracts/tipjar/src/staking/mod.rs
@@ -2,8 +2,8 @@
 //!
 //! This module provides staking functionality with time-weighted rewards.
 
-pub mod rewards;
 pub mod distribution;
+pub mod rewards;
 
 use soroban_sdk::{contracttype, token, Address, Env};
 
@@ -23,10 +23,10 @@ pub struct StakeInfo {
 pub struct StakingConfig {
     pub reward_pool: i128,
     pub total_staked: i128,
-    pub reward_rate_bps: u32, // Reward rate in basis points per year
-    pub unstake_cooldown: u64, // Cooldown period in seconds
+    pub reward_rate_bps: u32,      // Reward rate in basis points per year
+    pub unstake_cooldown: u64,     // Cooldown period in seconds
     pub max_time_multiplier: i128, // Maximum time multiplier (e.g., 2_000_000 for 2x)
-    pub time_weight_period: u64, // Period for time weighting in seconds
+    pub time_weight_period: u64,   // Period for time weighting in seconds
 }
 
 /// Storage keys for staking
@@ -109,7 +109,9 @@ pub fn get_total_staked(env: &Env) -> i128 {
 
 /// Update total staked amount
 pub fn update_total_staked(env: &Env, amount: i128) {
-    env.storage().persistent().set(&DataKey::TotalStaked, &amount);
+    env.storage()
+        .persistent()
+        .set(&DataKey::TotalStaked, &amount);
 }
 
 /// Get reward pool balance
@@ -122,7 +124,9 @@ pub fn get_reward_pool(env: &Env) -> i128 {
 
 /// Update reward pool balance
 pub fn update_reward_pool(env: &Env, amount: i128) {
-    env.storage().persistent().set(&DataKey::RewardPool, &amount);
+    env.storage()
+        .persistent()
+        .set(&DataKey::RewardPool, &amount);
 }
 
 /// Get staked token address

--- a/contracts/tipjar/src/staking/rewards.rs
+++ b/contracts/tipjar/src/staking/rewards.rs
@@ -93,11 +93,7 @@ pub fn calculate_impermanent_loss(
 }
 
 /// Calculate expected rewards for a given stake amount and duration
-pub fn calculate_expected_rewards(
-    env: &Env,
-    stake_amount: i128,
-    duration: u64,
-) -> i128 {
+pub fn calculate_expected_rewards(env: &Env, stake_amount: i128, duration: u64) -> i128 {
     let total_staked = super::get_total_staked(env);
     if total_staked == 0 {
         return 0;

--- a/contracts/tipjar/src/state_channel/mod.rs
+++ b/contracts/tipjar/src/state_channel/mod.rs
@@ -172,7 +172,13 @@ pub fn record_tip(
 
     env.events().publish(
         (symbol_short!("tch_tip"),),
-        (tipper.clone(), creator.clone(), token.clone(), tip_amount, nonce),
+        (
+            tipper.clone(),
+            creator.clone(),
+            token.clone(),
+            tip_amount,
+            nonce,
+        ),
     );
 }
 
@@ -200,7 +206,13 @@ pub fn settle(env: &Env, tipper: &Address, creator: &Address, token: &Address) {
 
     env.events().publish(
         (symbol_short!("tch_setl"),),
-        (tipper.clone(), creator.clone(), token.clone(), to_creator, to_tipper),
+        (
+            tipper.clone(),
+            creator.clone(),
+            token.clone(),
+            to_creator,
+            to_tipper,
+        ),
     );
 }
 
@@ -242,7 +254,14 @@ pub fn dispute(
 
             env.events().publish(
                 (symbol_short!("tch_disp"),),
-                (caller.clone(), tipper.clone(), creator.clone(), token.clone(), claimed_tipped_amount, nonce),
+                (
+                    caller.clone(),
+                    tipper.clone(),
+                    creator.clone(),
+                    token.clone(),
+                    claimed_tipped_amount,
+                    nonce,
+                ),
             );
         }
         TipChannelStatus::Disputed => {
@@ -260,7 +279,14 @@ pub fn dispute(
 
                 env.events().publish(
                     (symbol_short!("tch_disp"),),
-                    (caller.clone(), tipper.clone(), creator.clone(), token.clone(), claimed_tipped_amount, nonce),
+                    (
+                        caller.clone(),
+                        tipper.clone(),
+                        creator.clone(),
+                        token.clone(),
+                        claimed_tipped_amount,
+                        nonce,
+                    ),
                 );
             } else {
                 // Window elapsed — finalise with last submitted state.
@@ -280,7 +306,13 @@ pub fn dispute(
 
                 env.events().publish(
                     (symbol_short!("tch_fin"),),
-                    (tipper.clone(), creator.clone(), token.clone(), to_creator, to_tipper),
+                    (
+                        tipper.clone(),
+                        creator.clone(),
+                        token.clone(),
+                        to_creator,
+                        to_tipper,
+                    ),
                 );
             }
         }

--- a/contracts/tipjar/src/storage.rs
+++ b/contracts/tipjar/src/storage.rs
@@ -1,6 +1,10 @@
-use soroban_sdk::{Env};
+use soroban_sdk::Env;
 
-use crate::{DataKey, VestingKey, StreamKey, AuctionKey, MultiSigKey, DisputeKey, PrivateTipKey, InsuranceKey, OptionKey, BridgeKey, SyntheticKey, CircuitBreakerKey, MilestoneKey, RoleKey, StatsKey, LockedTipKey, MatchingKey, FeeKey, SnapshotKey, LimitKey, DelegationKey};
+use crate::{
+    AuctionKey, BridgeKey, CircuitBreakerKey, DataKey, DelegationKey, DisputeKey, FeeKey,
+    InsuranceKey, LimitKey, LockedTipKey, MatchingKey, MilestoneKey, MultiSigKey, OptionKey,
+    PrivateTipKey, RoleKey, SnapshotKey, StatsKey, StreamKey, SyntheticKey, VestingKey,
+};
 
 /// Default version for new contracts before any upgrade occurs.
 pub const DEFAULT_CONTRACT_VERSION: u32 = 0;
@@ -15,6 +19,7 @@ pub fn get_contract_version(env: &Env) -> u32 {
 
 /// Stores the current on-chain contract version.
 pub fn set_contract_version(env: &Env, version: u32) {
-    env.storage().instance().set(&DataKey::ContractVersion, &version);
+    env.storage()
+        .instance()
+        .set(&DataKey::ContractVersion, &version);
 }
-

--- a/contracts/tipjar/src/synthetic/admin.rs
+++ b/contracts/tipjar/src/synthetic/admin.rs
@@ -3,14 +3,17 @@
 //! Provides creator controls for managing synthetic assets including
 //! pause, resume, and parameter adjustments.
 
-use soroban_sdk::{token, Address, Env, Vec};
-use crate::{DataKey, TipJarError, CoreError, SystemError, FeatureError, VestingError, StreamError, AuctionError, CreditError, OtherError, SyntheticKey};
-use super::types::SyntheticAsset;
 use super::events::{
-    emit_synthetic_asset_created, emit_synthetic_asset_paused, emit_synthetic_asset_resumed,
-    emit_collateralization_updated, emit_collateral_updated,
+    emit_collateral_updated, emit_collateralization_updated, emit_synthetic_asset_created,
+    emit_synthetic_asset_paused, emit_synthetic_asset_resumed,
 };
 use super::supply::{get_collateralization_ratio, update_collateral};
+use super::types::SyntheticAsset;
+use crate::{
+    AuctionError, CoreError, CreditError, DataKey, FeatureError, OtherError, StreamError,
+    SyntheticKey, SystemError, TipJarError, VestingError,
+};
+use soroban_sdk::{token, Address, Env, Vec};
 
 /// Creates a new synthetic asset
 ///
@@ -56,11 +59,7 @@ pub fn create_synthetic_asset(
 
     // Generate unique asset_id using SyntheticAssetCounter
     let counter_key = DataKey::Synthetic(SyntheticKey::SyntheticAssetCounter);
-    let current_counter: u64 = env
-        .storage()
-        .instance()
-        .get(&counter_key)
-        .unwrap_or(0);
+    let current_counter: u64 = env.storage().instance().get(&counter_key).unwrap_or(0);
     let asset_id = current_counter + 1;
     env.storage().instance().set(&counter_key, &asset_id);
 
@@ -83,14 +82,17 @@ pub fn create_synthetic_asset(
     env.storage().persistent().set(&asset_key, &asset);
 
     // Add asset_id to creator's asset list
-    let creator_assets_key = DataKey::Synthetic(SyntheticKey::CreatorSyntheticAssets(creator.clone()));
+    let creator_assets_key =
+        DataKey::Synthetic(SyntheticKey::CreatorSyntheticAssets(creator.clone()));
     let mut creator_assets: Vec<u64> = env
         .storage()
         .persistent()
         .get(&creator_assets_key)
         .unwrap_or(Vec::new(env));
     creator_assets.push_back(asset_id);
-    env.storage().persistent().set(&creator_assets_key, &creator_assets);
+    env.storage()
+        .persistent()
+        .set(&creator_assets_key, &creator_assets);
 
     // Emit SyntheticAssetCreated event
     emit_synthetic_asset_created(
@@ -277,7 +279,9 @@ pub fn add_collateral(
     let new_balance = current_balance
         .checked_add(amount)
         .ok_or(CoreError::InvalidAmount)?;
-    env.storage().persistent().set(&creator_balance_key, &new_balance);
+    env.storage()
+        .persistent()
+        .set(&creator_balance_key, &new_balance);
 
     // Update total collateral via update_collateral()
     update_collateral(env, asset_id, amount)?;

--- a/contracts/tipjar/src/synthetic/minting.rs
+++ b/contracts/tipjar/src/synthetic/minting.rs
@@ -4,12 +4,18 @@
 //! and calculating appropriate token amounts based on oracle prices and
 //! collateralization ratios.
 
-use soroban_sdk::{token, Address, Env};
-use crate::{DataKey, TipJarError, CoreError, SystemError, FeatureError, VestingError, StreamError, AuctionError, CreditError, OtherError, VestingKey, StreamKey, AuctionKey, MultiSigKey, DisputeKey, PrivateTipKey, InsuranceKey, OptionKey, BridgeKey, SyntheticKey, CircuitBreakerKey, MilestoneKey, RoleKey, StatsKey, LockedTipKey, MatchingKey, FeeKey, SnapshotKey, LimitKey, DelegationKey};
-use super::types::SyntheticAsset;
 use super::events::emit_synthetic_tokens_minted;
 use super::oracle::get_oracle_price;
-use super::supply::{update_supply, update_collateral};
+use super::supply::{update_collateral, update_supply};
+use super::types::SyntheticAsset;
+use crate::{
+    AuctionError, AuctionKey, BridgeKey, CircuitBreakerKey, CoreError, CreditError, DataKey,
+    DelegationKey, DisputeKey, FeatureError, FeeKey, InsuranceKey, LimitKey, LockedTipKey,
+    MatchingKey, MilestoneKey, MultiSigKey, OptionKey, OtherError, PrivateTipKey, RoleKey,
+    SnapshotKey, StatsKey, StreamError, StreamKey, SyntheticKey, SystemError, TipJarError,
+    VestingError, VestingKey,
+};
+use soroban_sdk::{token, Address, Env};
 
 /// Calculates required collateral for minting synthetic tokens
 ///
@@ -72,12 +78,7 @@ pub fn calculate_required_collateral(
 ///
 /// # Requirements
 /// - Validates: Requirements 3.1, 3.2, 3.3, 3.4, 3.5, 3.6, 3.7, 3.8, 3.9, 3.10, 12.2, 12.4, 12.5, 12.7
-pub fn mint(
-    env: &Env,
-    user: &Address,
-    asset_id: u64,
-    amount: i128,
-) -> Result<i128, TipJarError> {
+pub fn mint(env: &Env, user: &Address, asset_id: u64, amount: i128) -> Result<i128, TipJarError> {
     // Validate amount is positive
     if amount <= 0 {
         return Err(CoreError::InvalidAmount);
@@ -106,12 +107,11 @@ pub fn mint(
     token_contract.transfer(user, &asset.creator, &required_collateral);
 
     // Lock collateral in tip pool (update SyntheticCollateral storage)
-    let collateral_key = DataKey::Synthetic(SyntheticKey::SyntheticCollateral(asset.creator.clone(), asset.backing_token.clone()));
-    let current_locked: i128 = env
-        .storage()
-        .persistent()
-        .get(&collateral_key)
-        .unwrap_or(0);
+    let collateral_key = DataKey::Synthetic(SyntheticKey::SyntheticCollateral(
+        asset.creator.clone(),
+        asset.backing_token.clone(),
+    ));
+    let current_locked: i128 = env.storage().persistent().get(&collateral_key).unwrap_or(0);
     let new_locked = current_locked
         .checked_add(required_collateral)
         .ok_or(CoreError::InvalidAmount)?;
@@ -119,11 +119,7 @@ pub fn mint(
 
     // Mint synthetic tokens to user (update SyntheticBalance storage)
     let balance_key = DataKey::Synthetic(SyntheticKey::SyntheticBalance(user.clone(), asset_id));
-    let current_balance: i128 = env
-        .storage()
-        .persistent()
-        .get(&balance_key)
-        .unwrap_or(0);
+    let current_balance: i128 = env.storage().persistent().get(&balance_key).unwrap_or(0);
     let new_balance = current_balance
         .checked_add(amount)
         .ok_or(CoreError::InvalidAmount)?;

--- a/contracts/tipjar/src/synthetic/mod.rs
+++ b/contracts/tipjar/src/synthetic/mod.rs
@@ -4,14 +4,14 @@
 //! backed by creator tip pools. Synthetic assets allow users to gain exposure to
 //! creator performance while providing creators with upfront liquidity.
 
-pub mod types;
-pub mod minting;
-pub mod redemption;
-pub mod oracle;
-pub mod supply;
 pub mod admin;
-pub mod queries;
 pub mod events;
+pub mod minting;
+pub mod oracle;
+pub mod queries;
+pub mod redemption;
+pub mod supply;
+pub mod types;
 
-pub use types::*;
 pub use events::*;
+pub use types::*;

--- a/contracts/tipjar/src/synthetic/oracle.rs
+++ b/contracts/tipjar/src/synthetic/oracle.rs
@@ -3,10 +3,16 @@
 //! Calculates real-time valuations of synthetic assets based on tip pool
 //! performance metrics.
 
-use soroban_sdk::Env;
-use crate::{DataKey, TipJarError, CoreError, SystemError, FeatureError, VestingError, StreamError, AuctionError, CreditError, OtherError, VestingKey, StreamKey, AuctionKey, MultiSigKey, DisputeKey, PrivateTipKey, InsuranceKey, OptionKey, BridgeKey, SyntheticKey, CircuitBreakerKey, MilestoneKey, RoleKey, StatsKey, LockedTipKey, MatchingKey, FeeKey, SnapshotKey, LimitKey, DelegationKey};
-use super::types::SyntheticAsset;
 use super::events::emit_price_updated;
+use super::types::SyntheticAsset;
+use crate::{
+    AuctionError, AuctionKey, BridgeKey, CircuitBreakerKey, CoreError, CreditError, DataKey,
+    DelegationKey, DisputeKey, FeatureError, FeeKey, InsuranceKey, LimitKey, LockedTipKey,
+    MatchingKey, MilestoneKey, MultiSigKey, OptionKey, OtherError, PrivateTipKey, RoleKey,
+    SnapshotKey, StatsKey, StreamError, StreamKey, SyntheticKey, SystemError, TipJarError,
+    VestingError, VestingKey,
+};
+use soroban_sdk::Env;
 
 /// Calculates and updates the oracle price for a synthetic asset
 ///
@@ -26,7 +32,7 @@ use super::events::emit_price_updated;
 /// - Validates: Requirements 4.1, 4.2, 4.3, 4.4, 4.5, 4.6, 4.7
 pub fn update_oracle_price(env: &Env, asset_id: u64) -> Result<i128, TipJarError> {
     // Retrieve the synthetic asset
-    let asset_key = DataKey::(Key::());
+    let asset_key = DataKey(Key());
     let mut asset: SyntheticAsset = env
         .storage()
         .persistent()
@@ -35,11 +41,7 @@ pub fn update_oracle_price(env: &Env, asset_id: u64) -> Result<i128, TipJarError
 
     // Get the tip pool balance for the creator and backing token
     let balance_key = DataKey::CreatorBalance(asset.creator.clone(), asset.backing_token.clone());
-    let tip_pool_balance: i128 = env
-        .storage()
-        .persistent()
-        .get(&balance_key)
-        .unwrap_or(0);
+    let tip_pool_balance: i128 = env.storage().persistent().get(&balance_key).unwrap_or(0);
 
     // Calculate the oracle price based on the formula
     let new_price = if asset.total_supply > 0 {
@@ -84,7 +86,7 @@ pub fn update_oracle_price(env: &Env, asset_id: u64) -> Result<i128, TipJarError
 /// - Validates: Requirements 4.1, 9.3
 pub fn get_oracle_price(env: &Env, asset_id: u64) -> Result<i128, TipJarError> {
     // Retrieve the synthetic asset
-    let asset_key = DataKey::(Key::());
+    let asset_key = DataKey(Key());
     let asset: SyntheticAsset = env
         .storage()
         .persistent()
@@ -94,8 +96,3 @@ pub fn get_oracle_price(env: &Env, asset_id: u64) -> Result<i128, TipJarError> {
     // Return the current oracle price
     Ok(asset.oracle_price)
 }
-
-
-
-
-

--- a/contracts/tipjar/src/synthetic/queries.rs
+++ b/contracts/tipjar/src/synthetic/queries.rs
@@ -3,13 +3,19 @@
 //! Provides read-only access to synthetic asset information for users
 //! to make informed decisions about minting and redemption.
 
-use soroban_sdk::{Address, Env, Vec};
-use crate::{DataKey, TipJarError, CoreError, SystemError, FeatureError, VestingError, StreamError, AuctionError, CreditError, OtherError, VestingKey, StreamKey, AuctionKey, MultiSigKey, DisputeKey, PrivateTipKey, InsuranceKey, OptionKey, BridgeKey, SyntheticKey, CircuitBreakerKey, MilestoneKey, RoleKey, StatsKey, LockedTipKey, MatchingKey, FeeKey, SnapshotKey, LimitKey, DelegationKey};
-use super::types::SyntheticAsset;
-use super::oracle::get_oracle_price;
-use super::supply::{get_total_supply, get_total_collateral, get_collateralization_ratio};
 use super::minting::calculate_required_collateral;
+use super::oracle::get_oracle_price;
 use super::redemption::calculate_redemption_value;
+use super::supply::{get_collateralization_ratio, get_total_collateral, get_total_supply};
+use super::types::SyntheticAsset;
+use crate::{
+    AuctionError, AuctionKey, BridgeKey, CircuitBreakerKey, CoreError, CreditError, DataKey,
+    DelegationKey, DisputeKey, FeatureError, FeeKey, InsuranceKey, LimitKey, LockedTipKey,
+    MatchingKey, MilestoneKey, MultiSigKey, OptionKey, OtherError, PrivateTipKey, RoleKey,
+    SnapshotKey, StatsKey, StreamError, StreamKey, SyntheticKey, SystemError, TipJarError,
+    VestingError, VestingKey,
+};
+use soroban_sdk::{Address, Env, Vec};
 
 /// Retrieves synthetic asset details by asset identifier
 ///
@@ -45,7 +51,8 @@ pub fn get_synthetic_asset(env: &Env, asset_id: u64) -> Result<SyntheticAsset, T
 /// # Requirements
 /// - Validates: Requirements 9.2
 pub fn get_creator_synthetic_assets(env: &Env, creator: &Address) -> Vec<u64> {
-    let creator_assets_key = DataKey::Synthetic(SyntheticKey::CreatorSyntheticAssets(creator.clone()));
+    let creator_assets_key =
+        DataKey::Synthetic(SyntheticKey::CreatorSyntheticAssets(creator.clone()));
     env.storage()
         .persistent()
         .get(&creator_assets_key)
@@ -66,10 +73,7 @@ pub fn get_creator_synthetic_assets(env: &Env, creator: &Address) -> Vec<u64> {
 /// - Validates: Requirements 9.8
 pub fn get_holder_balance(env: &Env, asset_id: u64, holder: &Address) -> i128 {
     let balance_key = DataKey::Synthetic(SyntheticKey::SyntheticBalance(holder.clone(), asset_id));
-    env.storage()
-        .persistent()
-        .get(&balance_key)
-        .unwrap_or(0)
+    env.storage().persistent().get(&balance_key).unwrap_or(0)
 }
 
 /// Retrieves the current oracle price for a synthetic asset

--- a/contracts/tipjar/src/synthetic/redemption.rs
+++ b/contracts/tipjar/src/synthetic/redemption.rs
@@ -3,12 +3,18 @@
 //! Manages the burning of synthetic tokens and distribution of underlying
 //! value back to token holders.
 
-use soroban_sdk::{token, Address, Env};
-use crate::{DataKey, TipJarError, CoreError, SystemError, FeatureError, VestingError, StreamError, AuctionError, CreditError, OtherError, VestingKey, StreamKey, AuctionKey, MultiSigKey, DisputeKey, PrivateTipKey, InsuranceKey, OptionKey, BridgeKey, SyntheticKey, CircuitBreakerKey, MilestoneKey, RoleKey, StatsKey, LockedTipKey, MatchingKey, FeeKey, SnapshotKey, LimitKey, DelegationKey};
-use super::types::SyntheticAsset;
 use super::events::emit_synthetic_tokens_redeemed;
 use super::oracle::get_oracle_price;
-use super::supply::{update_supply, update_collateral};
+use super::supply::{update_collateral, update_supply};
+use super::types::SyntheticAsset;
+use crate::{
+    AuctionError, AuctionKey, BridgeKey, CircuitBreakerKey, CoreError, CreditError, DataKey,
+    DelegationKey, DisputeKey, FeatureError, FeeKey, InsuranceKey, LimitKey, LockedTipKey,
+    MatchingKey, MilestoneKey, MultiSigKey, OptionKey, OtherError, PrivateTipKey, RoleKey,
+    SnapshotKey, StatsKey, StreamError, StreamKey, SyntheticKey, SystemError, TipJarError,
+    VestingError, VestingKey,
+};
+use soroban_sdk::{token, Address, Env};
 
 /// Calculates redemption value for a token amount
 ///
@@ -80,11 +86,7 @@ pub fn redeem(
 
     // Verify holder owns sufficient synthetic tokens
     let balance_key = DataKey::Synthetic(SyntheticKey::SyntheticBalance(holder.clone(), asset_id));
-    let current_balance: i128 = env
-        .storage()
-        .persistent()
-        .get(&balance_key)
-        .unwrap_or(0);
+    let current_balance: i128 = env.storage().persistent().get(&balance_key).unwrap_or(0);
 
     if current_balance < amount {
         return Err(CoreError::InsufficientBalance);
@@ -94,7 +96,8 @@ pub fn redeem(
     let redemption_value = calculate_redemption_value(env, asset_id, amount)?;
 
     // Check if tip pool has sufficient balance for redemption
-    let creator_balance_key = DataKey::CreatorBalance(asset.creator.clone(), asset.backing_token.clone());
+    let creator_balance_key =
+        DataKey::CreatorBalance(asset.creator.clone(), asset.backing_token.clone());
     let tip_pool_balance: i128 = env
         .storage()
         .persistent()
@@ -109,7 +112,7 @@ pub fn redeem(
     let new_balance = current_balance
         .checked_sub(amount)
         .ok_or(CoreError::InvalidAmount)?;
-    
+
     if new_balance == 0 {
         env.storage().persistent().remove(&balance_key);
     } else {
@@ -120,16 +123,15 @@ pub fn redeem(
     update_supply(env, asset_id, -amount)?;
 
     // Unlock collateral from tip pool (update SyntheticCollateral storage)
-    let collateral_key = DataKey::Synthetic(SyntheticKey::SyntheticCollateral(asset.creator.clone(), asset.backing_token.clone()));
-    let current_locked: i128 = env
-        .storage()
-        .persistent()
-        .get(&collateral_key)
-        .unwrap_or(0);
+    let collateral_key = DataKey::Synthetic(SyntheticKey::SyntheticCollateral(
+        asset.creator.clone(),
+        asset.backing_token.clone(),
+    ));
+    let current_locked: i128 = env.storage().persistent().get(&collateral_key).unwrap_or(0);
     let new_locked = current_locked
         .checked_sub(redemption_value)
         .ok_or(CoreError::InvalidAmount)?;
-    
+
     if new_locked == 0 {
         env.storage().persistent().remove(&collateral_key);
     } else {
@@ -144,11 +146,13 @@ pub fn redeem(
     let new_tip_pool_balance = tip_pool_balance
         .checked_sub(redemption_value)
         .ok_or(CoreError::InvalidAmount)?;
-    
+
     if new_tip_pool_balance == 0 {
         env.storage().persistent().remove(&creator_balance_key);
     } else {
-        env.storage().persistent().set(&creator_balance_key, &new_tip_pool_balance);
+        env.storage()
+            .persistent()
+            .set(&creator_balance_key, &new_tip_pool_balance);
     }
 
     // Update total collateral (decrease)

--- a/contracts/tipjar/src/synthetic/supply.rs
+++ b/contracts/tipjar/src/synthetic/supply.rs
@@ -3,10 +3,16 @@
 //! Monitors and records synthetic token supply, collateral amounts,
 //! and collateralization ratios.
 
-use soroban_sdk::Env;
-use crate::{DataKey, TipJarError, CoreError, SystemError, FeatureError, VestingError, StreamError, AuctionError, CreditError, OtherError, VestingKey, StreamKey, AuctionKey, MultiSigKey, DisputeKey, PrivateTipKey, InsuranceKey, OptionKey, BridgeKey, SyntheticKey, CircuitBreakerKey, MilestoneKey, RoleKey, StatsKey, LockedTipKey, MatchingKey, FeeKey, SnapshotKey, LimitKey, DelegationKey};
+use super::events::{emit_collateral_updated, emit_supply_updated};
 use super::types::SyntheticAsset;
-use super::events::{emit_supply_updated, emit_collateral_updated};
+use crate::{
+    AuctionError, AuctionKey, BridgeKey, CircuitBreakerKey, CoreError, CreditError, DataKey,
+    DelegationKey, DisputeKey, FeatureError, FeeKey, InsuranceKey, LimitKey, LockedTipKey,
+    MatchingKey, MilestoneKey, MultiSigKey, OptionKey, OtherError, PrivateTipKey, RoleKey,
+    SnapshotKey, StatsKey, StreamError, StreamKey, SyntheticKey, SystemError, TipJarError,
+    VestingError, VestingKey,
+};
+use soroban_sdk::Env;
 
 /// Updates total supply after minting or redemption
 ///
@@ -19,7 +25,7 @@ use super::events::{emit_supply_updated, emit_collateral_updated};
 /// - Validates: Requirements 3.5, 5.4, 6.1, 6.4, 6.9
 pub fn update_supply(env: &Env, asset_id: u64, delta: i128) -> Result<(), TipJarError> {
     // Retrieve the synthetic asset
-    let asset_key = DataKey::(Key::());
+    let asset_key = DataKey(Key());
     let mut asset: SyntheticAsset = env
         .storage()
         .persistent()
@@ -27,7 +33,8 @@ pub fn update_supply(env: &Env, asset_id: u64, delta: i128) -> Result<(), TipJar
         .ok_or(CreditError::SyntheticAssetNotFound)?;
 
     // Update the total supply
-    asset.total_supply = asset.total_supply
+    asset.total_supply = asset
+        .total_supply
         .checked_add(delta)
         .ok_or(CoreError::InvalidAmount)?;
 
@@ -51,7 +58,7 @@ pub fn update_supply(env: &Env, asset_id: u64, delta: i128) -> Result<(), TipJar
 /// - Validates: Requirements 3.6, 5.6, 6.2, 6.5, 6.10, 7.6
 pub fn update_collateral(env: &Env, asset_id: u64, delta: i128) -> Result<(), TipJarError> {
     // Retrieve the synthetic asset
-    let asset_key = DataKey::(Key::());
+    let asset_key = DataKey(Key());
     let mut asset: SyntheticAsset = env
         .storage()
         .persistent()
@@ -59,7 +66,8 @@ pub fn update_collateral(env: &Env, asset_id: u64, delta: i128) -> Result<(), Ti
         .ok_or(CreditError::SyntheticAssetNotFound)?;
 
     // Update the total collateral
-    asset.total_collateral = asset.total_collateral
+    asset.total_collateral = asset
+        .total_collateral
         .checked_add(delta)
         .ok_or(CoreError::InvalidAmount)?;
 
@@ -89,7 +97,7 @@ pub fn update_collateral(env: &Env, asset_id: u64, delta: i128) -> Result<(), Ti
 /// - Validates: Requirements 6.3, 6.8
 pub fn get_collateralization_ratio(env: &Env, asset_id: u64) -> Result<u32, TipJarError> {
     // Retrieve the synthetic asset
-    let asset_key = DataKey::(Key::());
+    let asset_key = DataKey(Key());
     let asset: SyntheticAsset = env
         .storage()
         .persistent()
@@ -103,7 +111,8 @@ pub fn get_collateralization_ratio(env: &Env, asset_id: u64) -> Result<u32, TipJ
     }
 
     // Calculate the synthetic value: total_supply * oracle_price
-    let synthetic_value = asset.total_supply
+    let synthetic_value = asset
+        .total_supply
         .checked_mul(asset.oracle_price)
         .ok_or(CoreError::InvalidAmount)?;
 
@@ -113,7 +122,8 @@ pub fn get_collateralization_ratio(env: &Env, asset_id: u64) -> Result<u32, TipJ
     }
 
     // Calculate ratio: (total_collateral / synthetic_value) * 10000
-    let ratio = asset.total_collateral
+    let ratio = asset
+        .total_collateral
         .checked_mul(10000)
         .ok_or(CoreError::InvalidAmount)?
         .checked_div(synthetic_value)
@@ -144,7 +154,7 @@ pub fn get_collateralization_ratio(env: &Env, asset_id: u64) -> Result<u32, TipJ
 /// - Validates: Requirements 6.6, 9.4
 pub fn get_total_supply(env: &Env, asset_id: u64) -> Result<i128, TipJarError> {
     // Retrieve the synthetic asset
-    let asset_key = DataKey::(Key::());
+    let asset_key = DataKey(Key());
     let asset: SyntheticAsset = env
         .storage()
         .persistent()
@@ -167,7 +177,7 @@ pub fn get_total_supply(env: &Env, asset_id: u64) -> Result<i128, TipJarError> {
 /// - Validates: Requirements 6.7, 9.4
 pub fn get_total_collateral(env: &Env, asset_id: u64) -> Result<i128, TipJarError> {
     // Retrieve the synthetic asset
-    let asset_key = DataKey::(Key::());
+    let asset_key = DataKey(Key());
     let asset: SyntheticAsset = env
         .storage()
         .persistent()
@@ -176,8 +186,3 @@ pub fn get_total_collateral(env: &Env, asset_id: u64) -> Result<i128, TipJarErro
 
     Ok(asset.total_collateral)
 }
-
-
-
-
-

--- a/contracts/tipjar/src/synthetic/types.rs
+++ b/contracts/tipjar/src/synthetic/types.rs
@@ -8,29 +8,29 @@ use soroban_sdk::{contracttype, Address};
 pub struct SyntheticAsset {
     /// Unique identifier for this synthetic asset
     pub asset_id: u64,
-    
+
     /// Creator whose tip pool backs this asset
     pub creator: Address,
-    
+
     /// Token address of the backing collateral
     pub backing_token: Address,
-    
+
     /// Total supply of synthetic tokens minted
     pub total_supply: i128,
-    
+
     /// Collateralization ratio in basis points (10000 = 100%)
     /// Valid range: 10000-50000 (100%-500%)
     pub collateralization_ratio: u32,
-    
+
     /// Timestamp when the asset was created
     pub created_at: u64,
-    
+
     /// Current oracle price (backing_token per synthetic_token)
     pub oracle_price: i128,
-    
+
     /// Total collateral locked in tip pool
     pub total_collateral: i128,
-    
+
     /// Whether the asset is active (true) or paused (false)
     pub active: bool,
 }

--- a/contracts/tipjar/src/time_lock_puzzle/mod.rs
+++ b/contracts/tipjar/src/time_lock_puzzle/mod.rs
@@ -1,0 +1,166 @@
+//! Tip Time-Lock Puzzles
+//!
+//! Implements cryptographic time-lock puzzles for delayed tip reveals and
+//! scheduled releases. A puzzle wraps a tip amount behind a computational
+//! challenge that becomes solvable only after a target unlock time.
+
+pub mod puzzle;
+pub mod solver;
+
+use soroban_sdk::{contracttype, Address, BytesN, Env};
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+/// Status of a time-lock puzzle.
+#[contracttype]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum PuzzleStatus {
+    /// Puzzle is active and not yet solved.
+    Active,
+    /// Puzzle has been solved and tip released.
+    Solved,
+    /// Puzzle was cancelled by the creator before solving.
+    Cancelled,
+}
+
+/// Difficulty tier controlling the number of required hash iterations.
+#[contracttype]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum PuzzleDifficulty {
+    /// ~1 000 iterations — suitable for short delays (minutes).
+    Easy,
+    /// ~10 000 iterations — suitable for medium delays (hours).
+    Medium,
+    /// ~100 000 iterations — suitable for long delays (days).
+    Hard,
+}
+
+/// A time-lock puzzle wrapping a tip.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TimeLockPuzzle {
+    /// Unique puzzle identifier.
+    pub id: u64,
+    /// Address that created (and funded) the puzzle.
+    pub creator: Address,
+    /// Intended tip recipient.
+    pub recipient: Address,
+    /// Token used for the tip.
+    pub token: Address,
+    /// Tip amount locked inside the puzzle.
+    pub amount: i128,
+    /// Puzzle commitment: SHA-256(secret || nonce).
+    pub commitment: BytesN<32>,
+    /// Number of sequential hash iterations required to solve.
+    pub iterations: u64,
+    /// Ledger timestamp before which the puzzle cannot be solved.
+    pub unlock_time: u64,
+    /// Ledger timestamp at which the puzzle was created.
+    pub created_at: u64,
+    /// Difficulty tier used when generating this puzzle.
+    pub difficulty: PuzzleDifficulty,
+    /// Current lifecycle status.
+    pub status: PuzzleStatus,
+}
+
+/// Storage keys scoped to the time-lock puzzle module.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum DataKey {
+    /// Puzzle record by ID.
+    Puzzle(u64),
+    /// Global puzzle counter.
+    PuzzleCounter,
+    /// List of puzzle IDs created by an address.
+    CreatorPuzzles(Address),
+    /// List of puzzle IDs targeting a recipient.
+    RecipientPuzzles(Address),
+}
+
+// ── Constants ────────────────────────────────────────────────────────────────
+
+/// Iteration count for Easy difficulty.
+pub const EASY_ITERATIONS: u64 = 1_000;
+/// Iteration count for Medium difficulty.
+pub const MEDIUM_ITERATIONS: u64 = 10_000;
+/// Iteration count for Hard difficulty.
+pub const HARD_ITERATIONS: u64 = 100_000;
+
+// ── Storage helpers ──────────────────────────────────────────────────────────
+
+/// Fetch a puzzle by ID, returning `None` if not found.
+pub fn get_puzzle(env: &Env, id: u64) -> Option<TimeLockPuzzle> {
+    env.storage().persistent().get(&DataKey::Puzzle(id))
+}
+
+/// Persist a puzzle record.
+pub fn save_puzzle(env: &Env, puzzle: &TimeLockPuzzle) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::Puzzle(puzzle.id), puzzle);
+}
+
+/// Allocate the next puzzle ID and increment the counter.
+pub fn next_puzzle_id(env: &Env) -> u64 {
+    let id: u64 = env
+        .storage()
+        .persistent()
+        .get(&DataKey::PuzzleCounter)
+        .unwrap_or(0)
+        + 1;
+    env.storage()
+        .persistent()
+        .set(&DataKey::PuzzleCounter, &id);
+    id
+}
+
+/// Append a puzzle ID to the creator's list.
+pub fn add_creator_puzzle(env: &Env, creator: &Address, puzzle_id: u64) {
+    let mut list: soroban_sdk::Vec<u64> = env
+        .storage()
+        .persistent()
+        .get(&DataKey::CreatorPuzzles(creator.clone()))
+        .unwrap_or_else(|| soroban_sdk::Vec::new(env));
+    list.push_back(puzzle_id);
+    env.storage()
+        .persistent()
+        .set(&DataKey::CreatorPuzzles(creator.clone()), &list);
+}
+
+/// Append a puzzle ID to the recipient's list.
+pub fn add_recipient_puzzle(env: &Env, recipient: &Address, puzzle_id: u64) {
+    let mut list: soroban_sdk::Vec<u64> = env
+        .storage()
+        .persistent()
+        .get(&DataKey::RecipientPuzzles(recipient.clone()))
+        .unwrap_or_else(|| soroban_sdk::Vec::new(env));
+    list.push_back(puzzle_id);
+    env.storage()
+        .persistent()
+        .set(&DataKey::RecipientPuzzles(recipient.clone()), &list);
+}
+
+/// Return all puzzle IDs created by `creator`.
+pub fn get_creator_puzzles(env: &Env, creator: &Address) -> soroban_sdk::Vec<u64> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::CreatorPuzzles(creator.clone()))
+        .unwrap_or_else(|| soroban_sdk::Vec::new(env))
+}
+
+/// Return all puzzle IDs targeting `recipient`.
+pub fn get_recipient_puzzles(env: &Env, recipient: &Address) -> soroban_sdk::Vec<u64> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::RecipientPuzzles(recipient.clone()))
+        .unwrap_or_else(|| soroban_sdk::Vec::new(env))
+}
+
+/// Map a `PuzzleDifficulty` to its iteration count.
+pub fn difficulty_iterations(difficulty: PuzzleDifficulty) -> u64 {
+    match difficulty {
+        PuzzleDifficulty::Easy => EASY_ITERATIONS,
+        PuzzleDifficulty::Medium => MEDIUM_ITERATIONS,
+        PuzzleDifficulty::Hard => HARD_ITERATIONS,
+    }
+}

--- a/contracts/tipjar/src/time_lock_puzzle/mod.rs
+++ b/contracts/tipjar/src/time_lock_puzzle/mod.rs
@@ -108,9 +108,7 @@ pub fn next_puzzle_id(env: &Env) -> u64 {
         .get(&DataKey::PuzzleCounter)
         .unwrap_or(0)
         + 1;
-    env.storage()
-        .persistent()
-        .set(&DataKey::PuzzleCounter, &id);
+    env.storage().persistent().set(&DataKey::PuzzleCounter, &id);
     id
 }
 

--- a/contracts/tipjar/src/time_lock_puzzle/puzzle.rs
+++ b/contracts/tipjar/src/time_lock_puzzle/puzzle.rs
@@ -1,0 +1,54 @@
+//! Puzzle generation and difficulty calculation.
+
+use soroban_sdk::{BytesN, Env};
+
+use super::{difficulty_iterations, PuzzleDifficulty};
+
+/// Generate a puzzle commitment from a secret and nonce.
+///
+/// Commitment = SHA-256(secret XOR nonce_bytes).
+/// On-chain we use `env.crypto().sha256()` which is the only available hash.
+pub fn generate_commitment(env: &Env, secret: &BytesN<32>, nonce: &BytesN<32>) -> BytesN<32> {
+    // XOR secret and nonce to produce the pre-image.
+    let secret_bytes = secret.to_array();
+    let nonce_bytes = nonce.to_array();
+    let mut pre_image = [0u8; 32];
+    for i in 0..32 {
+        pre_image[i] = secret_bytes[i] ^ nonce_bytes[i];
+    }
+    let pre_image_bytes = soroban_sdk::Bytes::from_array(env, &pre_image);
+    BytesN::from_array(env, &env.crypto().sha256(&pre_image_bytes).to_array())
+}
+
+/// Calculate the number of sequential hash iterations for a given difficulty
+/// and optional custom override.
+///
+/// If `custom_iterations` is `Some(n)` and `n > 0`, it is used directly.
+/// Otherwise the difficulty tier's default is returned.
+pub fn calculate_iterations(difficulty: PuzzleDifficulty, custom_iterations: Option<u64>) -> u64 {
+    if let Some(n) = custom_iterations {
+        if n > 0 {
+            return n;
+        }
+    }
+    difficulty_iterations(difficulty)
+}
+
+/// Verify that a proposed solution matches the stored commitment.
+///
+/// The solver must supply the original `secret` and `nonce`. We recompute the
+/// commitment and compare it to the stored value.
+pub fn verify_solution(
+    env: &Env,
+    commitment: &BytesN<32>,
+    secret: &BytesN<32>,
+    nonce: &BytesN<32>,
+) -> bool {
+    let recomputed = generate_commitment(env, secret, nonce);
+    recomputed == *commitment
+}
+
+/// Check whether the unlock time has been reached.
+pub fn is_time_reached(env: &Env, unlock_time: u64) -> bool {
+    env.ledger().timestamp() >= unlock_time
+}

--- a/contracts/tipjar/src/time_lock_puzzle/solver.rs
+++ b/contracts/tipjar/src/time_lock_puzzle/solver.rs
@@ -1,0 +1,87 @@
+//! Puzzle solving and status tracking.
+
+use soroban_sdk::{BytesN, Env};
+
+use super::{
+    get_puzzle, puzzle::{is_time_reached, verify_solution}, save_puzzle, PuzzleStatus, TimeLockPuzzle,
+};
+
+/// Result of a solve attempt.
+pub enum SolveResult {
+    /// Puzzle solved successfully; tip can now be released.
+    Success,
+    /// Unlock time has not been reached yet.
+    TooEarly,
+    /// The supplied secret/nonce did not match the commitment.
+    WrongSolution,
+    /// Puzzle is not in `Active` status.
+    NotActive,
+}
+
+/// Attempt to solve a puzzle.
+///
+/// Validates:
+/// 1. Puzzle exists and is `Active`.
+/// 2. `unlock_time` has been reached.
+/// 3. The provided `secret` + `nonce` reproduce the stored commitment.
+///
+/// On success the puzzle status is updated to `Solved`.
+pub fn solve_puzzle(
+    env: &Env,
+    puzzle_id: u64,
+    secret: &BytesN<32>,
+    nonce: &BytesN<32>,
+) -> SolveResult {
+    let mut puzzle: TimeLockPuzzle = match get_puzzle(env, puzzle_id) {
+        Some(p) => p,
+        None => return SolveResult::NotActive, // treat missing as not active
+    };
+
+    if puzzle.status != PuzzleStatus::Active {
+        return SolveResult::NotActive;
+    }
+
+    if !is_time_reached(env, puzzle.unlock_time) {
+        return SolveResult::TooEarly;
+    }
+
+    if !verify_solution(env, &puzzle.commitment, secret, nonce) {
+        return SolveResult::WrongSolution;
+    }
+
+    puzzle.status = PuzzleStatus::Solved;
+    save_puzzle(env, &puzzle);
+
+    SolveResult::Success
+}
+
+/// Cancel an active puzzle (only the creator may do this).
+///
+/// Returns `true` if the puzzle was successfully cancelled, `false` if it was
+/// already solved or cancelled.
+pub fn cancel_puzzle(env: &Env, puzzle_id: u64) -> bool {
+    let mut puzzle: TimeLockPuzzle = match get_puzzle(env, puzzle_id) {
+        Some(p) => p,
+        None => return false,
+    };
+
+    if puzzle.status != PuzzleStatus::Active {
+        return false;
+    }
+
+    puzzle.status = PuzzleStatus::Cancelled;
+    save_puzzle(env, &puzzle);
+    true
+}
+
+/// Return the current status of a puzzle without modifying state.
+pub fn get_puzzle_status(env: &Env, puzzle_id: u64) -> Option<PuzzleStatus> {
+    get_puzzle(env, puzzle_id).map(|p| p.status)
+}
+
+/// Return whether the puzzle's unlock time has been reached.
+pub fn is_puzzle_unlocked(env: &Env, puzzle_id: u64) -> bool {
+    get_puzzle(env, puzzle_id)
+        .map(|p| is_time_reached(env, p.unlock_time))
+        .unwrap_or(false)
+}

--- a/contracts/tipjar/src/time_lock_puzzle/solver.rs
+++ b/contracts/tipjar/src/time_lock_puzzle/solver.rs
@@ -3,7 +3,9 @@
 use soroban_sdk::{BytesN, Env};
 
 use super::{
-    get_puzzle, puzzle::{is_time_reached, verify_solution}, save_puzzle, PuzzleStatus, TimeLockPuzzle,
+    get_puzzle,
+    puzzle::{is_time_reached, verify_solution},
+    save_puzzle, PuzzleStatus, TimeLockPuzzle,
 };
 
 /// Result of a solve attempt.

--- a/contracts/tipjar/src/twap_oracle.rs
+++ b/contracts/tipjar/src/twap_oracle.rs
@@ -169,11 +169,7 @@ fn ring_index_back(write_index: u32, offset: u32, capacity: u32) -> u32 {
 /// Collects up to `max_observations` observations going backwards from the
 /// current write position, stopping when we exceed `window_seconds`.
 /// Returns observations in chronological order (oldest first).
-fn collect_window(
-    env: &Env,
-    oracle: &TwapOracle,
-    window_seconds: u64,
-) -> Vec<Observation> {
+fn collect_window(env: &Env, oracle: &TwapOracle, window_seconds: u64) -> Vec<Observation> {
     let mut result: Vec<Observation> = Vec::new(env);
 
     let total_written = oracle.observation_count;
@@ -276,7 +272,12 @@ pub fn create_oracle(
 
     env.events().publish(
         (symbol_short!("twap_new"),),
-        (oracle_id, base_token.clone(), quote_token.clone(), initial_price),
+        (
+            oracle_id,
+            base_token.clone(),
+            quote_token.clone(),
+            initial_price,
+        ),
     );
 
     oracle_id
@@ -308,12 +309,11 @@ pub fn record_price(env: &Env, updater: &Address, oracle_id: u64, price: i128) {
     }
 
     // Fetch the previous observation to compute the new accumulator
-    let prev = get_observation(env, oracle_id, oracle.write_index)
-        .unwrap_or(Observation {
-            timestamp: now,
-            price_cumulative: 0,
-            price,
-        });
+    let prev = get_observation(env, oracle_id, oracle.write_index).unwrap_or(Observation {
+        timestamp: now,
+        price_cumulative: 0,
+        price,
+    });
 
     let elapsed = now.saturating_sub(prev.timestamp);
     let new_accumulator = prev
@@ -494,8 +494,6 @@ pub fn deactivate_oracle(env: &Env, updater: &Address, oracle_id: u64) {
     oracle.active = false;
     set_oracle(env, &oracle);
 
-    env.events().publish(
-        (symbol_short!("twap_off"),),
-        (oracle_id,),
-    );
+    env.events()
+        .publish((symbol_short!("twap_off"),), (oracle_id,));
 }

--- a/contracts/tipjar/src/upgrade.rs
+++ b/contracts/tipjar/src/upgrade.rs
@@ -1,6 +1,9 @@
 use soroban_sdk::{symbol_short, BytesN, Env};
 
-use crate::{storage, TipJarError, CoreError, SystemError, FeatureError, VestingError, StreamError, AuctionError, CreditError, OtherError};
+use crate::{
+    storage, AuctionError, CoreError, CreditError, FeatureError, OtherError, StreamError,
+    SystemError, TipJarError, VestingError,
+};
 
 /// Performs an admin-authorized WASM upgrade and bumps the on-chain version.
 ///
@@ -60,6 +63,3 @@ pub fn upgrade(env: &Env, new_wasm_hash: BytesN<32>) {
 pub fn get_version(env: &Env) -> u32 {
     storage::get_contract_version(env)
 }
-
-
-

--- a/contracts/tipjar/src/volatility/history.rs
+++ b/contracts/tipjar/src/volatility/history.rs
@@ -6,11 +6,7 @@ use super::{get_snapshot, get_snapshot_count, VolatilitySnapshot};
 
 /// Return up to `limit` most-recent snapshots for `index_id` in
 /// reverse-chronological order (newest first).
-pub fn get_recent_snapshots(
-    env: &Env,
-    index_id: u64,
-    limit: u32,
-) -> Vec<VolatilitySnapshot> {
+pub fn get_recent_snapshots(env: &Env, index_id: u64, limit: u32) -> Vec<VolatilitySnapshot> {
     let total = get_snapshot_count(env, index_id);
     let mut result: Vec<VolatilitySnapshot> = Vec::new(env);
 

--- a/contracts/tipjar/src/volatility/mod.rs
+++ b/contracts/tipjar/src/volatility/mod.rs
@@ -123,9 +123,7 @@ pub struct VolatilityConfig {
 // ── Storage helpers ──────────────────────────────────────────────────────────
 
 pub fn get_index(env: &Env, index_id: u64) -> Option<VolatilityIndex> {
-    env.storage()
-        .persistent()
-        .get(&DataKey::VolIndex(index_id))
+    env.storage().persistent().get(&DataKey::VolIndex(index_id))
 }
 
 pub fn save_index(env: &Env, idx: &VolatilityIndex) {
@@ -166,9 +164,10 @@ pub fn get_snapshot(env: &Env, index_id: u64, seq: u64) -> Option<VolatilitySnap
 }
 
 pub fn save_snapshot(env: &Env, snap: &VolatilitySnapshot) {
-    env.storage()
-        .persistent()
-        .set(&DataKey::VolSnapshot(snap.index_id, snap.snapshot_seq), snap);
+    env.storage().persistent().set(
+        &DataKey::VolSnapshot(snap.index_id, snap.snapshot_seq),
+        snap,
+    );
 }
 
 pub fn get_snapshot_count(env: &Env, index_id: u64) -> u64 {
@@ -250,12 +249,7 @@ pub fn collect_window(env: &Env, idx: &VolatilityIndex) -> Vec<VolObservation> {
 
 /// Create a new volatility index for a (creator, token) pair.
 /// Returns the new index ID.
-pub fn create_index(
-    env: &Env,
-    creator: &Address,
-    token: &Address,
-    window_size: u32,
-) -> u64 {
+pub fn create_index(env: &Env, creator: &Address, token: &Address, window_size: u32) -> u64 {
     let index_id = next_id(env);
     let now = env.ledger().timestamp();
 
@@ -294,9 +288,21 @@ pub fn record_observation(env: &Env, index_id: u64, amount: i128) -> VolatilityI
 
     // Write new observation into ring buffer
     let next_slot = (idx.write_index + 1) % idx.window_size;
-    let write_slot = if idx.observation_count == 0 { 0 } else { next_slot };
+    let write_slot = if idx.observation_count == 0 {
+        0
+    } else {
+        next_slot
+    };
 
-    set_observation(env, index_id, write_slot, &VolObservation { timestamp: now, amount });
+    set_observation(
+        env,
+        index_id,
+        write_slot,
+        &VolObservation {
+            timestamp: now,
+            amount,
+        },
+    );
 
     idx.write_index = write_slot;
     idx.observation_count += 1;

--- a/contracts/tipjar/src/zk_proof/mod.rs
+++ b/contracts/tipjar/src/zk_proof/mod.rs
@@ -204,9 +204,7 @@ pub fn register_circuit(
         registered_at: env.ledger().timestamp(),
     };
 
-    env.storage()
-        .persistent()
-        .set(&DataKey::ZkCircuit(id), &vk);
+    env.storage().persistent().set(&DataKey::ZkCircuit(id), &vk);
 
     // Track circuits per owner
     let mut owner_circuits: Vec<u64> = env
@@ -219,10 +217,8 @@ pub fn register_circuit(
         .persistent()
         .set(&DataKey::ZkOwnerCircuits(owner.clone()), &owner_circuits);
 
-    env.events().publish(
-        (symbol_short!("zk_reg"),),
-        (id, owner.clone(), vk_hash),
-    );
+    env.events()
+        .publish((symbol_short!("zk_reg"),), (id, owner.clone(), vk_hash));
 
     id
 }
@@ -240,10 +236,8 @@ pub fn deactivate_circuit(env: &Env, circuit_id: u64) {
         .persistent()
         .set(&DataKey::ZkCircuit(circuit_id), &vk);
 
-    env.events().publish(
-        (symbol_short!("zk_deact"),),
-        (circuit_id,),
-    );
+    env.events()
+        .publish((symbol_short!("zk_deact"),), (circuit_id,));
 }
 
 // ── Proof submission & verification ──────────────────────────────────────────
@@ -343,7 +337,10 @@ pub fn verify_proof(env: &Env, proof_id: u64, is_valid: bool) {
         .get(&DataKey::ZkProof(proof_id))
         .expect("Proof not found");
 
-    assert!(proof.status == ProofStatus::Pending, "Proof already processed");
+    assert!(
+        proof.status == ProofStatus::Pending,
+        "Proof already processed"
+    );
 
     proof.status = if is_valid {
         ProofStatus::Verified
@@ -356,10 +353,8 @@ pub fn verify_proof(env: &Env, proof_id: u64, is_valid: bool) {
         .persistent()
         .set(&DataKey::ZkProof(proof_id), &proof);
 
-    env.events().publish(
-        (symbol_short!("zk_ver"),),
-        (proof_id, is_valid),
-    );
+    env.events()
+        .publish((symbol_short!("zk_ver"),), (proof_id, is_valid));
 }
 
 /// Revokes a proof. Admin only.
@@ -376,10 +371,8 @@ pub fn revoke_proof(env: &Env, proof_id: u64) {
         .persistent()
         .set(&DataKey::ZkProof(proof_id), &proof);
 
-    env.events().publish(
-        (symbol_short!("zk_rvk"),),
-        (proof_id,),
-    );
+    env.events()
+        .publish((symbol_short!("zk_rvk"),), (proof_id,));
 }
 
 // ── Private tips with ZK proofs ──────────────────────────────────────────────
@@ -429,14 +422,13 @@ pub fn create_private_tip(
         .get(&DataKey::ZkCreatorPrivateTips(creator.clone()))
         .unwrap_or_else(|| Vec::new(env));
     creator_tips.push_back(id);
-    env.storage()
-        .persistent()
-        .set(&DataKey::ZkCreatorPrivateTips(creator.clone()), &creator_tips);
-
-    env.events().publish(
-        (symbol_short!("zk_ptip"),),
-        (id, creator.clone(), proof_id),
+    env.storage().persistent().set(
+        &DataKey::ZkCreatorPrivateTips(creator.clone()),
+        &creator_tips,
     );
+
+    env.events()
+        .publish((symbol_short!("zk_ptip"),), (id, creator.clone(), proof_id));
 
     id
 }
@@ -456,10 +448,8 @@ pub fn claim_private_tip(env: &Env, tip_id: u64) {
         .persistent()
         .set(&DataKey::ZkPrivateTip(tip_id), &tip);
 
-    env.events().publish(
-        (symbol_short!("zk_clm"),),
-        (tip_id, tip.creator.clone()),
-    );
+    env.events()
+        .publish((symbol_short!("zk_clm"),), (tip_id, tip.creator.clone()));
 }
 
 // ── Nullifier management ─────────────────────────────────────────────────────

--- a/contracts/tipjar/tests/acl_tests.rs
+++ b/contracts/tipjar/tests/acl_tests.rs
@@ -2,9 +2,9 @@
 
 extern crate std;
 
-use soroban_sdk::{String, Address, Env};
+use soroban_sdk::{Address, Env, String};
 use tipjar::{
-    acl::{LEVEL_ADMIN, LEVEL_MODERATOR, LEVEL_CREATOR},
+    acl::{LEVEL_ADMIN, LEVEL_CREATOR, LEVEL_MODERATOR},
     TipJarContract, TipJarContractClient,
 };
 
@@ -153,7 +153,9 @@ fn test_change_entry_records_subject() {
 
     client.acl_assign_role(&admin, &user, &String::from_str(&env, "viewer"));
 
-    let entry = client.acl_get_change_entry(&0u64).expect("entry should exist");
+    let entry = client
+        .acl_get_change_entry(&0u64)
+        .expect("entry should exist");
     assert_eq!(entry.subject, user);
 }
 

--- a/contracts/tipjar/tests/auction_tests.rs
+++ b/contracts/tipjar/tests/auction_tests.rs
@@ -2,10 +2,19 @@
 
 extern crate std;
 
-use soroban_sdk::{testutils::{Address as _, Ledger, BytesN as _}, Address, Env, BytesN, Vec};
+use soroban_sdk::{
+    testutils::{Address as _, BytesN as _, Ledger},
+    Address, BytesN, Env, Vec,
+};
 use tipjar::{TipJarContract, TipJarContractClient, TipJarError};
 
-fn setup() -> (Env, TipJarContractClient<'static>, Address, Address, Address) {
+fn setup() -> (
+    Env,
+    TipJarContractClient<'static>,
+    Address,
+    Address,
+    Address,
+) {
     let env = Env::default();
     env.mock_all_auths();
 

--- a/contracts/tipjar/tests/batch_operations_tests.rs
+++ b/contracts/tipjar/tests/batch_operations_tests.rs
@@ -2,13 +2,9 @@
 
 extern crate std;
 
-use soroban_sdk::{
-    testutils::Address as _,
-    Address, Env, Vec,
-};
+use soroban_sdk::{testutils::Address as _, Address, Env, Vec};
 use tipjar::{
-    BatchResult, TipJarContract, TipJarContractClient, TipJarError, TipOperation,
-    WithdrawOperation,
+    BatchResult, TipJarContract, TipJarContractClient, TipJarError, TipOperation, WithdrawOperation,
 };
 
 // ── helpers ───────────────────────────────────────────────────────────────────
@@ -36,8 +32,7 @@ fn setup() -> (
     client.add_token(&admin, &token_id);
 
     let tipper = Address::generate(&env);
-    soroban_sdk::token::StellarAssetClient::new(&env, &token_id)
-        .mint(&tipper, &10_000_000i128);
+    soroban_sdk::token::StellarAssetClient::new(&env, &token_id).mint(&tipper, &10_000_000i128);
 
     let creator = Address::generate(&env);
 
@@ -113,9 +108,21 @@ fn test_batch_tip_v2_multiple_recipients() {
     let creator3 = Address::generate(&env);
 
     let mut ops: Vec<TipOperation> = Vec::new(&env);
-    ops.push_back(TipOperation { creator: creator1.clone(), token: token.clone(), amount: 500i128 });
-    ops.push_back(TipOperation { creator: creator2.clone(), token: token.clone(), amount: 750i128 });
-    ops.push_back(TipOperation { creator: creator3.clone(), token: token.clone(), amount: 250i128 });
+    ops.push_back(TipOperation {
+        creator: creator1.clone(),
+        token: token.clone(),
+        amount: 500i128,
+    });
+    ops.push_back(TipOperation {
+        creator: creator2.clone(),
+        token: token.clone(),
+        amount: 750i128,
+    });
+    ops.push_back(TipOperation {
+        creator: creator3.clone(),
+        token: token.clone(),
+        amount: 250i128,
+    });
 
     let results = client.batch_tip_v2(&tipper, &ops);
 
@@ -136,14 +143,28 @@ fn test_batch_tip_v2_multiple_tokens() {
     let (env, client, _admin, tipper, creator, token1, token2) = setup_two_tokens();
 
     let mut ops: Vec<TipOperation> = Vec::new(&env);
-    ops.push_back(TipOperation { creator: creator.clone(), token: token1.clone(), amount: 1_000i128 });
-    ops.push_back(TipOperation { creator: creator.clone(), token: token2.clone(), amount: 2_000i128 });
+    ops.push_back(TipOperation {
+        creator: creator.clone(),
+        token: token1.clone(),
+        amount: 1_000i128,
+    });
+    ops.push_back(TipOperation {
+        creator: creator.clone(),
+        token: token2.clone(),
+        amount: 2_000i128,
+    });
 
     let results = client.batch_tip_v2(&tipper, &ops);
 
     assert_eq!(results.len(), 2);
-    assert_eq!(client.get_withdrawable_balance(&creator, &token1), 1_000i128);
-    assert_eq!(client.get_withdrawable_balance(&creator, &token2), 2_000i128);
+    assert_eq!(
+        client.get_withdrawable_balance(&creator, &token1),
+        1_000i128
+    );
+    assert_eq!(
+        client.get_withdrawable_balance(&creator, &token2),
+        2_000i128
+    );
 }
 
 #[test]
@@ -153,7 +174,11 @@ fn test_batch_tip_v2_returns_correct_indices() {
     let mut ops: Vec<TipOperation> = Vec::new(&env);
     for i in 0..5u32 {
         let c = Address::generate(&env);
-        ops.push_back(TipOperation { creator: c, token: token.clone(), amount: (i as i128 + 1) * 100 });
+        ops.push_back(TipOperation {
+            creator: c,
+            token: token.clone(),
+            amount: (i as i128 + 1) * 100,
+        });
     }
 
     let results = client.batch_tip_v2(&tipper, &ops);
@@ -198,7 +223,11 @@ fn test_batch_tip_v2_invalid_amount_fails() {
     let (env, client, _admin, tipper, creator, token) = setup();
 
     let mut ops: Vec<TipOperation> = Vec::new(&env);
-    ops.push_back(TipOperation { creator: creator.clone(), token: token.clone(), amount: 0i128 });
+    ops.push_back(TipOperation {
+        creator: creator.clone(),
+        token: token.clone(),
+        amount: 0i128,
+    });
 
     let result = client.try_batch_tip_v2(&tipper, &ops);
     assert_eq!(result, Err(Ok(TipJarError::InvalidAmount)));
@@ -211,11 +240,14 @@ fn test_batch_tip_v2_unwhitelisted_token_fails() {
     // Register a token but don't whitelist it.
     let bad_token_admin = Address::generate(&env);
     let bad_token = env.register_stellar_asset_contract(bad_token_admin.clone());
-    soroban_sdk::token::StellarAssetClient::new(&env, &bad_token)
-        .mint(&tipper, &1_000_000i128);
+    soroban_sdk::token::StellarAssetClient::new(&env, &bad_token).mint(&tipper, &1_000_000i128);
 
     let mut ops: Vec<TipOperation> = Vec::new(&env);
-    ops.push_back(TipOperation { creator: creator.clone(), token: bad_token.clone(), amount: 100i128 });
+    ops.push_back(TipOperation {
+        creator: creator.clone(),
+        token: bad_token.clone(),
+        amount: 100i128,
+    });
 
     let result = client.try_batch_tip_v2(&tipper, &ops);
     assert_eq!(result, Err(Ok(TipJarError::TokenNotWhitelisted)));
@@ -227,8 +259,16 @@ fn test_batch_tip_v2_atomic_all_or_nothing() {
 
     // Second operation has amount 0 — should fail atomically (no partial state).
     let mut ops: Vec<TipOperation> = Vec::new(&env);
-    ops.push_back(TipOperation { creator: creator.clone(), token: token.clone(), amount: 500i128 });
-    ops.push_back(TipOperation { creator: creator.clone(), token: token.clone(), amount: 0i128 });
+    ops.push_back(TipOperation {
+        creator: creator.clone(),
+        token: token.clone(),
+        amount: 500i128,
+    });
+    ops.push_back(TipOperation {
+        creator: creator.clone(),
+        token: token.clone(),
+        amount: 0i128,
+    });
 
     let result = client.try_batch_tip_v2(&tipper, &ops);
     assert_eq!(result, Err(Ok(TipJarError::InvalidAmount)));
@@ -245,7 +285,11 @@ fn test_batch_tip_v2_paused_fails() {
     client.pause(&admin, &reason);
 
     let mut ops: Vec<TipOperation> = Vec::new(&env);
-    ops.push_back(TipOperation { creator: creator.clone(), token: token.clone(), amount: 100i128 });
+    ops.push_back(TipOperation {
+        creator: creator.clone(),
+        token: token.clone(),
+        amount: 100i128,
+    });
 
     let result = client.try_batch_tip_v2(&tipper, &ops);
     assert_eq!(result, Err(Ok(TipJarError::ContractPaused)));
@@ -277,7 +321,10 @@ fn test_batch_withdraw_single_token() {
     seed_creator_balance(&env, &client, &tipper, &creator, &token, 5_000i128);
 
     let mut ops: Vec<WithdrawOperation> = Vec::new(&env);
-    ops.push_back(WithdrawOperation { token: token.clone(), amount: 3_000i128 });
+    ops.push_back(WithdrawOperation {
+        token: token.clone(),
+        amount: 3_000i128,
+    });
 
     let results = client.batch_withdraw(&creator, &ops);
 
@@ -297,8 +344,14 @@ fn test_batch_withdraw_multiple_tokens() {
     seed_creator_balance(&env, &client, &tipper, &creator, &token2, 6_000i128);
 
     let mut ops: Vec<WithdrawOperation> = Vec::new(&env);
-    ops.push_back(WithdrawOperation { token: token1.clone(), amount: 4_000i128 });
-    ops.push_back(WithdrawOperation { token: token2.clone(), amount: 6_000i128 });
+    ops.push_back(WithdrawOperation {
+        token: token1.clone(),
+        amount: 4_000i128,
+    });
+    ops.push_back(WithdrawOperation {
+        token: token2.clone(),
+        amount: 6_000i128,
+    });
 
     let results = client.batch_withdraw(&creator, &ops);
 
@@ -319,8 +372,14 @@ fn test_batch_withdraw_partial_amount() {
     seed_creator_balance(&env, &client, &tipper, &creator, &token, 10_000i128);
 
     let mut ops: Vec<WithdrawOperation> = Vec::new(&env);
-    ops.push_back(WithdrawOperation { token: token.clone(), amount: 3_000i128 });
-    ops.push_back(WithdrawOperation { token: token.clone(), amount: 2_000i128 });
+    ops.push_back(WithdrawOperation {
+        token: token.clone(),
+        amount: 3_000i128,
+    });
+    ops.push_back(WithdrawOperation {
+        token: token.clone(),
+        amount: 2_000i128,
+    });
 
     let results = client.batch_withdraw(&creator, &ops);
 
@@ -345,7 +404,10 @@ fn test_batch_withdraw_exceeds_max_size_fails() {
 
     let mut ops: Vec<WithdrawOperation> = Vec::new(&env);
     for _ in 0..21u32 {
-        ops.push_back(WithdrawOperation { token: token.clone(), amount: 100i128 });
+        ops.push_back(WithdrawOperation {
+            token: token.clone(),
+            amount: 100i128,
+        });
     }
 
     let result = client.try_batch_withdraw(&creator, &ops);
@@ -358,7 +420,10 @@ fn test_batch_withdraw_invalid_amount_fails() {
     seed_creator_balance(&env, &client, &tipper, &creator, &token, 1_000i128);
 
     let mut ops: Vec<WithdrawOperation> = Vec::new(&env);
-    ops.push_back(WithdrawOperation { token: token.clone(), amount: 0i128 });
+    ops.push_back(WithdrawOperation {
+        token: token.clone(),
+        amount: 0i128,
+    });
 
     let result = client.try_batch_withdraw(&creator, &ops);
     assert_eq!(result, Err(Ok(TipJarError::InvalidAmount)));
@@ -370,7 +435,10 @@ fn test_batch_withdraw_insufficient_balance_fails() {
     seed_creator_balance(&env, &client, &tipper, &creator, &token, 500i128);
 
     let mut ops: Vec<WithdrawOperation> = Vec::new(&env);
-    ops.push_back(WithdrawOperation { token: token.clone(), amount: 1_000i128 });
+    ops.push_back(WithdrawOperation {
+        token: token.clone(),
+        amount: 1_000i128,
+    });
 
     let result = client.try_batch_withdraw(&creator, &ops);
     assert_eq!(result, Err(Ok(TipJarError::InsufficientBalance)));
@@ -383,8 +451,14 @@ fn test_batch_withdraw_atomic_all_or_nothing() {
     seed_creator_balance(&env, &client, &tipper, &creator, &token, 500i128);
 
     let mut ops: Vec<WithdrawOperation> = Vec::new(&env);
-    ops.push_back(WithdrawOperation { token: token.clone(), amount: 300i128 });
-    ops.push_back(WithdrawOperation { token: token.clone(), amount: 300i128 }); // 300+300 > 500
+    ops.push_back(WithdrawOperation {
+        token: token.clone(),
+        amount: 300i128,
+    });
+    ops.push_back(WithdrawOperation {
+        token: token.clone(),
+        amount: 300i128,
+    }); // 300+300 > 500
 
     let result = client.try_batch_withdraw(&creator, &ops);
     assert_eq!(result, Err(Ok(TipJarError::InsufficientBalance)));
@@ -402,7 +476,10 @@ fn test_batch_withdraw_paused_fails() {
     client.pause(&admin, &reason);
 
     let mut ops: Vec<WithdrawOperation> = Vec::new(&env);
-    ops.push_back(WithdrawOperation { token: token.clone(), amount: 500i128 });
+    ops.push_back(WithdrawOperation {
+        token: token.clone(),
+        amount: 500i128,
+    });
 
     let result = client.try_batch_withdraw(&creator, &ops);
     assert_eq!(result, Err(Ok(TipJarError::ContractPaused)));
@@ -415,8 +492,14 @@ fn test_batch_withdraw_returns_correct_indices() {
     seed_creator_balance(&env, &client, &tipper, &creator, &token2, 3_000i128);
 
     let mut ops: Vec<WithdrawOperation> = Vec::new(&env);
-    ops.push_back(WithdrawOperation { token: token1.clone(), amount: 1_000i128 });
-    ops.push_back(WithdrawOperation { token: token2.clone(), amount: 1_000i128 });
+    ops.push_back(WithdrawOperation {
+        token: token1.clone(),
+        amount: 1_000i128,
+    });
+    ops.push_back(WithdrawOperation {
+        token: token2.clone(),
+        amount: 1_000i128,
+    });
 
     let results = client.batch_withdraw(&creator, &ops);
 
@@ -434,7 +517,11 @@ fn test_batch_tip_v2_max_batch_size_succeeds() {
     let mut ops: Vec<TipOperation> = Vec::new(&env);
     for _ in 0..20u32 {
         let c = Address::generate(&env);
-        ops.push_back(TipOperation { creator: c, token: token.clone(), amount: 100i128 });
+        ops.push_back(TipOperation {
+            creator: c,
+            token: token.clone(),
+            amount: 100i128,
+        });
     }
 
     let results = client.batch_tip_v2(&tipper, &ops);
@@ -449,7 +536,10 @@ fn test_batch_withdraw_max_batch_size_succeeds() {
 
     let mut ops: Vec<WithdrawOperation> = Vec::new(&env);
     for _ in 0..20u32 {
-        ops.push_back(WithdrawOperation { token: token.clone(), amount: 100i128 });
+        ops.push_back(WithdrawOperation {
+            token: token.clone(),
+            amount: 100i128,
+        });
     }
 
     let results = client.batch_withdraw(&creator, &ops);

--- a/contracts/tipjar/tests/bonding_curve_tests.rs
+++ b/contracts/tipjar/tests/bonding_curve_tests.rs
@@ -53,13 +53,13 @@ fn setup() -> (
 fn linear_params() -> CurveParams {
     CurveParams {
         curve_type: CurveType::Linear,
-        base_price: PRECISION,       // 1.0
-        slope: PRECISION / 10,       // 0.1 per token
+        base_price: PRECISION, // 1.0
+        slope: PRECISION / 10, // 0.1 per token
         k_param: 0,
         midpoint: 0,
         max_price: 0,
-        buy_fee_bps: 100,            // 1%
-        sell_fee_bps: 100,           // 1%
+        buy_fee_bps: 100,  // 1%
+        sell_fee_bps: 100, // 1%
     }
 }
 
@@ -67,7 +67,7 @@ fn exponential_params() -> CurveParams {
     CurveParams {
         curve_type: CurveType::Exponential,
         base_price: PRECISION,
-        slope: PRECISION / 100,      // 0.01 growth rate
+        slope: PRECISION / 100, // 0.01 growth rate
         k_param: 0,
         midpoint: 0,
         max_price: 0,
@@ -81,9 +81,9 @@ fn sigmoid_params() -> CurveParams {
         curve_type: CurveType::Sigmoid,
         base_price: PRECISION,
         slope: 0,
-        k_param: PRECISION / 10,     // k = 0.1
-        midpoint: 50 * PRECISION,    // inflection at supply = 50
-        max_price: 10 * PRECISION,   // max price = 10
+        k_param: PRECISION / 10,   // k = 0.1
+        midpoint: 50 * PRECISION,  // inflection at supply = 50
+        max_price: 10 * PRECISION, // max price = 10
         buy_fee_bps: 200,
         sell_fee_bps: 200,
     }
@@ -100,8 +100,11 @@ fn test_create_linear_curve() {
     let (env, client, _admin, tip_token, reserve_token, creator) = setup();
 
     let curve_id = client.bc_create_curve(
-        &creator, &tip_token, &reserve_token,
-        &linear_params(), &0i128,
+        &creator,
+        &tip_token,
+        &reserve_token,
+        &linear_params(),
+        &0i128,
     );
 
     assert_eq!(curve_id, 1);
@@ -117,8 +120,11 @@ fn test_create_exponential_curve() {
     let (env, client, _admin, tip_token, reserve_token, creator) = setup();
 
     let curve_id = client.bc_create_curve(
-        &creator, &tip_token, &reserve_token,
-        &exponential_params(), &0i128,
+        &creator,
+        &tip_token,
+        &reserve_token,
+        &exponential_params(),
+        &0i128,
     );
 
     let curve = client.bc_get_curve(&curve_id);
@@ -130,8 +136,11 @@ fn test_create_sigmoid_curve() {
     let (env, client, _admin, tip_token, reserve_token, creator) = setup();
 
     let curve_id = client.bc_create_curve(
-        &creator, &tip_token, &reserve_token,
-        &sigmoid_params(), &0i128,
+        &creator,
+        &tip_token,
+        &reserve_token,
+        &sigmoid_params(),
+        &0i128,
     );
 
     let curve = client.bc_get_curve(&curve_id);
@@ -143,8 +152,11 @@ fn test_create_curve_with_initial_reserve() {
     let (env, client, _admin, tip_token, reserve_token, creator) = setup();
 
     let curve_id = client.bc_create_curve(
-        &creator, &tip_token, &reserve_token,
-        &linear_params(), &500_000i128,
+        &creator,
+        &tip_token,
+        &reserve_token,
+        &linear_params(),
+        &500_000i128,
     );
 
     let curve = client.bc_get_curve(&curve_id);
@@ -158,9 +170,7 @@ fn test_create_curve_zero_base_price_fails() {
     let mut params = linear_params();
     params.base_price = 0;
 
-    let result = client.try_bc_create_curve(
-        &creator, &tip_token, &reserve_token, &params, &0i128,
-    );
+    let result = client.try_bc_create_curve(&creator, &tip_token, &reserve_token, &params, &0i128);
     assert_eq!(result, Err(Ok(TipJarError::BcInvalidParams)));
 }
 
@@ -171,9 +181,7 @@ fn test_create_curve_fee_too_high_fails() {
     let mut params = linear_params();
     params.buy_fee_bps = 2_000; // 20% — exceeds MAX_FEE_BPS
 
-    let result = client.try_bc_create_curve(
-        &creator, &tip_token, &reserve_token, &params, &0i128,
-    );
+    let result = client.try_bc_create_curve(&creator, &tip_token, &reserve_token, &params, &0i128);
     assert_eq!(result, Err(Ok(TipJarError::BcFeeTooHigh)));
 }
 
@@ -181,8 +189,20 @@ fn test_create_curve_fee_too_high_fails() {
 fn test_create_curve_increments_id() {
     let (env, client, _admin, tip_token, reserve_token, creator) = setup();
 
-    let id1 = client.bc_create_curve(&creator, &tip_token, &reserve_token, &linear_params(), &0i128);
-    let id2 = client.bc_create_curve(&creator, &tip_token, &reserve_token, &linear_params(), &0i128);
+    let id1 = client.bc_create_curve(
+        &creator,
+        &tip_token,
+        &reserve_token,
+        &linear_params(),
+        &0i128,
+    );
+    let id2 = client.bc_create_curve(
+        &creator,
+        &tip_token,
+        &reserve_token,
+        &linear_params(),
+        &0i128,
+    );
 
     assert_eq!(id1, 1);
     assert_eq!(id2, 2);
@@ -195,7 +215,11 @@ fn test_spot_price_at_zero_supply_equals_base_price() {
     let (env, client, _admin, tip_token, reserve_token, creator) = setup();
 
     let curve_id = client.bc_create_curve(
-        &creator, &tip_token, &reserve_token, &linear_params(), &0i128,
+        &creator,
+        &tip_token,
+        &reserve_token,
+        &linear_params(),
+        &0i128,
     );
 
     let price = client.bc_get_spot_price(&curve_id);
@@ -207,7 +231,11 @@ fn test_spot_price_increases_after_buy() {
     let (env, client, _admin, tip_token, reserve_token, creator) = setup();
 
     let curve_id = client.bc_create_curve(
-        &creator, &tip_token, &reserve_token, &linear_params(), &0i128,
+        &creator,
+        &tip_token,
+        &reserve_token,
+        &linear_params(),
+        &0i128,
     );
 
     let price_before = client.bc_get_spot_price(&curve_id);
@@ -225,7 +253,11 @@ fn test_spot_price_decreases_after_sell() {
     let (env, client, _admin, tip_token, reserve_token, creator) = setup();
 
     let curve_id = client.bc_create_curve(
-        &creator, &tip_token, &reserve_token, &linear_params(), &0i128,
+        &creator,
+        &tip_token,
+        &reserve_token,
+        &linear_params(),
+        &0i128,
     );
 
     // Buy first
@@ -236,8 +268,7 @@ fn test_spot_price_decreases_after_sell() {
     let price_after_buy = client.bc_get_spot_price(&curve_id);
 
     // Mint tip tokens to buyer so they can sell
-    soroban_sdk::token::StellarAssetClient::new(&env, &tip_token)
-        .mint(&buyer, &(20 * PRECISION));
+    soroban_sdk::token::StellarAssetClient::new(&env, &tip_token).mint(&buyer, &(20 * PRECISION));
     client.bc_sell(&buyer, &curve_id, &(10 * PRECISION), &0i128);
 
     let price_after_sell = client.bc_get_spot_price(&curve_id);
@@ -251,7 +282,11 @@ fn test_buy_updates_supply_and_reserve() {
     let (env, client, _admin, tip_token, reserve_token, creator) = setup();
 
     let curve_id = client.bc_create_curve(
-        &creator, &tip_token, &reserve_token, &linear_params(), &0i128,
+        &creator,
+        &tip_token,
+        &reserve_token,
+        &linear_params(),
+        &0i128,
     );
 
     let buyer = Address::generate(&env);
@@ -275,7 +310,11 @@ fn test_buy_zero_amount_fails() {
     let (env, client, _admin, tip_token, reserve_token, creator) = setup();
 
     let curve_id = client.bc_create_curve(
-        &creator, &tip_token, &reserve_token, &linear_params(), &0i128,
+        &creator,
+        &tip_token,
+        &reserve_token,
+        &linear_params(),
+        &0i128,
     );
 
     let buyer = Address::generate(&env);
@@ -288,7 +327,11 @@ fn test_buy_slippage_exceeded_fails() {
     let (env, client, _admin, tip_token, reserve_token, creator) = setup();
 
     let curve_id = client.bc_create_curve(
-        &creator, &tip_token, &reserve_token, &linear_params(), &0i128,
+        &creator,
+        &tip_token,
+        &reserve_token,
+        &linear_params(),
+        &0i128,
     );
 
     let buyer = Address::generate(&env);
@@ -304,7 +347,11 @@ fn test_buy_inactive_curve_fails() {
     let (env, client, _admin, tip_token, reserve_token, creator) = setup();
 
     let curve_id = client.bc_create_curve(
-        &creator, &tip_token, &reserve_token, &linear_params(), &0i128,
+        &creator,
+        &tip_token,
+        &reserve_token,
+        &linear_params(),
+        &0i128,
     );
 
     client.bc_deactivate(&creator, &curve_id);
@@ -323,7 +370,11 @@ fn test_sell_reduces_supply_and_reserve() {
     let (env, client, _admin, tip_token, reserve_token, creator) = setup();
 
     let curve_id = client.bc_create_curve(
-        &creator, &tip_token, &reserve_token, &linear_params(), &0i128,
+        &creator,
+        &tip_token,
+        &reserve_token,
+        &linear_params(),
+        &0i128,
     );
 
     let buyer = Address::generate(&env);
@@ -332,8 +383,7 @@ fn test_sell_reduces_supply_and_reserve() {
     client.bc_buy(&buyer, &curve_id, &buy_amount, &5_000_000i128);
 
     // Give buyer tip tokens to sell
-    soroban_sdk::token::StellarAssetClient::new(&env, &tip_token)
-        .mint(&buyer, &buy_amount);
+    soroban_sdk::token::StellarAssetClient::new(&env, &tip_token).mint(&buyer, &buy_amount);
 
     let sell_amount = 5 * PRECISION;
     let result = client.bc_sell(&buyer, &curve_id, &sell_amount, &0i128);
@@ -350,15 +400,18 @@ fn test_sell_more_than_supply_fails() {
     let (env, client, _admin, tip_token, reserve_token, creator) = setup();
 
     let curve_id = client.bc_create_curve(
-        &creator, &tip_token, &reserve_token, &linear_params(), &0i128,
+        &creator,
+        &tip_token,
+        &reserve_token,
+        &linear_params(),
+        &0i128,
     );
 
     let buyer = Address::generate(&env);
     mint_reserve(&env, &reserve_token, &buyer, 2_000_000i128);
     client.bc_buy(&buyer, &curve_id, &(5 * PRECISION), &2_000_000i128);
 
-    soroban_sdk::token::StellarAssetClient::new(&env, &tip_token)
-        .mint(&buyer, &(100 * PRECISION));
+    soroban_sdk::token::StellarAssetClient::new(&env, &tip_token).mint(&buyer, &(100 * PRECISION));
 
     let result = client.try_bc_sell(&buyer, &curve_id, &(100 * PRECISION), &0i128);
     assert_eq!(result, Err(Ok(TipJarError::BcInsufficientSupply)));
@@ -369,15 +422,18 @@ fn test_sell_slippage_exceeded_fails() {
     let (env, client, _admin, tip_token, reserve_token, creator) = setup();
 
     let curve_id = client.bc_create_curve(
-        &creator, &tip_token, &reserve_token, &linear_params(), &0i128,
+        &creator,
+        &tip_token,
+        &reserve_token,
+        &linear_params(),
+        &0i128,
     );
 
     let buyer = Address::generate(&env);
     mint_reserve(&env, &reserve_token, &buyer, 5_000_000i128);
     client.bc_buy(&buyer, &curve_id, &(10 * PRECISION), &5_000_000i128);
 
-    soroban_sdk::token::StellarAssetClient::new(&env, &tip_token)
-        .mint(&buyer, &(10 * PRECISION));
+    soroban_sdk::token::StellarAssetClient::new(&env, &tip_token).mint(&buyer, &(10 * PRECISION));
 
     // min_collateral set impossibly high
     let result = client.try_bc_sell(&buyer, &curve_id, &(5 * PRECISION), &999_999_999i128);
@@ -391,7 +447,11 @@ fn test_quote_buy_cost_positive() {
     let (env, client, _admin, tip_token, reserve_token, creator) = setup();
 
     let curve_id = client.bc_create_curve(
-        &creator, &tip_token, &reserve_token, &linear_params(), &0i128,
+        &creator,
+        &tip_token,
+        &reserve_token,
+        &linear_params(),
+        &0i128,
     );
 
     let quote = client.bc_get_quote(&curve_id, &(10 * PRECISION));
@@ -405,7 +465,11 @@ fn test_quote_sell_return_after_buy() {
     let (env, client, _admin, tip_token, reserve_token, creator) = setup();
 
     let curve_id = client.bc_create_curve(
-        &creator, &tip_token, &reserve_token, &linear_params(), &0i128,
+        &creator,
+        &tip_token,
+        &reserve_token,
+        &linear_params(),
+        &0i128,
     );
 
     let buyer = Address::generate(&env);
@@ -424,7 +488,11 @@ fn test_quote_zero_amount_fails() {
     let (env, client, _admin, tip_token, reserve_token, creator) = setup();
 
     let curve_id = client.bc_create_curve(
-        &creator, &tip_token, &reserve_token, &linear_params(), &0i128,
+        &creator,
+        &tip_token,
+        &reserve_token,
+        &linear_params(),
+        &0i128,
     );
 
     let result = client.try_bc_get_quote(&curve_id, &0i128);
@@ -438,7 +506,11 @@ fn test_fees_accumulate_on_buy() {
     let (env, client, _admin, tip_token, reserve_token, creator) = setup();
 
     let curve_id = client.bc_create_curve(
-        &creator, &tip_token, &reserve_token, &linear_params(), &0i128,
+        &creator,
+        &tip_token,
+        &reserve_token,
+        &linear_params(),
+        &0i128,
     );
 
     let buyer = Address::generate(&env);
@@ -454,7 +526,11 @@ fn test_withdraw_fees_transfers_to_creator() {
     let (env, client, _admin, tip_token, reserve_token, creator) = setup();
 
     let curve_id = client.bc_create_curve(
-        &creator, &tip_token, &reserve_token, &linear_params(), &0i128,
+        &creator,
+        &tip_token,
+        &reserve_token,
+        &linear_params(),
+        &0i128,
     );
 
     let buyer = Address::generate(&env);
@@ -476,7 +552,11 @@ fn test_withdraw_fees_no_fees_fails() {
     let (env, client, _admin, tip_token, reserve_token, creator) = setup();
 
     let curve_id = client.bc_create_curve(
-        &creator, &tip_token, &reserve_token, &linear_params(), &0i128,
+        &creator,
+        &tip_token,
+        &reserve_token,
+        &linear_params(),
+        &0i128,
     );
 
     let result = client.try_bc_withdraw_fees(&creator, &curve_id);
@@ -488,7 +568,11 @@ fn test_update_fees() {
     let (env, client, _admin, tip_token, reserve_token, creator) = setup();
 
     let curve_id = client.bc_create_curve(
-        &creator, &tip_token, &reserve_token, &linear_params(), &0i128,
+        &creator,
+        &tip_token,
+        &reserve_token,
+        &linear_params(),
+        &0i128,
     );
 
     client.bc_update_fees(&creator, &curve_id, &200u32, &300u32);
@@ -503,7 +587,11 @@ fn test_update_fees_too_high_fails() {
     let (env, client, _admin, tip_token, reserve_token, creator) = setup();
 
     let curve_id = client.bc_create_curve(
-        &creator, &tip_token, &reserve_token, &linear_params(), &0i128,
+        &creator,
+        &tip_token,
+        &reserve_token,
+        &linear_params(),
+        &0i128,
     );
 
     let result = client.try_bc_update_fees(&creator, &curve_id, &5_000u32, &0u32);
@@ -517,7 +605,11 @@ fn test_deactivate_curve() {
     let (env, client, _admin, tip_token, reserve_token, creator) = setup();
 
     let curve_id = client.bc_create_curve(
-        &creator, &tip_token, &reserve_token, &linear_params(), &0i128,
+        &creator,
+        &tip_token,
+        &reserve_token,
+        &linear_params(),
+        &0i128,
     );
 
     client.bc_deactivate(&creator, &curve_id);
@@ -531,7 +623,11 @@ fn test_deactivate_already_inactive_fails() {
     let (env, client, _admin, tip_token, reserve_token, creator) = setup();
 
     let curve_id = client.bc_create_curve(
-        &creator, &tip_token, &reserve_token, &linear_params(), &0i128,
+        &creator,
+        &tip_token,
+        &reserve_token,
+        &linear_params(),
+        &0i128,
     );
 
     client.bc_deactivate(&creator, &curve_id);
@@ -547,7 +643,11 @@ fn test_bc_buy_paused_fails() {
     let (env, client, admin, tip_token, reserve_token, creator) = setup();
 
     let curve_id = client.bc_create_curve(
-        &creator, &tip_token, &reserve_token, &linear_params(), &0i128,
+        &creator,
+        &tip_token,
+        &reserve_token,
+        &linear_params(),
+        &0i128,
     );
 
     let reason = soroban_sdk::String::from_str(&env, "maintenance");
@@ -567,7 +667,11 @@ fn test_exponential_curve_buy() {
     let (env, client, _admin, tip_token, reserve_token, creator) = setup();
 
     let curve_id = client.bc_create_curve(
-        &creator, &tip_token, &reserve_token, &exponential_params(), &0i128,
+        &creator,
+        &tip_token,
+        &reserve_token,
+        &exponential_params(),
+        &0i128,
     );
 
     let buyer = Address::generate(&env);
@@ -583,7 +687,11 @@ fn test_sigmoid_curve_buy() {
     let (env, client, _admin, tip_token, reserve_token, creator) = setup();
 
     let curve_id = client.bc_create_curve(
-        &creator, &tip_token, &reserve_token, &sigmoid_params(), &0i128,
+        &creator,
+        &tip_token,
+        &reserve_token,
+        &sigmoid_params(),
+        &0i128,
     );
 
     let buyer = Address::generate(&env);

--- a/contracts/tipjar/tests/circuit_breaker_tests.rs
+++ b/contracts/tipjar/tests/circuit_breaker_tests.rs
@@ -3,12 +3,19 @@
 extern crate std;
 
 use soroban_sdk::{
+    symbol_short,
     testutils::{Address as _, Ledger},
-    Address, Env, symbol_short,
+    Address, Env,
 };
-use tipjar::{TipJarContract, TipJarContractClient, TipJarError, CircuitBreakerConfig};
+use tipjar::{CircuitBreakerConfig, TipJarContract, TipJarContractClient, TipJarError};
 
-fn setup() -> (Env, TipJarContractClient<'static>, Address, Address, Address) {
+fn setup() -> (
+    Env,
+    TipJarContractClient<'static>,
+    Address,
+    Address,
+    Address,
+) {
     let env = Env::default();
     env.mock_all_auths();
 
@@ -55,11 +62,11 @@ fn test_circuit_breaker_single_tip_spike() {
     // Tip exceeding limit should trigger breaker and fail
     let result = client.try_tip(&sender, &creator, &token, &1001i128);
     assert!(result.is_err());
-    
+
     // Subsequent tip should fail due to halt even if within limit
     let result2 = client.try_tip(&sender, &creator, &token, &100i128);
     assert!(result2.is_err());
-    
+
     // Check state
     let state = client.get_circuit_breaker_state().unwrap();
     assert!(state.halted_until > env.ledger().timestamp());
@@ -82,11 +89,11 @@ fn test_circuit_breaker_volume_spike() {
 
     // Tip 1: 1500 (total 1500) - OK
     client.tip(&sender, &creator, &token, &1500i128);
-    
+
     // Tip 2: 600 (total 2100) - Should trigger volume breaker
     let result = client.try_tip(&sender, &creator, &token, &600i128);
     assert!(result.is_err());
-    
+
     let state = client.get_circuit_breaker_state().unwrap();
     assert!(state.halted_until > env.ledger().timestamp());
     assert_eq!(state.trigger_count, 1);
@@ -108,10 +115,10 @@ fn test_circuit_breaker_cooldown_expiry() {
 
     // Trigger breaker
     let _ = client.try_tip(&sender, &creator, &token, &1500i128);
-    
+
     // Advance time past cooldown (1800s)
     env.ledger().with_mut(|l| l.timestamp += 1801);
-    
+
     // Should succeed now
     client.tip(&sender, &creator, &token, &100i128);
     assert_eq!(client.get_withdrawable_balance(&creator, &token), 100i128);
@@ -133,13 +140,13 @@ fn test_manual_trigger_and_reset() {
 
     // Manual trigger
     client.trigger_circuit_breaker(&admin, &symbol_short!("manual"));
-    
+
     let result = client.try_tip(&sender, &creator, &token, &100i128);
     assert!(result.is_err());
-    
+
     // Manual reset
     client.reset_circuit_breaker(&admin);
-    
+
     client.tip(&sender, &creator, &token, &100i128);
     assert_eq!(client.get_withdrawable_balance(&creator, &token), 100i128);
 }

--- a/contracts/tipjar/tests/conviction_voting_tests.rs
+++ b/contracts/tipjar/tests/conviction_voting_tests.rs
@@ -8,20 +8,20 @@ use soroban_sdk::{testutils::*, Address, Env, String, Vec};
 #[test]
 fn test_conviction_multiplier_calculation() {
     let env = Env::default();
-    
+
     // Initialize conviction voting
     // conviction::init_conviction_voting(&env);
-    
+
     // Test 1: No time locked = 1x multiplier
     let conviction_start = env.ledger().timestamp();
     // let multiplier = conviction::calculate_conviction_multiplier(&env, conviction_start);
     // assert_eq!(multiplier, 1_000_000); // 1x
-    
+
     // Test 2: Half conviction period = 2x multiplier (linear interpolation)
     // let half_period = conviction_start - (DEFAULT_CONVICTION_PERIOD / 2);
     // let multiplier = conviction::calculate_conviction_multiplier(&env, half_period);
     // assert_eq!(multiplier, 2_000_000); // 2x (halfway to 3x max)
-    
+
     // Test 3: Full conviction period = 3x multiplier (max)
     // let full_period = conviction_start - DEFAULT_CONVICTION_PERIOD;
     // let multiplier = conviction::calculate_conviction_multiplier(&env, full_period);
@@ -31,17 +31,17 @@ fn test_conviction_multiplier_calculation() {
 #[test]
 fn test_conviction_vote_recording() {
     let env = Env::default();
-    
+
     // Initialize conviction voting
     // conviction::init_conviction_voting(&env);
-    
+
     // Test recording a conviction vote
     // let voter = Address::random(&env);
     // let proposal_id = 1u64;
     // let base_voting_power = 1_000_000_000i128; // 1000 tokens
-    
+
     // conviction::record_conviction_vote(&env, &voter, proposal_id, base_voting_power);
-    
+
     // Verify vote was recorded
     // let conviction_vote = conviction::get_conviction_vote(&env, proposal_id, &voter);
     // assert!(conviction_vote.is_some());
@@ -52,22 +52,22 @@ fn test_conviction_vote_recording() {
 #[test]
 fn test_conviction_vote_change_with_decay() {
     let env = Env::default();
-    
+
     // Initialize conviction voting
     // conviction::init_conviction_voting(&env);
-    
+
     // Test changing a conviction vote with decay penalty
     // let voter = Address::random(&env);
     // let proposal_id = 1u64;
     // let initial_power = 1_000_000_000i128;
-    
+
     // Record initial vote
     // conviction::record_conviction_vote(&env, &voter, proposal_id, initial_power);
-    
+
     // Update vote with higher power
     // let new_power = 2_000_000_000i128;
     // conviction::update_conviction_vote(&env, &voter, proposal_id, new_power);
-    
+
     // Verify vote was updated
     // let conviction_vote = conviction::get_conviction_vote(&env, proposal_id, &voter);
     // assert!(conviction_vote.is_some());
@@ -80,15 +80,15 @@ fn test_conviction_vote_change_with_decay() {
 #[test]
 fn test_minimum_conviction_threshold() {
     let env = Env::default();
-    
+
     // Initialize conviction voting
     // conviction::init_conviction_voting(&env);
-    
+
     // Test that voting power below threshold is rejected
     // let voter = Address::random(&env);
     // let proposal_id = 1u64;
     // let low_power = 10_000i128; // Below default threshold
-    
+
     // This should panic
     // conviction::record_conviction_vote(&env, &voter, proposal_id, low_power);
 }
@@ -96,19 +96,19 @@ fn test_minimum_conviction_threshold() {
 #[test]
 fn test_voter_total_conviction() {
     let env = Env::default();
-    
+
     // Initialize conviction voting
     // conviction::init_conviction_voting(&env);
-    
+
     // Test tracking total conviction across multiple proposals
     // let voter = Address::random(&env);
     // let power_per_proposal = 1_000_000_000i128;
-    
+
     // Vote on multiple proposals
     // for proposal_id in 1..=3 {
     //     conviction::record_conviction_vote(&env, &voter, proposal_id as u64, power_per_proposal);
     // }
-    
+
     // Verify total conviction
     // let total = conviction::get_voter_total_conviction(&env, &voter);
     // assert_eq!(total, power_per_proposal * 3);
@@ -117,22 +117,22 @@ fn test_voter_total_conviction() {
 #[test]
 fn test_proposal_threshold_with_conviction() {
     let env = Env::default();
-    
+
     // Initialize conviction voting
     // conviction::init_conviction_voting(&env);
-    
+
     // Test that proposal threshold is reduced based on conviction
     // let voter = Address::random(&env);
-    
+
     // No conviction yet
     // let threshold_no_conviction = conviction::get_proposal_threshold_with_conviction(&env, &voter);
     // assert_eq!(threshold_no_conviction, DEFAULT_MIN_CONVICTION_THRESHOLD);
-    
+
     // Build up conviction
     // for proposal_id in 1..=10 {
     //     conviction::record_conviction_vote(&env, &voter, proposal_id as u64, 1_000_000_000i128);
     // }
-    
+
     // Threshold should be reduced
     // let threshold_with_conviction = conviction::get_proposal_threshold_with_conviction(&env, &voter);
     // assert!(threshold_with_conviction < threshold_no_conviction);
@@ -141,22 +141,22 @@ fn test_proposal_threshold_with_conviction() {
 #[test]
 fn test_conviction_history_tracking() {
     let env = Env::default();
-    
+
     // Initialize conviction voting
     // conviction::init_conviction_voting(&env);
-    
+
     // Test that conviction vote history is tracked
     // let voter = Address::random(&env);
     // let proposal_id = 1u64;
     // let base_voting_power = 1_000_000_000i128;
-    
+
     // Record vote
     // conviction::record_conviction_vote(&env, &voter, proposal_id, base_voting_power);
     // let conviction_vote = conviction::get_conviction_vote(&env, proposal_id, &voter).unwrap();
-    
+
     // Record history
     // conviction::record_conviction_history(&env, proposal_id, &voter, &conviction_vote);
-    
+
     // Verify history was recorded
     // let history = conviction::get_conviction_history(&env, proposal_id, &voter);
     // assert!(history.is_some());
@@ -166,19 +166,19 @@ fn test_conviction_history_tracking() {
 #[test]
 fn test_effective_voting_power_with_multiplier() {
     let env = Env::default();
-    
+
     // Initialize conviction voting
     // conviction::init_conviction_voting(&env);
-    
+
     // Test that effective voting power includes conviction multiplier
     // let voter = Address::random(&env);
     // let proposal_id = 1u64;
     // let base_voting_power = 1_000_000_000i128;
-    
+
     // Record vote
     // conviction::record_conviction_vote(&env, &voter, proposal_id, base_voting_power);
     // let conviction_vote = conviction::get_conviction_vote(&env, proposal_id, &voter).unwrap();
-    
+
     // At start, multiplier should be 1x
     // let effective_power = conviction::calculate_effective_voting_power(&env, &conviction_vote);
     // assert_eq!(effective_power, base_voting_power);
@@ -187,22 +187,22 @@ fn test_effective_voting_power_with_multiplier() {
 #[test]
 fn test_accumulated_conviction_over_time() {
     let env = Env::default();
-    
+
     // Initialize conviction voting
     // conviction::init_conviction_voting(&env);
-    
+
     // Test that conviction accumulates over time
     // let voter = Address::random(&env);
     // let proposal_id = 1u64;
     // let base_voting_power = 1_000_000_000i128;
-    
+
     // Record vote
     // conviction::record_conviction_vote(&env, &voter, proposal_id, base_voting_power);
     // let conviction_vote = conviction::get_conviction_vote(&env, proposal_id, &voter).unwrap();
-    
+
     // Initial accumulated conviction should be 0
     // assert_eq!(conviction_vote.accumulated_conviction, 0);
-    
+
     // After time passes, accumulated conviction should increase
     // (This would require advancing the ledger timestamp in tests)
 }
@@ -210,18 +210,18 @@ fn test_accumulated_conviction_over_time() {
 #[test]
 fn test_conviction_config_update() {
     let env = Env::default();
-    
+
     // Initialize conviction voting
     // conviction::init_conviction_voting(&env);
-    
+
     // Test updating conviction voting configuration
     // let mut config = conviction::get_conviction_config(&env);
     // let original_period = config.conviction_period;
-    
+
     // Update configuration
     // config.conviction_period = original_period * 2;
     // conviction::update_conviction_config(&env, &config);
-    
+
     // Verify update
     // let updated_config = conviction::get_conviction_config(&env);
     // assert_eq!(updated_config.conviction_period, original_period * 2);

--- a/contracts/tipjar/tests/credit_tests.rs
+++ b/contracts/tipjar/tests/credit_tests.rs
@@ -8,7 +8,13 @@ use soroban_sdk::{
 };
 use tipjar::{CreditConfig, TipJarContract, TipJarContractClient};
 
-fn setup() -> (Env, TipJarContractClient<'static>, Address, Address, Address) {
+fn setup() -> (
+    Env,
+    TipJarContractClient<'static>,
+    Address,
+    Address,
+    Address,
+) {
     let env = Env::default();
     env.mock_all_auths();
 
@@ -41,7 +47,16 @@ fn provide_lending_liquidity(
     amount: i128,
 ) {
     // insurance_contribute routes premium into platform fee balance.
-    client.insurance_set_config(admin, &1i128, &2_000_000i128, &500u32, &8_000u32, &0u64, &0u32, &0u32);
+    client.insurance_set_config(
+        admin,
+        &1i128,
+        &2_000_000i128,
+        &500u32,
+        &8_000u32,
+        &0u64,
+        &0u32,
+        &0u32,
+    );
     let funder = Address::generate(env);
     let token_client = soroban_sdk::token::StellarAssetClient::new(env, token);
     token_client.mint(&funder, &(amount + 10_000));
@@ -55,9 +70,9 @@ fn test_credit_limit_and_borrow() {
 
     let config = CreditConfig {
         max_credit_ratio_bps: 2000, // 20%
-        interest_rate_bps: 100,      // 1% per 30 days
+        interest_rate_bps: 100,     // 1% per 30 days
         min_total_tips: 1000,
-        repayment_share_bps: 5000,   // 50%
+        repayment_share_bps: 5000, // 50%
         enabled: true,
     };
     client.set_credit_config(&admin, &config);
@@ -90,9 +105,9 @@ fn test_interest_accrual_and_manual_repayment() {
 
     let config = CreditConfig {
         max_credit_ratio_bps: 5000, // 50%
-        interest_rate_bps: 1000,     // 10% per 30 days
+        interest_rate_bps: 1000,    // 10% per 30 days
         min_total_tips: 0,
-        repayment_share_bps: 0,      // disable auto repayment for this test
+        repayment_share_bps: 0, // disable auto repayment for this test
         enabled: true,
     };
     client.set_credit_config(&admin, &config);

--- a/contracts/tipjar/tests/delegation_tests.rs
+++ b/contracts/tipjar/tests/delegation_tests.rs
@@ -2,10 +2,19 @@
 
 extern crate std;
 
-use soroban_sdk::{testutils::{Address as _, Ledger}, Address, Env, String};
+use soroban_sdk::{
+    testutils::{Address as _, Ledger},
+    Address, Env, String,
+};
 use tipjar::{DataKey, Delegation, TipJarContract, TipJarContractClient, TipJarError};
 
-fn setup() -> (Env, TipJarContractClient<'static>, Address, Address, Address) {
+fn setup() -> (
+    Env,
+    TipJarContractClient<'static>,
+    Address,
+    Address,
+    Address,
+) {
     let env = Env::default();
     env.mock_all_auths();
 
@@ -42,7 +51,10 @@ fn test_delegate_withdrawal_and_limit_tracking() {
     client.withdraw_as_delegate(&delegate, &creator, &token, &200i128);
 
     assert_eq!(client.get_withdrawable_balance(&creator, &token), 300i128);
-    assert_eq!(soroban_sdk::token::StellarAssetClient::new(&env, &token).balance(&delegate), 200i128);
+    assert_eq!(
+        soroban_sdk::token::StellarAssetClient::new(&env, &token).balance(&delegate),
+        200i128
+    );
 
     let delegation = client.get_delegation(&creator, &delegate).unwrap();
     assert_eq!(delegation.used_amount, 200i128);

--- a/contracts/tipjar/tests/derivatives_tests.rs
+++ b/contracts/tipjar/tests/derivatives_tests.rs
@@ -15,18 +15,14 @@ use soroban_sdk::{
     token, Address, Env,
 };
 use tipjar::{
-    derivatives::{
-        self, DerivativeKind, DerivativeStatus,
-        PRICE_PRECISION,
-    },
     derivatives::pricing::{
-        black_scholes, futures_fair_value, swap_fair_value, PricingInput,
-        isqrt, norm_cdf,
+        black_scholes, futures_fair_value, isqrt, norm_cdf, swap_fair_value, PricingInput,
     },
     derivatives::risk::{
-        check_margin_health, portfolio_health, find_liquidatable, HEALTH_PRECISION,
+        check_margin_health, find_liquidatable, portfolio_health, HEALTH_PRECISION,
     },
     derivatives::settlement,
+    derivatives::{self, DerivativeKind, DerivativeStatus, PRICE_PRECISION},
 };
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
@@ -46,21 +42,31 @@ fn mint(env: &Env, token: &Address, to: &Address, amount: i128) {
 fn test_isqrt_basic() {
     assert_eq!(isqrt(0), 0);
     assert_eq!(isqrt(PRICE_PRECISION * PRICE_PRECISION), PRICE_PRECISION);
-    assert_eq!(isqrt(4 * PRICE_PRECISION * PRICE_PRECISION), 2 * PRICE_PRECISION);
+    assert_eq!(
+        isqrt(4 * PRICE_PRECISION * PRICE_PRECISION),
+        2 * PRICE_PRECISION
+    );
 }
 
 #[test]
 fn test_norm_cdf_at_zero() {
     let p = norm_cdf(0);
     // N(0) ≈ 0.5
-    assert!((p - 500_000).abs() < 5_000, "N(0) should be ~0.5, got {}", p);
+    assert!(
+        (p - 500_000).abs() < 5_000,
+        "N(0) should be ~0.5, got {}",
+        p
+    );
 }
 
 #[test]
 fn test_norm_cdf_symmetry() {
     let p1 = norm_cdf(PRICE_PRECISION);
     let p_neg1 = norm_cdf(-PRICE_PRECISION);
-    assert!((p1 + p_neg1 - PRICE_PRECISION).abs() < 10_000, "symmetry failed");
+    assert!(
+        (p1 + p_neg1 - PRICE_PRECISION).abs() < 10_000,
+        "symmetry failed"
+    );
 }
 
 #[test]
@@ -75,7 +81,11 @@ fn test_black_scholes_atm() {
     let prices = black_scholes(&input).expect("should price ATM option");
     // ATM call and put should be close
     let diff = (prices.call - prices.put).abs();
-    assert!(diff < PRICE_PRECISION / 10, "ATM call/put diff too large: {}", diff);
+    assert!(
+        diff < PRICE_PRECISION / 10,
+        "ATM call/put diff too large: {}",
+        diff
+    );
     assert!(prices.call > 0, "call should be positive");
     assert!(prices.put > 0, "put should be positive");
 }
@@ -83,24 +93,36 @@ fn test_black_scholes_atm() {
 #[test]
 fn test_black_scholes_deep_itm_call() {
     let input = PricingInput {
-        spot: 2 * PRICE_PRECISION,  // S = 2.0
-        strike: PRICE_PRECISION,    // K = 1.0
+        spot: 2 * PRICE_PRECISION, // S = 2.0
+        strike: PRICE_PRECISION,   // K = 1.0
         time_to_expiry_secs: 86_400 * 30,
         volatility_bps: 3_000,
         risk_free_rate_bps: 500,
     };
     let prices = black_scholes(&input).expect("should price deep ITM call");
     // Deep ITM call ≈ S - K = 1.0
-    assert!(prices.call > PRICE_PRECISION * 9 / 10, "deep ITM call should be close to intrinsic");
+    assert!(
+        prices.call > PRICE_PRECISION * 9 / 10,
+        "deep ITM call should be close to intrinsic"
+    );
     // Deep ITM put ≈ 0
-    assert!(prices.put < PRICE_PRECISION / 10, "deep ITM put should be near zero");
+    assert!(
+        prices.put < PRICE_PRECISION / 10,
+        "deep ITM put should be near zero"
+    );
 }
 
 #[test]
 fn test_futures_fair_value_above_spot() {
     let fair = futures_fair_value(PRICE_PRECISION, 86_400 * 365, 500);
-    assert!(fair > PRICE_PRECISION, "futures should be above spot with positive rate");
-    assert!(fair < 11 * PRICE_PRECISION / 10, "futures should be < 1.1x spot");
+    assert!(
+        fair > PRICE_PRECISION,
+        "futures should be above spot with positive rate"
+    );
+    assert!(
+        fair < 11 * PRICE_PRECISION / 10,
+        "futures should be < 1.1x spot"
+    );
 }
 
 #[test]
@@ -234,8 +256,14 @@ fn test_update_mark_price() {
 
     let now = env.ledger().timestamp();
     let id = derivatives::open(
-        &env, &long, DerivativeKind::Future, &token,
-        1_000_000, PRICE_PRECISION, 0, now + 86_400,
+        &env,
+        &long,
+        DerivativeKind::Future,
+        &token,
+        1_000_000,
+        PRICE_PRECISION,
+        0,
+        now + 86_400,
     );
     derivatives::match_contract(&env, &short, id);
 
@@ -262,8 +290,14 @@ fn test_margin_health_healthy() {
 
     let now = env.ledger().timestamp();
     let id = derivatives::open(
-        &env, &long, DerivativeKind::Future, &token,
-        1_000_000, PRICE_PRECISION, 0, now + 86_400,
+        &env,
+        &long,
+        DerivativeKind::Future,
+        &token,
+        1_000_000,
+        PRICE_PRECISION,
+        0,
+        now + 86_400,
     );
     derivatives::match_contract(&env, &short, id);
 
@@ -311,8 +345,14 @@ fn test_settle_expired_futures_long_profit() {
     let expires_at = now + 100;
 
     let id = derivatives::open(
-        &env, &long, DerivativeKind::Future, &token,
-        1_000_000, PRICE_PRECISION, 0, expires_at,
+        &env,
+        &long,
+        DerivativeKind::Future,
+        &token,
+        1_000_000,
+        PRICE_PRECISION,
+        0,
+        expires_at,
     );
     derivatives::match_contract(&env, &short, id);
 
@@ -344,8 +384,14 @@ fn test_settle_expired_call_option_itm() {
     let expires_at = now + 100;
 
     let id = derivatives::open(
-        &env, &writer, DerivativeKind::Call, &token,
-        1_000_000, PRICE_PRECISION, 50_000, expires_at,
+        &env,
+        &writer,
+        DerivativeKind::Call,
+        &token,
+        1_000_000,
+        PRICE_PRECISION,
+        50_000,
+        expires_at,
     );
     derivatives::match_contract(&env, &holder, id);
 
@@ -375,8 +421,14 @@ fn test_settle_expired_call_option_otm() {
     let expires_at = now + 100;
 
     let id = derivatives::open(
-        &env, &writer, DerivativeKind::Call, &token,
-        1_000_000, PRICE_PRECISION, 50_000, expires_at,
+        &env,
+        &writer,
+        DerivativeKind::Call,
+        &token,
+        1_000_000,
+        PRICE_PRECISION,
+        50_000,
+        expires_at,
     );
     derivatives::match_contract(&env, &holder, id);
 
@@ -406,8 +458,14 @@ fn test_exercise_call_option_itm() {
     let expires_at = now + 86_400;
 
     let id = derivatives::open(
-        &env, &writer, DerivativeKind::Call, &token,
-        1_000_000, PRICE_PRECISION, 50_000, expires_at,
+        &env,
+        &writer,
+        DerivativeKind::Call,
+        &token,
+        1_000_000,
+        PRICE_PRECISION,
+        50_000,
+        expires_at,
     );
     derivatives::match_contract(&env, &holder, id);
 

--- a/contracts/tipjar/tests/events_leaderboard_snapshot_tests.rs
+++ b/contracts/tipjar/tests/events_leaderboard_snapshot_tests.rs
@@ -13,7 +13,13 @@ use tipjar::{
 
 // ── helpers ──────────────────────────────────────────────────────────────────
 
-fn setup() -> (Env, TipJarContractClient<'static>, Address, Address, Address) {
+fn setup() -> (
+    Env,
+    TipJarContractClient<'static>,
+    Address,
+    Address,
+    Address,
+) {
     let env = Env::default();
     env.mock_all_auths();
 

--- a/contracts/tipjar/tests/fractional_ownership_tests.rs
+++ b/contracts/tipjar/tests/fractional_ownership_tests.rs
@@ -28,7 +28,9 @@ fn test_mint_fractions_creates_pool() {
 
     client.mint_fractions(&creator, &1_000u64, &10i128);
 
-    let pool = client.get_fraction_pool(&creator).expect("pool should exist");
+    let pool = client
+        .get_fraction_pool(&creator)
+        .expect("pool should exist");
     assert_eq!(pool.total_supply, 1_000);
     assert_eq!(pool.buyout_price_per_fraction, 10);
     assert_eq!(pool.pending_revenue, 0);

--- a/contracts/tipjar/tests/homomorphic_encryption_tests.rs
+++ b/contracts/tipjar/tests/homomorphic_encryption_tests.rs
@@ -297,7 +297,7 @@ fn test_multiply_bytes_by_scalar() {
 // Integration test examples (require full Soroban environment)
 
 #[test]
-#[ignore]  // Requires Soroban test environment
+#[ignore] // Requires Soroban test environment
 fn integration_test_full_encrypted_tip_flow() {
     // Full flow: init -> encrypt -> aggregate -> reveal
     // 1. Initialize homomorphic encryption
@@ -309,7 +309,7 @@ fn integration_test_full_encrypted_tip_flow() {
 }
 
 #[test]
-#[ignore]  // Requires Soroban test environment
+#[ignore] // Requires Soroban test environment
 fn integration_test_key_rotation_with_existing_tips() {
     // Test key rotation with existing encrypted tips
     // 1. Create tips with key v1
@@ -320,7 +320,7 @@ fn integration_test_key_rotation_with_existing_tips() {
 }
 
 #[test]
-#[ignore]  // Requires Soroban test environment
+#[ignore] // Requires Soroban test environment
 fn integration_test_concurrent_operations() {
     // Test concurrent encrypted operations
     // 1. Multiple creators creating tips simultaneously
@@ -330,7 +330,7 @@ fn integration_test_concurrent_operations() {
 }
 
 #[test]
-#[ignore]  // Requires Soroban test environment
+#[ignore] // Requires Soroban test environment
 fn integration_test_privacy_guarantees() {
     // Test privacy guarantees
     // 1. Verify ciphertexts don't leak information

--- a/contracts/tipjar/tests/insurance_tests.rs
+++ b/contracts/tipjar/tests/insurance_tests.rs
@@ -3,12 +3,18 @@
 extern crate std;
 
 use soroban_sdk::{
-    testutils::{Address as _, Ledger, BytesN as _},
-    Address, Env, BytesN, Vec,
+    testutils::{Address as _, BytesN as _, Ledger},
+    Address, BytesN, Env, Vec,
 };
-use tipjar::{TipJarContract, TipJarContractClient, TipJarError, ClaimStatus, InsurancePoolConfig};
+use tipjar::{ClaimStatus, InsurancePoolConfig, TipJarContract, TipJarContractClient, TipJarError};
 
-fn setup() -> (Env, TipJarContractClient<'static>, Address, Address, Address) {
+fn setup() -> (
+    Env,
+    TipJarContractClient<'static>,
+    Address,
+    Address,
+    Address,
+) {
     let env = Env::default();
     env.mock_all_auths();
 
@@ -37,14 +43,13 @@ fn test_insurance_config() {
     let (env, client, _sender, admin, _token) = setup();
 
     client.insurance_set_config(
-        &admin,
-        &100i128,    // min_contribution
-        &10000i128,  // max_contribution
-        &200u32,     // premium_rate_bps (2%)
-        &5000u32,    // payout_ratio_bps (50%)
-        &3600u64,    // claim_cooldown
-        &100u32,     // admin_fee_bps
-        &100u32,     // tip_premium_bps (1%)
+        &admin, &100i128,   // min_contribution
+        &10000i128, // max_contribution
+        &200u32,    // premium_rate_bps (2%)
+        &5000u32,   // payout_ratio_bps (50%)
+        &3600u64,   // claim_cooldown
+        &100u32,    // admin_fee_bps
+        &100u32,    // tip_premium_bps (1%)
     );
 
     let config = client.insurance_get_config();
@@ -61,9 +66,7 @@ fn test_insurance_manual_contribution() {
     let (env, client, creator, admin, token) = setup();
 
     // Configure insurance
-    client.insurance_set_config(
-        &admin, &100, &10000, &200, &5000, &3600, &100, &100
-    );
+    client.insurance_set_config(&admin, &100, &10000, &200, &5000, &3600, &100, &100);
 
     // Fund creator for contribution
     let token_asset = soroban_sdk::token::StellarAssetClient::new(&env, &token);
@@ -90,9 +93,7 @@ fn test_tip_automatic_premium() {
     let creator = Address::generate(&env);
 
     // Configure insurance with 1% tip premium
-    client.insurance_set_config(
-        &admin, &100, &10000, &200, &5000, &3600, &100, &100
-    );
+    client.insurance_set_config(&admin, &100, &10000, &200, &5000, &3600, &100, &100);
 
     client.tip(&sender, &creator, &token, &10000i128);
 
@@ -114,14 +115,14 @@ fn test_tip_automatic_premium() {
 fn test_insurance_claim_flow() {
     let (env, client, creator, admin, token) = setup();
     let sender = Address::generate(&env);
-    
+
     // Fund sender
     let token_asset = soroban_sdk::token::StellarAssetClient::new(&env, &token);
     token_asset.mint(&sender, &100000i128);
 
     // Configure insurance: 1% premium, 100% payout ratio for simplicity
     client.insurance_set_config(
-        &admin, &100, &100000, &200, &10000, &3600, &100, &1000 // 10% premium
+        &admin, &100, &100000, &200, &10000, &3600, &100, &1000, // 10% premium
     );
 
     // Tip creator to build pool and coverage
@@ -147,10 +148,10 @@ fn test_insurance_claim_flow() {
     // Pay claim
     let old_creator_bal = token_asset.balance(&creator);
     client.insurance_pay_claim(&admin, &claim_id);
-    
+
     let claim = client.insurance_get_claim(&claim_id);
     assert!(matches!(claim.status, ClaimStatus::Paid));
-    
+
     let new_creator_bal = token_asset.balance(&creator);
     assert_eq!(new_creator_bal - old_creator_bal, 500);
 
@@ -163,10 +164,8 @@ fn test_insurance_claim_flow() {
 #[should_panic(expected = "HostError: Error(Contract, #55)")] // NoCoverage
 fn test_claim_without_coverage_fails() {
     let (env, client, creator, admin, token) = setup();
-    
-    client.insurance_set_config(
-        &admin, &100, &10000, &200, &5000, &3600, &100, &100
-    );
+
+    client.insurance_set_config(&admin, &100, &10000, &200, &5000, &3600, &100, &100);
 
     let tx_hash = BytesN::from_array(&env, &[0u8; 32]);
     client.insurance_submit_claim(&creator, &token, &500i128, &tx_hash);
@@ -179,11 +178,11 @@ fn test_claim_exceeding_coverage_fails() {
     let creator = Address::generate(&env);
 
     client.insurance_set_config(
-        &admin, &100, &10000, &200, &5000, &3600, &100, &100 // 50% payout ratio
+        &admin, &100, &10000, &200, &5000, &3600, &100, &100, // 50% payout ratio
     );
 
     // Tip to build coverage
-    client.tip(&sender, &creator, &token, &2000i128); 
+    client.tip(&sender, &creator, &token, &2000i128);
     // Net=1980. Premium=20. Coverage = 19 * 50% = 9.
 
     let tx_hash = BytesN::from_array(&env, &[0u8; 32]);
@@ -194,15 +193,13 @@ fn test_claim_exceeding_coverage_fails() {
 fn test_insurance_batch_processing() {
     let (env, client, creator, admin, token) = setup();
     let sender = Address::generate(&env);
-    
+
     // Fund sender
     let token_asset = soroban_sdk::token::StellarAssetClient::new(&env, &token);
     token_asset.mint(&sender, &100000i128);
 
     // Configure insurance
-    client.insurance_set_config(
-        &admin, &100, &100000, &200, &10000, &3600, &100, &1000
-    );
+    client.insurance_set_config(&admin, &100, &100000, &200, &10000, &3600, &100, &1000);
 
     // Tip creator to build coverage
     client.tip(&sender, &creator, &token, &20000i128);
@@ -217,18 +214,38 @@ fn test_insurance_batch_processing() {
     claim_ids.push_back(claim_id_2);
 
     // Batch approve
-    client.insurance_process_claims_batch(&admin, &claim_ids, &soroban_sdk::String::from_str(&env, "approve"));
+    client.insurance_process_claims_batch(
+        &admin,
+        &claim_ids,
+        &soroban_sdk::String::from_str(&env, "approve"),
+    );
 
-    assert!(matches!(client.insurance_get_claim(&claim_id_1).status, ClaimStatus::Approved));
-    assert!(matches!(client.insurance_get_claim(&claim_id_2).status, ClaimStatus::Approved));
+    assert!(matches!(
+        client.insurance_get_claim(&claim_id_1).status,
+        ClaimStatus::Approved
+    ));
+    assert!(matches!(
+        client.insurance_get_claim(&claim_id_2).status,
+        ClaimStatus::Approved
+    ));
 
     // Batch pay
     let old_creator_bal = token_asset.balance(&creator);
-    client.insurance_process_claims_batch(&admin, &claim_ids, &soroban_sdk::String::from_str(&env, "pay"));
+    client.insurance_process_claims_batch(
+        &admin,
+        &claim_ids,
+        &soroban_sdk::String::from_str(&env, "pay"),
+    );
 
-    assert!(matches!(client.insurance_get_claim(&claim_id_1).status, ClaimStatus::Paid));
-    assert!(matches!(client.insurance_get_claim(&claim_id_2).status, ClaimStatus::Paid));
-    
+    assert!(matches!(
+        client.insurance_get_claim(&claim_id_1).status,
+        ClaimStatus::Paid
+    ));
+    assert!(matches!(
+        client.insurance_get_claim(&claim_id_2).status,
+        ClaimStatus::Paid
+    ));
+
     let new_creator_bal = token_asset.balance(&creator);
     assert_eq!(new_creator_bal - old_creator_bal, 800);
 

--- a/contracts/tipjar/tests/liquidity_mining_tests.rs
+++ b/contracts/tipjar/tests/liquidity_mining_tests.rs
@@ -35,8 +35,7 @@ fn setup() -> (
     client.add_token(&admin, &reward_token);
 
     // Mint reward tokens to admin for program funding
-    soroban_sdk::token::StellarAssetClient::new(&env, &reward_token)
-        .mint(&admin, &10_000_000i128);
+    soroban_sdk::token::StellarAssetClient::new(&env, &reward_token).mint(&admin, &10_000_000i128);
 
     (env, client, admin, lp_token, reward_token)
 }
@@ -72,10 +71,10 @@ fn test_create_program_returns_id() {
         &lp_token,
         &reward_token,
         &1_000_000i128,
-        &2_000u32,  // 20% APY
-        &0u64,      // no cliff
+        &2_000u32,      // 20% APY
+        &0u64,          // no cliff
         &31_536_000u64, // 1 year vesting
-        &0u64,      // no end
+        &0u64,          // no end
     );
 
     assert_eq!(program_id, 1);
@@ -91,8 +90,8 @@ fn test_create_program_stores_config() {
         &reward_token,
         &500_000i128,
         &1_000u32,
-        &86_400u64,     // 1 day cliff
-        &2_592_000u64,  // 30 day vesting
+        &86_400u64,    // 1 day cliff
+        &2_592_000u64, // 30 day vesting
         &0u64,
     );
 
@@ -110,8 +109,14 @@ fn test_create_program_zero_rewards_fails() {
     let (env, client, admin, lp_token, reward_token) = setup();
 
     let result = client.try_lm_create_program(
-        &admin, &lp_token, &reward_token,
-        &0i128, &1_000u32, &0u64, &86_400u64, &0u64,
+        &admin,
+        &lp_token,
+        &reward_token,
+        &0i128,
+        &1_000u32,
+        &0u64,
+        &86_400u64,
+        &0u64,
     );
     assert_eq!(result, Err(Ok(TipJarError::InvalidAmount)));
 }
@@ -121,8 +126,14 @@ fn test_create_program_zero_rate_fails() {
     let (env, client, admin, lp_token, reward_token) = setup();
 
     let result = client.try_lm_create_program(
-        &admin, &lp_token, &reward_token,
-        &1_000_000i128, &0u32, &0u64, &86_400u64, &0u64,
+        &admin,
+        &lp_token,
+        &reward_token,
+        &1_000_000i128,
+        &0u32,
+        &0u64,
+        &86_400u64,
+        &0u64,
     );
     assert_eq!(result, Err(Ok(TipJarError::LmInvalidRate)));
 }
@@ -132,9 +143,12 @@ fn test_create_program_cliff_exceeds_duration_fails() {
     let (env, client, admin, lp_token, reward_token) = setup();
 
     let result = client.try_lm_create_program(
-        &admin, &lp_token, &reward_token,
-        &1_000_000i128, &1_000u32,
-        &2_000u64,  // cliff > duration
+        &admin,
+        &lp_token,
+        &reward_token,
+        &1_000_000i128,
+        &1_000u32,
+        &2_000u64, // cliff > duration
         &1_000u64,
         &0u64,
     );
@@ -148,8 +162,14 @@ fn test_stake_updates_position_and_program() {
     let (env, client, admin, lp_token, reward_token) = setup();
 
     let program_id = client.lm_create_program(
-        &admin, &lp_token, &reward_token,
-        &1_000_000i128, &2_000u32, &0u64, &31_536_000u64, &0u64,
+        &admin,
+        &lp_token,
+        &reward_token,
+        &1_000_000i128,
+        &2_000u32,
+        &0u64,
+        &31_536_000u64,
+        &0u64,
     );
 
     let provider = Address::generate(&env);
@@ -169,8 +189,14 @@ fn test_stake_zero_amount_fails() {
     let (env, client, admin, lp_token, reward_token) = setup();
 
     let program_id = client.lm_create_program(
-        &admin, &lp_token, &reward_token,
-        &1_000_000i128, &2_000u32, &0u64, &31_536_000u64, &0u64,
+        &admin,
+        &lp_token,
+        &reward_token,
+        &1_000_000i128,
+        &2_000u32,
+        &0u64,
+        &31_536_000u64,
+        &0u64,
     );
 
     let provider = Address::generate(&env);
@@ -183,8 +209,14 @@ fn test_stake_inactive_program_fails() {
     let (env, client, admin, lp_token, reward_token) = setup();
 
     let program_id = client.lm_create_program(
-        &admin, &lp_token, &reward_token,
-        &1_000_000i128, &2_000u32, &0u64, &31_536_000u64, &0u64,
+        &admin,
+        &lp_token,
+        &reward_token,
+        &1_000_000i128,
+        &2_000u32,
+        &0u64,
+        &31_536_000u64,
+        &0u64,
     );
 
     client.lm_deactivate_program(&admin, &program_id);
@@ -201,8 +233,14 @@ fn test_stake_multiple_providers() {
     let (env, client, admin, lp_token, reward_token) = setup();
 
     let program_id = client.lm_create_program(
-        &admin, &lp_token, &reward_token,
-        &1_000_000i128, &2_000u32, &0u64, &31_536_000u64, &0u64,
+        &admin,
+        &lp_token,
+        &reward_token,
+        &1_000_000i128,
+        &2_000u32,
+        &0u64,
+        &31_536_000u64,
+        &0u64,
     );
 
     let p1 = Address::generate(&env);
@@ -224,8 +262,14 @@ fn test_unstake_reduces_position() {
     let (env, client, admin, lp_token, reward_token) = setup();
 
     let program_id = client.lm_create_program(
-        &admin, &lp_token, &reward_token,
-        &1_000_000i128, &2_000u32, &0u64, &31_536_000u64, &0u64,
+        &admin,
+        &lp_token,
+        &reward_token,
+        &1_000_000i128,
+        &2_000u32,
+        &0u64,
+        &31_536_000u64,
+        &0u64,
     );
 
     let provider = Address::generate(&env);
@@ -247,8 +291,14 @@ fn test_unstake_more_than_staked_fails() {
     let (env, client, admin, lp_token, reward_token) = setup();
 
     let program_id = client.lm_create_program(
-        &admin, &lp_token, &reward_token,
-        &1_000_000i128, &2_000u32, &0u64, &31_536_000u64, &0u64,
+        &admin,
+        &lp_token,
+        &reward_token,
+        &1_000_000i128,
+        &2_000u32,
+        &0u64,
+        &31_536_000u64,
+        &0u64,
     );
 
     let provider = Address::generate(&env);
@@ -266,9 +316,14 @@ fn test_rewards_accrue_over_time() {
     let (env, client, admin, lp_token, reward_token) = setup();
 
     let program_id = client.lm_create_program(
-        &admin, &lp_token, &reward_token,
-        &1_000_000i128, &10_000u32, // 100% APY
-        &0u64, &31_536_000u64, &0u64,
+        &admin,
+        &lp_token,
+        &reward_token,
+        &1_000_000i128,
+        &10_000u32, // 100% APY
+        &0u64,
+        &31_536_000u64,
+        &0u64,
     );
 
     let provider = Address::generate(&env);
@@ -289,8 +344,14 @@ fn test_no_rewards_before_staking() {
     let (env, client, admin, lp_token, reward_token) = setup();
 
     let program_id = client.lm_create_program(
-        &admin, &lp_token, &reward_token,
-        &1_000_000i128, &2_000u32, &0u64, &31_536_000u64, &0u64,
+        &admin,
+        &lp_token,
+        &reward_token,
+        &1_000_000i128,
+        &2_000u32,
+        &0u64,
+        &31_536_000u64,
+        &0u64,
     );
 
     let provider = Address::generate(&env);
@@ -306,9 +367,14 @@ fn test_nothing_vested_before_cliff() {
 
     let cliff = 86_400u64; // 1 day
     let program_id = client.lm_create_program(
-        &admin, &lp_token, &reward_token,
-        &1_000_000i128, &10_000u32,
-        &cliff, &(cliff * 30), &0u64,
+        &admin,
+        &lp_token,
+        &reward_token,
+        &1_000_000i128,
+        &10_000u32,
+        &cliff,
+        &(cliff * 30),
+        &0u64,
     );
 
     let provider = Address::generate(&env);
@@ -330,9 +396,14 @@ fn test_rewards_vest_after_cliff() {
     let cliff = 86_400u64;
     let duration = cliff * 30;
     let program_id = client.lm_create_program(
-        &admin, &lp_token, &reward_token,
-        &1_000_000i128, &10_000u32,
-        &cliff, &duration, &0u64,
+        &admin,
+        &lp_token,
+        &reward_token,
+        &1_000_000i128,
+        &10_000u32,
+        &cliff,
+        &duration,
+        &0u64,
     );
 
     let provider = Address::generate(&env);
@@ -353,9 +424,14 @@ fn test_claim_before_cliff_fails() {
 
     let cliff = 86_400u64;
     let program_id = client.lm_create_program(
-        &admin, &lp_token, &reward_token,
-        &1_000_000i128, &10_000u32,
-        &cliff, &(cliff * 30), &0u64,
+        &admin,
+        &lp_token,
+        &reward_token,
+        &1_000_000i128,
+        &10_000u32,
+        &cliff,
+        &(cliff * 30),
+        &0u64,
     );
 
     let provider = Address::generate(&env);
@@ -376,9 +452,14 @@ fn test_claim_after_cliff_succeeds() {
     let cliff = 0u64; // no cliff for simplicity
     let duration = 31_536_000u64;
     let program_id = client.lm_create_program(
-        &admin, &lp_token, &reward_token,
-        &1_000_000i128, &10_000u32, // 100% APY
-        &cliff, &duration, &0u64,
+        &admin,
+        &lp_token,
+        &reward_token,
+        &1_000_000i128,
+        &10_000u32, // 100% APY
+        &cliff,
+        &duration,
+        &0u64,
     );
 
     let provider = Address::generate(&env);
@@ -402,8 +483,14 @@ fn test_boost_increases_multiplier() {
     let (env, client, admin, lp_token, reward_token) = setup();
 
     let program_id = client.lm_create_program(
-        &admin, &lp_token, &reward_token,
-        &1_000_000i128, &2_000u32, &0u64, &31_536_000u64, &0u64,
+        &admin,
+        &lp_token,
+        &reward_token,
+        &1_000_000i128,
+        &2_000u32,
+        &0u64,
+        &31_536_000u64,
+        &0u64,
     );
 
     let provider = Address::generate(&env);
@@ -426,8 +513,14 @@ fn test_full_year_lock_gives_max_boost() {
     let (env, client, admin, lp_token, reward_token) = setup();
 
     let program_id = client.lm_create_program(
-        &admin, &lp_token, &reward_token,
-        &1_000_000i128, &2_000u32, &0u64, &31_536_000u64, &0u64,
+        &admin,
+        &lp_token,
+        &reward_token,
+        &1_000_000i128,
+        &2_000u32,
+        &0u64,
+        &31_536_000u64,
+        &0u64,
     );
 
     let provider = Address::generate(&env);
@@ -446,8 +539,14 @@ fn test_boost_zero_duration_fails() {
     let (env, client, admin, lp_token, reward_token) = setup();
 
     let program_id = client.lm_create_program(
-        &admin, &lp_token, &reward_token,
-        &1_000_000i128, &2_000u32, &0u64, &31_536_000u64, &0u64,
+        &admin,
+        &lp_token,
+        &reward_token,
+        &1_000_000i128,
+        &2_000u32,
+        &0u64,
+        &31_536_000u64,
+        &0u64,
     );
 
     let provider = Address::generate(&env);
@@ -463,8 +562,14 @@ fn test_boost_lower_than_current_fails() {
     let (env, client, admin, lp_token, reward_token) = setup();
 
     let program_id = client.lm_create_program(
-        &admin, &lp_token, &reward_token,
-        &1_000_000i128, &2_000u32, &0u64, &31_536_000u64, &0u64,
+        &admin,
+        &lp_token,
+        &reward_token,
+        &1_000_000i128,
+        &2_000u32,
+        &0u64,
+        &31_536_000u64,
+        &0u64,
     );
 
     let provider = Address::generate(&env);
@@ -486,8 +591,14 @@ fn test_deactivate_program() {
     let (env, client, admin, lp_token, reward_token) = setup();
 
     let program_id = client.lm_create_program(
-        &admin, &lp_token, &reward_token,
-        &1_000_000i128, &2_000u32, &0u64, &31_536_000u64, &0u64,
+        &admin,
+        &lp_token,
+        &reward_token,
+        &1_000_000i128,
+        &2_000u32,
+        &0u64,
+        &31_536_000u64,
+        &0u64,
     );
 
     client.lm_deactivate_program(&admin, &program_id);
@@ -501,8 +612,14 @@ fn test_deactivate_already_inactive_fails() {
     let (env, client, admin, lp_token, reward_token) = setup();
 
     let program_id = client.lm_create_program(
-        &admin, &lp_token, &reward_token,
-        &1_000_000i128, &2_000u32, &0u64, &31_536_000u64, &0u64,
+        &admin,
+        &lp_token,
+        &reward_token,
+        &1_000_000i128,
+        &2_000u32,
+        &0u64,
+        &31_536_000u64,
+        &0u64,
     );
 
     client.lm_deactivate_program(&admin, &program_id);
@@ -518,12 +635,24 @@ fn test_provider_programs_tracked() {
     let (env, client, admin, lp_token, reward_token) = setup();
 
     let p1 = client.lm_create_program(
-        &admin, &lp_token, &reward_token,
-        &500_000i128, &2_000u32, &0u64, &31_536_000u64, &0u64,
+        &admin,
+        &lp_token,
+        &reward_token,
+        &500_000i128,
+        &2_000u32,
+        &0u64,
+        &31_536_000u64,
+        &0u64,
     );
     let p2 = client.lm_create_program(
-        &admin, &lp_token, &reward_token,
-        &500_000i128, &3_000u32, &0u64, &31_536_000u64, &0u64,
+        &admin,
+        &lp_token,
+        &reward_token,
+        &500_000i128,
+        &3_000u32,
+        &0u64,
+        &31_536_000u64,
+        &0u64,
     );
 
     let provider = Address::generate(&env);
@@ -542,8 +671,14 @@ fn test_lm_stake_paused_fails() {
     let (env, client, admin, lp_token, reward_token) = setup();
 
     let program_id = client.lm_create_program(
-        &admin, &lp_token, &reward_token,
-        &1_000_000i128, &2_000u32, &0u64, &31_536_000u64, &0u64,
+        &admin,
+        &lp_token,
+        &reward_token,
+        &1_000_000i128,
+        &2_000u32,
+        &0u64,
+        &31_536_000u64,
+        &0u64,
     );
 
     let reason = soroban_sdk::String::from_str(&env, "maintenance");

--- a/contracts/tipjar/tests/multisig_withdrawal_tests.rs
+++ b/contracts/tipjar/tests/multisig_withdrawal_tests.rs
@@ -39,7 +39,16 @@ fn setup() -> (
     let signer1 = Address::generate(&env);
     let signer2 = Address::generate(&env);
 
-    (env, client, admin, sender, Address::generate(&env), token_id, signer1, signer2)
+    (
+        env,
+        client,
+        admin,
+        sender,
+        Address::generate(&env),
+        token_id,
+        signer1,
+        signer2,
+    )
 }
 
 fn configure(

--- a/contracts/tipjar/tests/options_trading_tests.rs
+++ b/contracts/tipjar/tests/options_trading_tests.rs
@@ -6,18 +6,23 @@ use soroban_sdk::{
 };
 
 mod tipjar {
-    soroban_sdk::contractimport!(
-        file = "../target/wasm32-unknown-unknown/release/tipjar.wasm"
-    );
+    soroban_sdk::contractimport!(file = "../target/wasm32-unknown-unknown/release/tipjar.wasm");
 }
 
-use tipjar::{OptionType, OptionStatus, Client as TipJarClient};
+use tipjar::{Client as TipJarClient, OptionStatus, OptionType};
 
 fn create_token_contract<'a>(env: &Env, admin: &Address) -> token::StellarAssetClient<'a> {
     token::StellarAssetClient::new(env, &env.register_stellar_asset_contract(admin.clone()))
 }
 
-fn setup_test_env() -> (Env, TipJarClient, Address, Address, Address, token::StellarAssetClient) {
+fn setup_test_env() -> (
+    Env,
+    TipJarClient,
+    Address,
+    Address,
+    Address,
+    token::StellarAssetClient,
+) {
     let env = Env::default();
     env.mock_all_auths();
 
@@ -101,7 +106,7 @@ fn test_write_put_option() {
 
     let option = client.get_option(&option_id).unwrap();
     assert_eq!(option.option_type, OptionType::Put);
-    
+
     // Put collateral should be strike_price * amount / 1_000_000
     let expected_collateral = (strike_price * amount) / 1_000_000;
     assert_eq!(option.collateral, expected_collateral);

--- a/contracts/tipjar/tests/payment_channel_tests.rs
+++ b/contracts/tipjar/tests/payment_channel_tests.rs
@@ -11,7 +11,14 @@ use tipjar::{
     ChannelError, DataKey, TipJarContract, TipJarContractClient, TipJarError,
 };
 
-fn setup() -> (Env, TipJarContractClient<'static>, Address, Address, Address, Address) {
+fn setup() -> (
+    Env,
+    TipJarContractClient<'static>,
+    Address,
+    Address,
+    Address,
+    Address,
+) {
     let env = Env::default();
     env.mock_all_auths();
 
@@ -124,7 +131,7 @@ fn test_dispute_close_initiate_and_finalise() {
 
     let tok = soroban_sdk::token::Client::new(&env, &token);
     assert_eq!(tok.balance(&party_a), 1300); // 1000 - 500 + 800
-    assert_eq!(tok.balance(&party_b), 700);  // 1000 - 500 + 200
+    assert_eq!(tok.balance(&party_b), 700); // 1000 - 500 + 200
 }
 
 #[test]

--- a/contracts/tipjar/tests/quadratic_funding_tests.rs
+++ b/contracts/tipjar/tests/quadratic_funding_tests.rs
@@ -11,7 +11,13 @@ use tipjar::{
 // ── helpers ───────────────────────────────────────────────────────────────────
 
 /// Returns (env, client, admin, token, contract_id).
-fn setup() -> (Env, TipJarContractClient<'static>, Address, Address, Address) {
+fn setup() -> (
+    Env,
+    TipJarContractClient<'static>,
+    Address,
+    Address,
+    Address,
+) {
     let env = Env::default();
     env.mock_all_auths();
 
@@ -81,7 +87,9 @@ fn test_contribute_basic() {
 
     client.qf_contribute(&contributor, &round_id, &project, &100);
 
-    let c = client.qf_get_contribution(&round_id, &project, &contributor).unwrap();
+    let c = client
+        .qf_get_contribution(&round_id, &project, &contributor)
+        .unwrap();
     assert_eq!(c.amount, 100);
     assert_eq!(c.contributor, contributor);
     assert_eq!(c.project, project);
@@ -217,7 +225,10 @@ fn test_distribute_matching_two_projects() {
     let token_client = soroban_sdk::token::TokenClient::new(&env, &token);
     let bal_a = token_client.balance(&project_a);
     let bal_b = token_client.balance(&project_b);
-    assert!(bal_a > bal_b, "project_a should receive more matching: {bal_a} vs {bal_b}");
+    assert!(
+        bal_a > bal_b,
+        "project_a should receive more matching: {bal_a} vs {bal_b}"
+    );
 
     // Total distributed = matching_pool (contributions are returned to contributors).
     assert_eq!(bal_a + bal_b, matching_pool);

--- a/contracts/tipjar/tests/rollup_tests.rs
+++ b/contracts/tipjar/tests/rollup_tests.rs
@@ -25,7 +25,12 @@ impl Ctx {
         let client = TipJarContractClient::new(&env, &contract_id);
         client.init(&admin);
         client.init_rollup(&admin, &sequencer);
-        Self { env, client, admin, sequencer }
+        Self {
+            env,
+            client,
+            admin,
+            sequencer,
+        }
     }
 
     fn root(&self, seed: u8) -> BytesN<32> {
@@ -34,7 +39,9 @@ impl Ctx {
 
     fn advance_past_challenge(&self) {
         let challenge_period = 7 * 24 * 3600u64;
-        self.env.ledger().with_mut(|l| l.timestamp += challenge_period + 1);
+        self.env
+            .ledger()
+            .with_mut(|l| l.timestamp += challenge_period + 1);
     }
 }
 
@@ -72,8 +79,12 @@ fn test_submit_batch_increments_id() {
     let creator = Address::generate(&ctx.env);
     let token = Address::generate(&ctx.env);
 
-    let id1 = ctx.client.submit_rollup_batch(&ctx.sequencer, &ctx.root(1), &creator, &token, &1000, &10);
-    let id2 = ctx.client.submit_rollup_batch(&ctx.sequencer, &ctx.root(2), &creator, &token, &500, &5);
+    let id1 =
+        ctx.client
+            .submit_rollup_batch(&ctx.sequencer, &ctx.root(1), &creator, &token, &1000, &10);
+    let id2 =
+        ctx.client
+            .submit_rollup_batch(&ctx.sequencer, &ctx.root(2), &creator, &token, &500, &5);
     assert_eq!(id1, 1);
     assert_eq!(id2, 2);
 
@@ -88,7 +99,9 @@ fn test_submit_batch_stores_pending() {
     let token = Address::generate(&ctx.env);
     let root = ctx.root(42);
 
-    let id = ctx.client.submit_rollup_batch(&ctx.sequencer, &root, &creator, &token, &800, &8);
+    let id = ctx
+        .client
+        .submit_rollup_batch(&ctx.sequencer, &root, &creator, &token, &800, &8);
     let batch = ctx.client.get_rollup_batch(&id).unwrap();
 
     assert_eq!(batch.batch_id, id);
@@ -104,7 +117,10 @@ fn test_submit_batch_unauthorized_sequencer() {
     let impostor = Address::generate(&ctx.env);
     let creator = Address::generate(&ctx.env);
     let token = Address::generate(&ctx.env);
-    assert!(ctx.client.try_submit_rollup_batch(&impostor, &ctx.root(1), &creator, &token, &100, &1).is_err());
+    assert!(ctx
+        .client
+        .try_submit_rollup_batch(&impostor, &ctx.root(1), &creator, &token, &100, &1)
+        .is_err());
 }
 
 #[test]
@@ -112,7 +128,10 @@ fn test_submit_batch_invalid_amount() {
     let ctx = Ctx::new();
     let creator = Address::generate(&ctx.env);
     let token = Address::generate(&ctx.env);
-    assert!(ctx.client.try_submit_rollup_batch(&ctx.sequencer, &ctx.root(1), &creator, &token, &0, &0).is_err());
+    assert!(ctx
+        .client
+        .try_submit_rollup_batch(&ctx.sequencer, &ctx.root(1), &creator, &token, &0, &0)
+        .is_err());
 }
 
 // ── finalization ──────────────────────────────────────────────────────────────
@@ -123,7 +142,9 @@ fn test_finalize_after_challenge_period() {
     let creator = Address::generate(&ctx.env);
     let token = Address::generate(&ctx.env);
 
-    let id = ctx.client.submit_rollup_batch(&ctx.sequencer, &ctx.root(1), &creator, &token, &1000, &10);
+    let id =
+        ctx.client
+            .submit_rollup_batch(&ctx.sequencer, &ctx.root(1), &creator, &token, &1000, &10);
     ctx.advance_past_challenge();
     ctx.client.finalize_rollup_batch(&id);
 
@@ -141,7 +162,9 @@ fn test_finalize_before_challenge_period_fails() {
     let creator = Address::generate(&ctx.env);
     let token = Address::generate(&ctx.env);
 
-    let id = ctx.client.submit_rollup_batch(&ctx.sequencer, &ctx.root(1), &creator, &token, &1000, &10);
+    let id =
+        ctx.client
+            .submit_rollup_batch(&ctx.sequencer, &ctx.root(1), &creator, &token, &1000, &10);
     // Do NOT advance time
     assert!(ctx.client.try_finalize_rollup_batch(&id).is_err());
 }
@@ -152,7 +175,9 @@ fn test_finalize_credits_creator_balance() {
     let creator = Address::generate(&ctx.env);
     let token = Address::generate(&ctx.env);
 
-    let id = ctx.client.submit_rollup_batch(&ctx.sequencer, &ctx.root(1), &creator, &token, &500, &5);
+    let id =
+        ctx.client
+            .submit_rollup_batch(&ctx.sequencer, &ctx.root(1), &creator, &token, &500, &5);
     ctx.advance_past_challenge();
     ctx.client.finalize_rollup_batch(&id);
 
@@ -171,9 +196,13 @@ fn test_fraud_proof_accepted_on_root_mismatch() {
     let token = Address::generate(&ctx.env);
     let challenger = Address::generate(&ctx.env);
 
-    let id = ctx.client.submit_rollup_batch(&ctx.sequencer, &ctx.root(1), &creator, &token, &1000, &10);
+    let id =
+        ctx.client
+            .submit_rollup_batch(&ctx.sequencer, &ctx.root(1), &creator, &token, &1000, &10);
     // Submit fraud proof with a different root
-    let accepted = ctx.client.submit_fraud_proof(&challenger, &id, &ctx.root(99));
+    let accepted = ctx
+        .client
+        .submit_fraud_proof(&challenger, &id, &ctx.root(99));
     assert!(accepted);
 
     let batch = ctx.client.get_rollup_batch(&id).unwrap();
@@ -192,7 +221,9 @@ fn test_fraud_proof_rejected_on_matching_root() {
     let challenger = Address::generate(&ctx.env);
     let root = ctx.root(1);
 
-    let id = ctx.client.submit_rollup_batch(&ctx.sequencer, &root, &creator, &token, &1000, &10);
+    let id = ctx
+        .client
+        .submit_rollup_batch(&ctx.sequencer, &root, &creator, &token, &1000, &10);
     // Same root — no fraud
     let accepted = ctx.client.submit_fraud_proof(&challenger, &id, &root);
     assert!(!accepted);
@@ -208,9 +239,14 @@ fn test_fraud_proof_after_challenge_period_fails() {
     let token = Address::generate(&ctx.env);
     let challenger = Address::generate(&ctx.env);
 
-    let id = ctx.client.submit_rollup_batch(&ctx.sequencer, &ctx.root(1), &creator, &token, &1000, &10);
+    let id =
+        ctx.client
+            .submit_rollup_batch(&ctx.sequencer, &ctx.root(1), &creator, &token, &1000, &10);
     ctx.advance_past_challenge();
-    assert!(ctx.client.try_submit_fraud_proof(&challenger, &id, &ctx.root(99)).is_err());
+    assert!(ctx
+        .client
+        .try_submit_fraud_proof(&challenger, &id, &ctx.root(99))
+        .is_err());
 }
 
 #[test]
@@ -220,8 +256,11 @@ fn test_get_fraud_proof() {
     let token = Address::generate(&ctx.env);
     let challenger = Address::generate(&ctx.env);
 
-    let id = ctx.client.submit_rollup_batch(&ctx.sequencer, &ctx.root(1), &creator, &token, &1000, &10);
-    ctx.client.submit_fraud_proof(&challenger, &id, &ctx.root(99));
+    let id =
+        ctx.client
+            .submit_rollup_batch(&ctx.sequencer, &ctx.root(1), &creator, &token, &1000, &10);
+    ctx.client
+        .submit_fraud_proof(&challenger, &id, &ctx.root(99));
 
     let proof = ctx.client.get_fraud_proof(&id).unwrap();
     assert_eq!(proof.batch_id, id);
@@ -236,8 +275,11 @@ fn test_challenged_batch_cannot_be_finalized() {
     let token = Address::generate(&ctx.env);
     let challenger = Address::generate(&ctx.env);
 
-    let id = ctx.client.submit_rollup_batch(&ctx.sequencer, &ctx.root(1), &creator, &token, &1000, &10);
-    ctx.client.submit_fraud_proof(&challenger, &id, &ctx.root(99));
+    let id =
+        ctx.client
+            .submit_rollup_batch(&ctx.sequencer, &ctx.root(1), &creator, &token, &1000, &10);
+    ctx.client
+        .submit_fraud_proof(&challenger, &id, &ctx.root(99));
     ctx.advance_past_challenge();
 
     assert!(ctx.client.try_finalize_rollup_batch(&id).is_err());

--- a/contracts/tipjar/tests/royalty_split_tests.rs
+++ b/contracts/tipjar/tests/royalty_split_tests.rs
@@ -3,10 +3,7 @@
 extern crate std;
 
 use soroban_sdk::{vec, Address, Env};
-use tipjar::{
-    royalty::{SplitRecipient},
-    TipJarContract, TipJarContractClient,
-};
+use tipjar::{royalty::SplitRecipient, TipJarContract, TipJarContractClient};
 
 fn setup() -> (Env, TipJarContractClient<'static>, Address) {
     let env = Env::default();
@@ -36,8 +33,14 @@ fn test_set_split_stores_config() {
 
     let recipients = vec![
         &env,
-        SplitRecipient { recipient: a.clone(), share_bps: 6_000 },
-        SplitRecipient { recipient: b.clone(), share_bps: 4_000 },
+        SplitRecipient {
+            recipient: a.clone(),
+            share_bps: 6_000,
+        },
+        SplitRecipient {
+            recipient: b.clone(),
+            share_bps: 4_000,
+        },
     ];
     client.set_split(&split_id, &owner, &recipients);
 
@@ -69,8 +72,14 @@ fn test_modify_split_updates_recipients() {
         &owner,
         &vec![
             &env,
-            SplitRecipient { recipient: a.clone(), share_bps: 5_000 },
-            SplitRecipient { recipient: b.clone(), share_bps: 5_000 },
+            SplitRecipient {
+                recipient: a.clone(),
+                share_bps: 5_000,
+            },
+            SplitRecipient {
+                recipient: b.clone(),
+                share_bps: 5_000,
+            },
         ],
     );
 
@@ -79,9 +88,18 @@ fn test_modify_split_updates_recipients() {
         &owner,
         &vec![
             &env,
-            SplitRecipient { recipient: a.clone(), share_bps: 3_000 },
-            SplitRecipient { recipient: b.clone(), share_bps: 3_000 },
-            SplitRecipient { recipient: c.clone(), share_bps: 4_000 },
+            SplitRecipient {
+                recipient: a.clone(),
+                share_bps: 3_000,
+            },
+            SplitRecipient {
+                recipient: b.clone(),
+                share_bps: 3_000,
+            },
+            SplitRecipient {
+                recipient: c.clone(),
+                share_bps: 4_000,
+            },
         ],
     );
 
@@ -104,8 +122,14 @@ fn test_distribute_credits_balances_proportionally() {
         &owner,
         &vec![
             &env,
-            SplitRecipient { recipient: a.clone(), share_bps: 7_000 },
-            SplitRecipient { recipient: b.clone(), share_bps: 3_000 },
+            SplitRecipient {
+                recipient: a.clone(),
+                share_bps: 7_000,
+            },
+            SplitRecipient {
+                recipient: b.clone(),
+                share_bps: 3_000,
+            },
         ],
     );
 
@@ -129,7 +153,7 @@ fn test_distribute_no_config_returns_zero() {
 fn test_nested_split_distributes_recursively() {
     let (env, client, _) = setup();
     let owner = Address::generate(&env);
-    let team = Address::generate(&env);   // inner split
+    let team = Address::generate(&env); // inner split
     let a = Address::generate(&env);
     let b = Address::generate(&env);
     let c = Address::generate(&env);
@@ -140,8 +164,14 @@ fn test_nested_split_distributes_recursively() {
         &owner,
         &vec![
             &env,
-            SplitRecipient { recipient: a.clone(), share_bps: 5_000 },
-            SplitRecipient { recipient: b.clone(), share_bps: 5_000 },
+            SplitRecipient {
+                recipient: a.clone(),
+                share_bps: 5_000,
+            },
+            SplitRecipient {
+                recipient: b.clone(),
+                share_bps: 5_000,
+            },
         ],
     );
 
@@ -152,8 +182,14 @@ fn test_nested_split_distributes_recursively() {
         &owner,
         &vec![
             &env,
-            SplitRecipient { recipient: c.clone(), share_bps: 4_000 },
-            SplitRecipient { recipient: team.clone(), share_bps: 6_000 },
+            SplitRecipient {
+                recipient: c.clone(),
+                share_bps: 4_000,
+            },
+            SplitRecipient {
+                recipient: team.clone(),
+                share_bps: 6_000,
+            },
         ],
     );
 
@@ -177,7 +213,13 @@ fn test_history_count_increments_on_distribute() {
     client.set_split(
         &split_id,
         &owner,
-        &vec![&env, SplitRecipient { recipient: a.clone(), share_bps: 10_000 }],
+        &vec![
+            &env,
+            SplitRecipient {
+                recipient: a.clone(),
+                share_bps: 10_000,
+            },
+        ],
     );
 
     assert_eq!(client.get_split_history_count(&split_id), 0);
@@ -197,12 +239,20 @@ fn test_history_entry_records_amount() {
     client.set_split(
         &split_id,
         &owner,
-        &vec![&env, SplitRecipient { recipient: a.clone(), share_bps: 10_000 }],
+        &vec![
+            &env,
+            SplitRecipient {
+                recipient: a.clone(),
+                share_bps: 10_000,
+            },
+        ],
     );
 
     client.distribute_split(&split_id, &500i128);
 
-    let entry = client.get_split_history_entry(&split_id, &0u64).expect("entry should exist");
+    let entry = client
+        .get_split_history_entry(&split_id, &0u64)
+        .expect("entry should exist");
     assert_eq!(entry.amount, 500);
 }
 

--- a/contracts/tipjar/tests/sidechain_tests.rs
+++ b/contracts/tipjar/tests/sidechain_tests.rs
@@ -28,7 +28,12 @@ impl Ctx {
         client.init(&admin);
         client.init_sidechain(&admin, &operator);
 
-        Self { env, client, admin, operator }
+        Self {
+            env,
+            client,
+            admin,
+            operator,
+        }
     }
 
     fn state_root(&self, seed: u8) -> BytesN<32> {
@@ -73,10 +78,14 @@ fn test_init_sidechain_unauthorized() {
 fn test_submit_checkpoint_increments_seq() {
     let ctx = Ctx::new();
 
-    let seq1 = ctx.client.submit_checkpoint(&ctx.operator, &ctx.state_root(1), &10, &1000);
+    let seq1 = ctx
+        .client
+        .submit_checkpoint(&ctx.operator, &ctx.state_root(1), &10, &1000);
     assert_eq!(seq1, 1);
 
-    let seq2 = ctx.client.submit_checkpoint(&ctx.operator, &ctx.state_root(2), &5, &500);
+    let seq2 = ctx
+        .client
+        .submit_checkpoint(&ctx.operator, &ctx.state_root(2), &5, &500);
     assert_eq!(seq2, 2);
 
     let state = ctx.client.get_sidechain_state();
@@ -88,7 +97,9 @@ fn test_submit_checkpoint_stores_data() {
     let ctx = Ctx::new();
     let root = ctx.state_root(42);
 
-    let seq = ctx.client.submit_checkpoint(&ctx.operator, &root, &20, &2000);
+    let seq = ctx
+        .client
+        .submit_checkpoint(&ctx.operator, &root, &20, &2000);
 
     let cp = ctx.client.get_checkpoint(&seq).unwrap();
     assert_eq!(cp.seq, seq);
@@ -103,7 +114,9 @@ fn test_submit_checkpoint_unauthorized() {
     let ctx = Ctx::new();
     let impostor = Address::generate(&ctx.env);
 
-    let result = ctx.client.try_submit_checkpoint(&impostor, &ctx.state_root(1), &10, &1000);
+    let result = ctx
+        .client
+        .try_submit_checkpoint(&impostor, &ctx.state_root(1), &10, &1000);
     assert!(result.is_err());
 }
 
@@ -112,7 +125,9 @@ fn test_submit_checkpoint_unauthorized() {
 #[test]
 fn test_finalize_checkpoint() {
     let ctx = Ctx::new();
-    let seq = ctx.client.submit_checkpoint(&ctx.operator, &ctx.state_root(1), &10, &1000);
+    let seq = ctx
+        .client
+        .submit_checkpoint(&ctx.operator, &ctx.state_root(1), &10, &1000);
 
     ctx.client.finalize_checkpoint(&ctx.operator, &seq);
 
@@ -123,7 +138,9 @@ fn test_finalize_checkpoint() {
 #[test]
 fn test_finalize_checkpoint_updates_state() {
     let ctx = Ctx::new();
-    let seq = ctx.client.submit_checkpoint(&ctx.operator, &ctx.state_root(1), &10, &1000);
+    let seq = ctx
+        .client
+        .submit_checkpoint(&ctx.operator, &ctx.state_root(1), &10, &1000);
     ctx.client.finalize_checkpoint(&ctx.operator, &seq);
 
     let state = ctx.client.get_sidechain_state();
@@ -139,17 +156,14 @@ fn test_record_and_settle_batch() {
     let creator = Address::generate(&ctx.env);
     let token = ctx.token();
 
-    let seq = ctx.client.submit_checkpoint(&ctx.operator, &ctx.state_root(1), &5, &500);
+    let seq = ctx
+        .client
+        .submit_checkpoint(&ctx.operator, &ctx.state_root(1), &5, &500);
     ctx.client.finalize_checkpoint(&ctx.operator, &seq);
 
-    let batch_id = ctx.client.record_tip_batch(
-        &ctx.operator,
-        &creator,
-        &token,
-        &500,
-        &5,
-        &seq,
-    );
+    let batch_id = ctx
+        .client
+        .record_tip_batch(&ctx.operator, &creator, &token, &500, &5, &seq);
     assert_eq!(batch_id, 1);
 
     ctx.client.finalize_tips(&batch_id);
@@ -164,17 +178,14 @@ fn test_settle_batch_credits_creator_balance() {
     let creator = Address::generate(&ctx.env);
     let token = ctx.token();
 
-    let seq = ctx.client.submit_checkpoint(&ctx.operator, &ctx.state_root(1), &3, &300);
+    let seq = ctx
+        .client
+        .submit_checkpoint(&ctx.operator, &ctx.state_root(1), &3, &300);
     ctx.client.finalize_checkpoint(&ctx.operator, &seq);
 
-    let batch_id = ctx.client.record_tip_batch(
-        &ctx.operator,
-        &creator,
-        &token,
-        &300,
-        &3,
-        &seq,
-    );
+    let batch_id = ctx
+        .client
+        .record_tip_batch(&ctx.operator, &creator, &token, &300, &3, &seq);
     ctx.client.finalize_tips(&batch_id);
 
     // Creator balance should be credited
@@ -189,16 +200,13 @@ fn test_settle_batch_requires_finalized_checkpoint() {
     let token = ctx.token();
 
     // Submit but do NOT finalize the checkpoint
-    let seq = ctx.client.submit_checkpoint(&ctx.operator, &ctx.state_root(1), &5, &500);
+    let seq = ctx
+        .client
+        .submit_checkpoint(&ctx.operator, &ctx.state_root(1), &5, &500);
 
-    let batch_id = ctx.client.record_tip_batch(
-        &ctx.operator,
-        &creator,
-        &token,
-        &500,
-        &5,
-        &seq,
-    );
+    let batch_id = ctx
+        .client
+        .record_tip_batch(&ctx.operator, &creator, &token, &500, &5, &seq);
 
     // Should panic because checkpoint is not finalized
     let result = ctx.client.try_finalize_tips(&batch_id);
@@ -211,17 +219,14 @@ fn test_record_batch_invalid_amount() {
     let creator = Address::generate(&ctx.env);
     let token = ctx.token();
 
-    let seq = ctx.client.submit_checkpoint(&ctx.operator, &ctx.state_root(1), &0, &0);
+    let seq = ctx
+        .client
+        .submit_checkpoint(&ctx.operator, &ctx.state_root(1), &0, &0);
     ctx.client.finalize_checkpoint(&ctx.operator, &seq);
 
-    let result = ctx.client.try_record_tip_batch(
-        &ctx.operator,
-        &creator,
-        &token,
-        &0,
-        &0,
-        &seq,
-    );
+    let result = ctx
+        .client
+        .try_record_tip_batch(&ctx.operator, &creator, &token, &0, &0, &seq);
     assert!(result.is_err());
 }
 
@@ -233,11 +238,17 @@ fn test_multiple_batches_accumulate() {
     let creator = Address::generate(&ctx.env);
     let token = ctx.token();
 
-    let seq = ctx.client.submit_checkpoint(&ctx.operator, &ctx.state_root(1), &10, &1000);
+    let seq = ctx
+        .client
+        .submit_checkpoint(&ctx.operator, &ctx.state_root(1), &10, &1000);
     ctx.client.finalize_checkpoint(&ctx.operator, &seq);
 
-    let b1 = ctx.client.record_tip_batch(&ctx.operator, &creator, &token, &400, &4, &seq);
-    let b2 = ctx.client.record_tip_batch(&ctx.operator, &creator, &token, &600, &6, &seq);
+    let b1 = ctx
+        .client
+        .record_tip_batch(&ctx.operator, &creator, &token, &400, &4, &seq);
+    let b2 = ctx
+        .client
+        .record_tip_batch(&ctx.operator, &creator, &token, &600, &6, &seq);
 
     ctx.client.finalize_tips(&b1);
     ctx.client.finalize_tips(&b2);
@@ -250,10 +261,14 @@ fn test_multiple_batches_accumulate() {
 fn test_multiple_checkpoints_state() {
     let ctx = Ctx::new();
 
-    let s1 = ctx.client.submit_checkpoint(&ctx.operator, &ctx.state_root(1), &5, &500);
+    let s1 = ctx
+        .client
+        .submit_checkpoint(&ctx.operator, &ctx.state_root(1), &5, &500);
     ctx.client.finalize_checkpoint(&ctx.operator, &s1);
 
-    let s2 = ctx.client.submit_checkpoint(&ctx.operator, &ctx.state_root(2), &10, &1000);
+    let s2 = ctx
+        .client
+        .submit_checkpoint(&ctx.operator, &ctx.state_root(2), &10, &1000);
     ctx.client.finalize_checkpoint(&ctx.operator, &s2);
 
     let state = ctx.client.get_sidechain_state();

--- a/contracts/tipjar/tests/streaming_tests.rs
+++ b/contracts/tipjar/tests/streaming_tests.rs
@@ -2,10 +2,19 @@
 
 extern crate std;
 
-use soroban_sdk::{testutils::{Address as _, Ledger}, Address, Env, String};
+use soroban_sdk::{
+    testutils::{Address as _, Ledger},
+    Address, Env, String,
+};
 use tipjar::{DataKey, Stream, StreamStatus, TipJarContract, TipJarContractClient, TipJarError};
 
-fn setup() -> (Env, TipJarContractClient<'static>, Address, Address, Address) {
+fn setup() -> (
+    Env,
+    TipJarContractClient<'static>,
+    Address,
+    Address,
+    Address,
+) {
     let env = Env::default();
     env.mock_all_auths();
 
@@ -32,10 +41,7 @@ fn test_create_stream() {
     let (env, client, sender, creator, token) = setup();
 
     let stream_id = client.create_stream(
-        &sender,
-        &creator,
-        &token,
-        &1i128,  // 1 token per second
+        &sender, &creator, &token, &1i128,  // 1 token per second
         &100u64, // 100 seconds duration
     );
 
@@ -58,19 +64,13 @@ fn test_create_stream_invalid_rate() {
     let (env, client, sender, creator, token) = setup();
 
     let result = client.try_create_stream(
-        &sender,
-        &creator,
-        &token,
-        &0i128,  // Invalid rate
+        &sender, &creator, &token, &0i128, // Invalid rate
         &100u64,
     );
     assert_eq!(result, Err(Ok(TipJarError::InvalidStreamRate)));
 
     let result = client.try_create_stream(
-        &sender,
-        &creator,
-        &token,
-        &1001i128,  // Exceeds maximum
+        &sender, &creator, &token, &1001i128, // Exceeds maximum
         &100u64,
     );
     assert_eq!(result, Err(Ok(TipJarError::StreamRateExceedsMaximum)));
@@ -81,11 +81,7 @@ fn test_create_stream_invalid_duration() {
     let (env, client, sender, creator, token) = setup();
 
     let result = client.try_create_stream(
-        &sender,
-        &creator,
-        &token,
-        &1i128,
-        &0u64,  // Invalid duration
+        &sender, &creator, &token, &1i128, &0u64, // Invalid duration
     );
     assert_eq!(result, Err(Ok(TipJarError::InvalidAmount)));
 }
@@ -95,10 +91,7 @@ fn test_calculate_streamed_amount() {
     let (env, client, sender, creator, token) = setup();
 
     let stream_id = client.create_stream(
-        &sender,
-        &creator,
-        &token,
-        &2i128,  // 2 tokens per second
+        &sender, &creator, &token, &2i128,  // 2 tokens per second
         &100u64, // 100 seconds
     );
 
@@ -109,17 +102,17 @@ fn test_calculate_streamed_amount() {
     // After 10 seconds
     env.ledger().with_mut(|ledger| ledger.timestamp += 10);
     let streamed = client.get_streamed_amount(&stream_id);
-    assert_eq!(streamed, 20i128);  // 2 * 10
+    assert_eq!(streamed, 20i128); // 2 * 10
 
     // After 50 more seconds (total 60)
     env.ledger().with_mut(|ledger| ledger.timestamp += 50);
     let streamed = client.get_streamed_amount(&stream_id);
-    assert_eq!(streamed, 120i128);  // 2 * 60
+    assert_eq!(streamed, 120i128); // 2 * 60
 
     // After 50 more seconds (total 110, exceeds duration)
     env.ledger().with_mut(|ledger| ledger.timestamp += 50);
     let streamed = client.get_streamed_amount(&stream_id);
-    assert_eq!(streamed, 200i128);  // 2 * 100 (max)
+    assert_eq!(streamed, 200i128); // 2 * 100 (max)
 }
 
 #[test]
@@ -127,11 +120,8 @@ fn test_withdraw_streamed() {
     let (env, client, sender, creator, token) = setup();
 
     let stream_id = client.create_stream(
-        &sender,
-        &creator,
-        &token,
-        &3i128,   // 3 tokens per second
-        &100u64,  // 100 seconds
+        &sender, &creator, &token, &3i128,  // 3 tokens per second
+        &100u64, // 100 seconds
     );
 
     // After 20 seconds, 60 tokens should be available
@@ -167,13 +157,7 @@ fn test_withdraw_streamed() {
 fn test_withdraw_streamed_completed() {
     let (env, client, sender, creator, token) = setup();
 
-    let stream_id = client.create_stream(
-        &sender,
-        &creator,
-        &token,
-        &2i128,
-        &50u64,
-    );
+    let stream_id = client.create_stream(&sender, &creator, &token, &2i128, &50u64);
 
     // Advance past end time
     env.ledger().with_mut(|ledger| ledger.timestamp += 60);
@@ -194,13 +178,7 @@ fn test_withdraw_streamed_completed() {
 fn test_cancel_stream() {
     let (env, client, sender, creator, token) = setup();
 
-    let stream_id = client.create_stream(
-        &sender,
-        &creator,
-        &token,
-        &5i128,
-        &100u64,
-    );
+    let stream_id = client.create_stream(&sender, &creator, &token, &5i128, &100u64);
 
     // After 20 seconds, 100 tokens streamed (5 * 20)
     env.ledger().with_mut(|ledger| ledger.timestamp += 20);
@@ -226,13 +204,7 @@ fn test_cancel_stream() {
 fn test_stop_and_start_stream() {
     let (env, client, sender, creator, token) = setup();
 
-    let stream_id = client.create_stream(
-        &sender,
-        &creator,
-        &token,
-        &4i128,
-        &100u64,
-    );
+    let stream_id = client.create_stream(&sender, &creator, &token, &4i128, &100u64);
 
     // After 10 seconds, 40 tokens
     env.ledger().with_mut(|ledger| ledger.timestamp += 10);
@@ -265,13 +237,7 @@ fn test_unauthorized_operations() {
     let (env, client, sender, creator, token) = setup();
     let other = Address::generate(&env);
 
-    let stream_id = client.create_stream(
-        &sender,
-        &creator,
-        &token,
-        &1i128,
-        &100u64,
-    );
+    let stream_id = client.create_stream(&sender, &creator, &token, &1i128, &100u64);
 
     // Other user can't stop stream
     let result = client.try_stop_stream(&other, &stream_id);
@@ -296,13 +262,7 @@ fn test_unauthorized_operations() {
 fn test_withdraw_without_streamed_amount() {
     let (env, client, sender, creator, token) = setup();
 
-    let stream_id = client.create_stream(
-        &sender,
-        &creator,
-        &token,
-        &1i128,
-        &100u64,
-    );
+    let stream_id = client.create_stream(&sender, &creator, &token, &1i128, &100u64);
 
     // Try to withdraw before stream starts (should fail)
     let result = client.try_withdraw_streamed(&creator, &stream_id);
@@ -355,13 +315,7 @@ fn test_cancel_nonexistent_stream() {
 fn test_stream_already_completed() {
     let (env, client, sender, creator, token) = setup();
 
-    let stream_id = client.create_stream(
-        &sender,
-        &creator,
-        &token,
-        &1i128,
-        &10u64,
-    );
+    let stream_id = client.create_stream(&sender, &creator, &token, &1i128, &10u64);
 
     // Advance past end time
     env.ledger().with_mut(|ledger| ledger.timestamp += 20);
@@ -391,13 +345,7 @@ fn test_stream_rate_limit() {
 fn test_paused_stream_cannot_withdraw() {
     let (env, client, sender, creator, token) = setup();
 
-    let stream_id = client.create_stream(
-        &sender,
-        &creator,
-        &token,
-        &5i128,
-        &100u64,
-    );
+    let stream_id = client.create_stream(&sender, &creator, &token, &5i128, &100u64);
 
     // Advance 10 seconds
     env.ledger().with_mut(|ledger| ledger.timestamp += 10);
@@ -416,13 +364,7 @@ fn test_paused_stream_cannot_withdraw() {
 fn test_double_cancel() {
     let (env, client, sender, creator, token) = setup();
 
-    let stream_id = client.create_stream(
-        &sender,
-        &creator,
-        &token,
-        &1i128,
-        &100u64,
-    );
+    let stream_id = client.create_stream(&sender, &creator, &token, &1i128, &100u64);
 
     client.cancel_stream(&sender, &stream_id);
     let result = client.try_cancel_stream(&sender, &stream_id);
@@ -448,13 +390,7 @@ fn test_stream_token_whitelist() {
 fn test_stream_get_available_to_withdraw() {
     let (env, client, sender, creator, token) = setup();
 
-    let stream_id = client.create_stream(
-        &sender,
-        &creator,
-        &token,
-        &10i128,
-        &100u64,
-    );
+    let stream_id = client.create_stream(&sender, &creator, &token, &10i128, &100u64);
 
     // Initially 0
     assert_eq!(client.get_available_to_withdraw(&stream_id), 0);
@@ -478,13 +414,7 @@ fn test_stream_get_available_to_withdraw() {
 fn test_stream_completed_no_more_withdrawals() {
     let (env, client, sender, creator, token) = setup();
 
-    let stream_id = client.create_stream(
-        &sender,
-        &creator,
-        &token,
-        &1i128,
-        &10u64,
-    );
+    let stream_id = client.create_stream(&sender, &creator, &token, &1i128, &10u64);
 
     // Advance past end
     env.ledger().with_mut(|ledger| ledger.timestamp += 20);
@@ -513,11 +443,7 @@ fn test_stream_duration_accurate() {
     let (env, client, sender, creator, token) = setup();
 
     let stream_id = client.create_stream(
-        &sender,
-        &creator,
-        &token,
-        &10i128,
-        &300u64, // 5 minutes
+        &sender, &creator, &token, &10i128, &300u64, // 5 minutes
     );
 
     let stream = client.get_stream(&stream_id).unwrap();

--- a/contracts/tipjar/tests/subscription_tiers.rs
+++ b/contracts/tipjar/tests/subscription_tiers.rs
@@ -15,12 +15,20 @@ const ONE_MONTH: u64 = 2_592_000;
 
 // ── setup ─────────────────────────────────────────────────────────────────────
 
-fn setup() -> (Env, TipJarContractClient<'static>, Address, Address, Address) {
+fn setup() -> (
+    Env,
+    TipJarContractClient<'static>,
+    Address,
+    Address,
+    Address,
+) {
     let env = Env::default();
     env.mock_all_auths();
 
     let token_admin = Address::generate(&env);
-    let token = env.register_stellar_asset_contract_v2(token_admin.clone()).address();
+    let token = env
+        .register_stellar_asset_contract_v2(token_admin.clone())
+        .address();
 
     let admin = Address::generate(&env);
     let contract_id = env.register(TipJarContract, ());
@@ -105,7 +113,9 @@ fn test_get_tier_benefits_returns_description() {
 #[test]
 fn test_get_tier_benefits_returns_none_when_not_configured() {
     let (_env, client, _admin, _token, _ta) = setup();
-    assert!(client.get_tier_benefits(&SubscriptionTier::Silver).is_none());
+    assert!(client
+        .get_tier_benefits(&SubscriptionTier::Silver)
+        .is_none());
 }
 
 // ── create_tiered_subscription ────────────────────────────────────────────────
@@ -216,8 +226,7 @@ fn test_upgrade_fails_when_tier_not_configured() {
         &ONE_MONTH,
     );
 
-    let result =
-        client.try_upgrade_subscription(&subscriber, &creator, &SubscriptionTier::Gold);
+    let result = client.try_upgrade_subscription(&subscriber, &creator, &SubscriptionTier::Gold);
     assert!(result.is_err());
 }
 

--- a/contracts/tipjar/tests/synthetic_events_tests.rs
+++ b/contracts/tipjar/tests/synthetic_events_tests.rs
@@ -135,7 +135,13 @@ fn test_all_events_have_timestamps() {
     });
 
     // Emit various events - they should all use the ledger timestamp
-    emit_synthetic_asset_created(&env, asset_id, creator.clone(), backing_token.clone(), 15000);
+    emit_synthetic_asset_created(
+        &env,
+        asset_id,
+        creator.clone(),
+        backing_token.clone(),
+        15000,
+    );
     emit_synthetic_tokens_minted(&env, asset_id, minter.clone(), 1000, 1500);
     emit_price_updated(&env, asset_id, 1200);
     emit_supply_updated(&env, asset_id, 10000);

--- a/contracts/tipjar/tests/synthetic_oracle_tests.rs
+++ b/contracts/tipjar/tests/synthetic_oracle_tests.rs
@@ -1,9 +1,9 @@
 #![cfg(test)]
 
 use soroban_sdk::{testutils::Address as _, Address, Env};
-use tipjar::{DataKey, TipJarError};
+use tipjar::synthetic::oracle::{get_oracle_price, update_oracle_price};
 use tipjar::synthetic::types::SyntheticAsset;
-use tipjar::synthetic::oracle::{update_oracle_price, get_oracle_price};
+use tipjar::{DataKey, TipJarError};
 
 /// Helper function to create a test synthetic asset
 fn create_test_asset(
@@ -25,10 +25,10 @@ fn create_test_asset(
         total_collateral,
         active: true,
     };
-    
+
     let asset_key = DataKey::SyntheticAsset(asset_id);
     env.storage().persistent().set(&asset_key, &asset);
-    
+
     asset
 }
 
@@ -44,19 +44,26 @@ fn test_update_oracle_price_with_supply() {
     let creator = Address::generate(&env);
     let backing_token = Address::generate(&env);
     let asset_id = 1u64;
-    
+
     // Create asset with supply of 1000
-    create_test_asset(&env, asset_id, creator.clone(), backing_token.clone(), 1000, 1500);
-    
+    create_test_asset(
+        &env,
+        asset_id,
+        creator.clone(),
+        backing_token.clone(),
+        1000,
+        1500,
+    );
+
     // Set tip pool balance to 2000
     set_creator_balance(&env, &creator, &backing_token, 2000);
-    
+
     // Update oracle price
     let price = update_oracle_price(&env, asset_id).unwrap();
-    
+
     // Price should be 2000 / 1000 = 2
     assert_eq!(price, 2);
-    
+
     // Verify price is stored in asset
     let asset_key = DataKey::SyntheticAsset(asset_id);
     let asset: SyntheticAsset = env.storage().persistent().get(&asset_key).unwrap();
@@ -69,16 +76,16 @@ fn test_update_oracle_price_zero_supply() {
     let creator = Address::generate(&env);
     let backing_token = Address::generate(&env);
     let asset_id = 1u64;
-    
+
     // Create asset with zero supply
     create_test_asset(&env, asset_id, creator.clone(), backing_token.clone(), 0, 0);
-    
+
     // Set tip pool balance to 5000
     set_creator_balance(&env, &creator, &backing_token, 5000);
-    
+
     // Update oracle price
     let price = update_oracle_price(&env, asset_id).unwrap();
-    
+
     // Price should be initial price (1 unit = 10^7 stroops)
     assert_eq!(price, 10_000_000);
 }
@@ -89,16 +96,23 @@ fn test_update_oracle_price_zero_balance_with_supply() {
     let creator = Address::generate(&env);
     let backing_token = Address::generate(&env);
     let asset_id = 1u64;
-    
+
     // Create asset with supply but zero balance
-    create_test_asset(&env, asset_id, creator.clone(), backing_token.clone(), 1000, 0);
-    
+    create_test_asset(
+        &env,
+        asset_id,
+        creator.clone(),
+        backing_token.clone(),
+        1000,
+        0,
+    );
+
     // Set tip pool balance to 0
     set_creator_balance(&env, &creator, &backing_token, 0);
-    
+
     // Update oracle price
     let price = update_oracle_price(&env, asset_id).unwrap();
-    
+
     // Price should be 0 when balance is 0 and supply > 0
     assert_eq!(price, 0);
 }
@@ -109,16 +123,23 @@ fn test_update_oracle_price_large_values() {
     let creator = Address::generate(&env);
     let backing_token = Address::generate(&env);
     let asset_id = 1u64;
-    
+
     // Create asset with large supply
-    create_test_asset(&env, asset_id, creator.clone(), backing_token.clone(), 1_000_000, 1_500_000);
-    
+    create_test_asset(
+        &env,
+        asset_id,
+        creator.clone(),
+        backing_token.clone(),
+        1_000_000,
+        1_500_000,
+    );
+
     // Set large tip pool balance
     set_creator_balance(&env, &creator, &backing_token, 5_000_000);
-    
+
     // Update oracle price
     let price = update_oracle_price(&env, asset_id).unwrap();
-    
+
     // Price should be 5_000_000 / 1_000_000 = 5
     assert_eq!(price, 5);
 }
@@ -129,16 +150,16 @@ fn test_update_oracle_price_fractional_result() {
     let creator = Address::generate(&env);
     let backing_token = Address::generate(&env);
     let asset_id = 1u64;
-    
+
     // Create asset where division results in fraction
     create_test_asset(&env, asset_id, creator.clone(), backing_token.clone(), 3, 0);
-    
+
     // Set tip pool balance
     set_creator_balance(&env, &creator, &backing_token, 10);
-    
+
     // Update oracle price
     let price = update_oracle_price(&env, asset_id).unwrap();
-    
+
     // Price should be 10 / 3 = 3 (integer division)
     assert_eq!(price, 3);
 }
@@ -147,10 +168,10 @@ fn test_update_oracle_price_fractional_result() {
 fn test_update_oracle_price_nonexistent_asset() {
     let env = Env::default();
     let asset_id = 999u64;
-    
+
     // Try to update price for non-existent asset
     let result = update_oracle_price(&env, asset_id);
-    
+
     // Should return SyntheticAssetNotFound error
     assert_eq!(result, Err(TipJarError::SyntheticAssetNotFound));
 }
@@ -161,16 +182,23 @@ fn test_get_oracle_price() {
     let creator = Address::generate(&env);
     let backing_token = Address::generate(&env);
     let asset_id = 1u64;
-    
+
     // Create asset with a specific oracle price
-    let mut asset = create_test_asset(&env, asset_id, creator.clone(), backing_token.clone(), 1000, 1500);
+    let mut asset = create_test_asset(
+        &env,
+        asset_id,
+        creator.clone(),
+        backing_token.clone(),
+        1000,
+        1500,
+    );
     asset.oracle_price = 1234;
     let asset_key = DataKey::SyntheticAsset(asset_id);
     env.storage().persistent().set(&asset_key, &asset);
-    
+
     // Get oracle price
     let price = get_oracle_price(&env, asset_id).unwrap();
-    
+
     // Should return the stored price
     assert_eq!(price, 1234);
 }
@@ -179,10 +207,10 @@ fn test_get_oracle_price() {
 fn test_get_oracle_price_nonexistent_asset() {
     let env = Env::default();
     let asset_id = 999u64;
-    
+
     // Try to get price for non-existent asset
     let result = get_oracle_price(&env, asset_id);
-    
+
     // Should return SyntheticAssetNotFound error
     assert_eq!(result, Err(TipJarError::SyntheticAssetNotFound));
 }
@@ -193,19 +221,26 @@ fn test_get_oracle_price_after_update() {
     let creator = Address::generate(&env);
     let backing_token = Address::generate(&env);
     let asset_id = 1u64;
-    
+
     // Create asset
-    create_test_asset(&env, asset_id, creator.clone(), backing_token.clone(), 500, 750);
-    
+    create_test_asset(
+        &env,
+        asset_id,
+        creator.clone(),
+        backing_token.clone(),
+        500,
+        750,
+    );
+
     // Set tip pool balance
     set_creator_balance(&env, &creator, &backing_token, 1000);
-    
+
     // Update oracle price
     let updated_price = update_oracle_price(&env, asset_id).unwrap();
-    
+
     // Get oracle price
     let retrieved_price = get_oracle_price(&env, asset_id).unwrap();
-    
+
     // Both should match
     assert_eq!(updated_price, retrieved_price);
     assert_eq!(retrieved_price, 2); // 1000 / 500 = 2
@@ -217,24 +252,31 @@ fn test_oracle_price_updates_on_balance_change() {
     let creator = Address::generate(&env);
     let backing_token = Address::generate(&env);
     let asset_id = 1u64;
-    
+
     // Create asset
-    create_test_asset(&env, asset_id, creator.clone(), backing_token.clone(), 1000, 1000);
-    
+    create_test_asset(
+        &env,
+        asset_id,
+        creator.clone(),
+        backing_token.clone(),
+        1000,
+        1000,
+    );
+
     // Set initial tip pool balance
     set_creator_balance(&env, &creator, &backing_token, 1000);
-    
+
     // Update oracle price
     let price1 = update_oracle_price(&env, asset_id).unwrap();
     assert_eq!(price1, 1); // 1000 / 1000 = 1
-    
+
     // Increase tip pool balance (simulating new tips)
     set_creator_balance(&env, &creator, &backing_token, 2000);
-    
+
     // Update oracle price again
     let price2 = update_oracle_price(&env, asset_id).unwrap();
     assert_eq!(price2, 2); // 2000 / 1000 = 2
-    
+
     // Price should have increased
     assert!(price2 > price1);
 }
@@ -245,15 +287,22 @@ fn test_oracle_price_with_no_balance_entry() {
     let creator = Address::generate(&env);
     let backing_token = Address::generate(&env);
     let asset_id = 1u64;
-    
+
     // Create asset with supply
-    create_test_asset(&env, asset_id, creator.clone(), backing_token.clone(), 100, 150);
-    
+    create_test_asset(
+        &env,
+        asset_id,
+        creator.clone(),
+        backing_token.clone(),
+        100,
+        150,
+    );
+
     // Don't set any balance (defaults to 0)
-    
+
     // Update oracle price
     let price = update_oracle_price(&env, asset_id).unwrap();
-    
+
     // Price should be 0 when balance is 0 and supply > 0
     assert_eq!(price, 0);
 }
@@ -264,19 +313,26 @@ fn test_oracle_price_emits_event() {
     let creator = Address::generate(&env);
     let backing_token = Address::generate(&env);
     let asset_id = 1u64;
-    
+
     // Create asset
-    create_test_asset(&env, asset_id, creator.clone(), backing_token.clone(), 1000, 1500);
-    
+    create_test_asset(
+        &env,
+        asset_id,
+        creator.clone(),
+        backing_token.clone(),
+        1000,
+        1500,
+    );
+
     // Set tip pool balance
     set_creator_balance(&env, &creator, &backing_token, 3000);
-    
+
     // Update oracle price (should emit event)
     let price = update_oracle_price(&env, asset_id).unwrap();
-    
+
     // Verify the function executed successfully
     assert_eq!(price, 3);
-    
+
     // Note: Event emission verification would require more complex test setup
     // with event listeners, but we can verify the function doesn't panic
 }

--- a/contracts/tipjar/tests/synthetic_supply_tests.rs
+++ b/contracts/tipjar/tests/synthetic_supply_tests.rs
@@ -1,12 +1,12 @@
 #![cfg(test)]
 
 use soroban_sdk::{testutils::Address as _, Address, Env};
-use tipjar::{DataKey, TipJarError};
-use tipjar::synthetic::types::SyntheticAsset;
 use tipjar::synthetic::supply::{
-    update_supply, update_collateral, get_collateralization_ratio,
-    get_total_supply, get_total_collateral
+    get_collateralization_ratio, get_total_collateral, get_total_supply, update_collateral,
+    update_supply,
 };
+use tipjar::synthetic::types::SyntheticAsset;
+use tipjar::{DataKey, TipJarError};
 
 /// Helper function to create a test synthetic asset
 fn create_test_asset(
@@ -29,10 +29,10 @@ fn create_test_asset(
         total_collateral,
         active: true,
     };
-    
+
     let asset_key = DataKey::SyntheticAsset(asset_id);
     env.storage().persistent().set(&asset_key, &asset);
-    
+
     asset
 }
 
@@ -42,13 +42,21 @@ fn test_update_supply_positive_delta() {
     let creator = Address::generate(&env);
     let backing_token = Address::generate(&env);
     let asset_id = 1u64;
-    
+
     // Create asset with initial supply of 1000
-    create_test_asset(&env, asset_id, creator.clone(), backing_token.clone(), 1000, 1500, 10);
-    
+    create_test_asset(
+        &env,
+        asset_id,
+        creator.clone(),
+        backing_token.clone(),
+        1000,
+        1500,
+        10,
+    );
+
     // Update supply by +500 (minting)
     update_supply(&env, asset_id, 500).unwrap();
-    
+
     // Verify supply increased
     let new_supply = get_total_supply(&env, asset_id).unwrap();
     assert_eq!(new_supply, 1500);
@@ -60,13 +68,21 @@ fn test_update_supply_negative_delta() {
     let creator = Address::generate(&env);
     let backing_token = Address::generate(&env);
     let asset_id = 1u64;
-    
+
     // Create asset with initial supply of 1000
-    create_test_asset(&env, asset_id, creator.clone(), backing_token.clone(), 1000, 1500, 10);
-    
+    create_test_asset(
+        &env,
+        asset_id,
+        creator.clone(),
+        backing_token.clone(),
+        1000,
+        1500,
+        10,
+    );
+
     // Update supply by -300 (redemption)
     update_supply(&env, asset_id, -300).unwrap();
-    
+
     // Verify supply decreased
     let new_supply = get_total_supply(&env, asset_id).unwrap();
     assert_eq!(new_supply, 700);
@@ -76,10 +92,10 @@ fn test_update_supply_negative_delta() {
 fn test_update_supply_nonexistent_asset() {
     let env = Env::default();
     let asset_id = 999u64;
-    
+
     // Try to update supply for non-existent asset
     let result = update_supply(&env, asset_id, 100);
-    
+
     // Should return SyntheticAssetNotFound error
     assert_eq!(result, Err(TipJarError::SyntheticAssetNotFound));
 }
@@ -90,13 +106,21 @@ fn test_update_collateral_positive_delta() {
     let creator = Address::generate(&env);
     let backing_token = Address::generate(&env);
     let asset_id = 1u64;
-    
+
     // Create asset with initial collateral of 1500
-    create_test_asset(&env, asset_id, creator.clone(), backing_token.clone(), 1000, 1500, 10);
-    
+    create_test_asset(
+        &env,
+        asset_id,
+        creator.clone(),
+        backing_token.clone(),
+        1000,
+        1500,
+        10,
+    );
+
     // Update collateral by +500 (locking)
     update_collateral(&env, asset_id, 500).unwrap();
-    
+
     // Verify collateral increased
     let new_collateral = get_total_collateral(&env, asset_id).unwrap();
     assert_eq!(new_collateral, 2000);
@@ -108,13 +132,21 @@ fn test_update_collateral_negative_delta() {
     let creator = Address::generate(&env);
     let backing_token = Address::generate(&env);
     let asset_id = 1u64;
-    
+
     // Create asset with initial collateral of 1500
-    create_test_asset(&env, asset_id, creator.clone(), backing_token.clone(), 1000, 1500, 10);
-    
+    create_test_asset(
+        &env,
+        asset_id,
+        creator.clone(),
+        backing_token.clone(),
+        1000,
+        1500,
+        10,
+    );
+
     // Update collateral by -300 (unlocking)
     update_collateral(&env, asset_id, -300).unwrap();
-    
+
     // Verify collateral decreased
     let new_collateral = get_total_collateral(&env, asset_id).unwrap();
     assert_eq!(new_collateral, 1200);
@@ -124,10 +156,10 @@ fn test_update_collateral_negative_delta() {
 fn test_update_collateral_nonexistent_asset() {
     let env = Env::default();
     let asset_id = 999u64;
-    
+
     // Try to update collateral for non-existent asset
     let result = update_collateral(&env, asset_id, 100);
-    
+
     // Should return SyntheticAssetNotFound error
     assert_eq!(result, Err(TipJarError::SyntheticAssetNotFound));
 }
@@ -138,14 +170,22 @@ fn test_get_collateralization_ratio_normal() {
     let creator = Address::generate(&env);
     let backing_token = Address::generate(&env);
     let asset_id = 1u64;
-    
+
     // Create asset with:
     // - total_supply: 1000
     // - oracle_price: 10
     // - total_collateral: 15000
     // Expected ratio: (15000 / (1000 * 10)) * 10000 = 15000 bps (150%)
-    create_test_asset(&env, asset_id, creator.clone(), backing_token.clone(), 1000, 15000, 10);
-    
+    create_test_asset(
+        &env,
+        asset_id,
+        creator.clone(),
+        backing_token.clone(),
+        1000,
+        15000,
+        10,
+    );
+
     let ratio = get_collateralization_ratio(&env, asset_id).unwrap();
     assert_eq!(ratio, 15000);
 }
@@ -156,10 +196,18 @@ fn test_get_collateralization_ratio_zero_supply() {
     let creator = Address::generate(&env);
     let backing_token = Address::generate(&env);
     let asset_id = 1u64;
-    
+
     // Create asset with zero supply
-    create_test_asset(&env, asset_id, creator.clone(), backing_token.clone(), 0, 1000, 10);
-    
+    create_test_asset(
+        &env,
+        asset_id,
+        creator.clone(),
+        backing_token.clone(),
+        0,
+        1000,
+        10,
+    );
+
     // When supply is zero, ratio should be u32::MAX (infinite)
     let ratio = get_collateralization_ratio(&env, asset_id).unwrap();
     assert_eq!(ratio, u32::MAX);
@@ -171,10 +219,18 @@ fn test_get_collateralization_ratio_zero_price() {
     let creator = Address::generate(&env);
     let backing_token = Address::generate(&env);
     let asset_id = 1u64;
-    
+
     // Create asset with zero oracle price
-    create_test_asset(&env, asset_id, creator.clone(), backing_token.clone(), 1000, 1500, 0);
-    
+    create_test_asset(
+        &env,
+        asset_id,
+        creator.clone(),
+        backing_token.clone(),
+        1000,
+        1500,
+        0,
+    );
+
     // When price is zero, synthetic value is zero, ratio should be u32::MAX
     let ratio = get_collateralization_ratio(&env, asset_id).unwrap();
     assert_eq!(ratio, u32::MAX);
@@ -186,14 +242,22 @@ fn test_get_collateralization_ratio_undercollateralized() {
     let creator = Address::generate(&env);
     let backing_token = Address::generate(&env);
     let asset_id = 1u64;
-    
+
     // Create asset with:
     // - total_supply: 1000
     // - oracle_price: 10
     // - total_collateral: 8000
     // Expected ratio: (8000 / (1000 * 10)) * 10000 = 8000 bps (80%)
-    create_test_asset(&env, asset_id, creator.clone(), backing_token.clone(), 1000, 8000, 10);
-    
+    create_test_asset(
+        &env,
+        asset_id,
+        creator.clone(),
+        backing_token.clone(),
+        1000,
+        8000,
+        10,
+    );
+
     let ratio = get_collateralization_ratio(&env, asset_id).unwrap();
     assert_eq!(ratio, 8000);
 }
@@ -204,14 +268,22 @@ fn test_get_collateralization_ratio_overcollateralized() {
     let creator = Address::generate(&env);
     let backing_token = Address::generate(&env);
     let asset_id = 1u64;
-    
+
     // Create asset with:
     // - total_supply: 1000
     // - oracle_price: 10
     // - total_collateral: 50000
     // Expected ratio: (50000 / (1000 * 10)) * 10000 = 50000 bps (500%)
-    create_test_asset(&env, asset_id, creator.clone(), backing_token.clone(), 1000, 50000, 10);
-    
+    create_test_asset(
+        &env,
+        asset_id,
+        creator.clone(),
+        backing_token.clone(),
+        1000,
+        50000,
+        10,
+    );
+
     let ratio = get_collateralization_ratio(&env, asset_id).unwrap();
     assert_eq!(ratio, 50000);
 }
@@ -220,10 +292,10 @@ fn test_get_collateralization_ratio_overcollateralized() {
 fn test_get_collateralization_ratio_nonexistent_asset() {
     let env = Env::default();
     let asset_id = 999u64;
-    
+
     // Try to get ratio for non-existent asset
     let result = get_collateralization_ratio(&env, asset_id);
-    
+
     // Should return SyntheticAssetNotFound error
     assert_eq!(result, Err(TipJarError::SyntheticAssetNotFound));
 }
@@ -234,10 +306,18 @@ fn test_get_total_supply() {
     let creator = Address::generate(&env);
     let backing_token = Address::generate(&env);
     let asset_id = 1u64;
-    
+
     // Create asset with specific supply
-    create_test_asset(&env, asset_id, creator.clone(), backing_token.clone(), 12345, 15000, 10);
-    
+    create_test_asset(
+        &env,
+        asset_id,
+        creator.clone(),
+        backing_token.clone(),
+        12345,
+        15000,
+        10,
+    );
+
     let supply = get_total_supply(&env, asset_id).unwrap();
     assert_eq!(supply, 12345);
 }
@@ -246,10 +326,10 @@ fn test_get_total_supply() {
 fn test_get_total_supply_nonexistent_asset() {
     let env = Env::default();
     let asset_id = 999u64;
-    
+
     // Try to get supply for non-existent asset
     let result = get_total_supply(&env, asset_id);
-    
+
     // Should return SyntheticAssetNotFound error
     assert_eq!(result, Err(TipJarError::SyntheticAssetNotFound));
 }
@@ -260,10 +340,18 @@ fn test_get_total_collateral() {
     let creator = Address::generate(&env);
     let backing_token = Address::generate(&env);
     let asset_id = 1u64;
-    
+
     // Create asset with specific collateral
-    create_test_asset(&env, asset_id, creator.clone(), backing_token.clone(), 1000, 67890, 10);
-    
+    create_test_asset(
+        &env,
+        asset_id,
+        creator.clone(),
+        backing_token.clone(),
+        1000,
+        67890,
+        10,
+    );
+
     let collateral = get_total_collateral(&env, asset_id).unwrap();
     assert_eq!(collateral, 67890);
 }
@@ -272,10 +360,10 @@ fn test_get_total_collateral() {
 fn test_get_total_collateral_nonexistent_asset() {
     let env = Env::default();
     let asset_id = 999u64;
-    
+
     // Try to get collateral for non-existent asset
     let result = get_total_collateral(&env, asset_id);
-    
+
     // Should return SyntheticAssetNotFound error
     assert_eq!(result, Err(TipJarError::SyntheticAssetNotFound));
 }
@@ -286,16 +374,24 @@ fn test_supply_tracking_invariant() {
     let creator = Address::generate(&env);
     let backing_token = Address::generate(&env);
     let asset_id = 1u64;
-    
+
     // Create asset with initial supply of 1000
-    create_test_asset(&env, asset_id, creator.clone(), backing_token.clone(), 1000, 1500, 10);
-    
+    create_test_asset(
+        &env,
+        asset_id,
+        creator.clone(),
+        backing_token.clone(),
+        1000,
+        1500,
+        10,
+    );
+
     // Perform multiple operations
-    update_supply(&env, asset_id, 500).unwrap();  // +500 -> 1500
-    update_supply(&env, asset_id, 300).unwrap();  // +300 -> 1800
+    update_supply(&env, asset_id, 500).unwrap(); // +500 -> 1500
+    update_supply(&env, asset_id, 300).unwrap(); // +300 -> 1800
     update_supply(&env, asset_id, -200).unwrap(); // -200 -> 1600
     update_supply(&env, asset_id, -100).unwrap(); // -100 -> 1500
-    
+
     // Verify final supply
     let final_supply = get_total_supply(&env, asset_id).unwrap();
     assert_eq!(final_supply, 1500);
@@ -307,16 +403,24 @@ fn test_collateral_tracking_invariant() {
     let creator = Address::generate(&env);
     let backing_token = Address::generate(&env);
     let asset_id = 1u64;
-    
+
     // Create asset with initial collateral of 1500
-    create_test_asset(&env, asset_id, creator.clone(), backing_token.clone(), 1000, 1500, 10);
-    
+    create_test_asset(
+        &env,
+        asset_id,
+        creator.clone(),
+        backing_token.clone(),
+        1000,
+        1500,
+        10,
+    );
+
     // Perform multiple operations
-    update_collateral(&env, asset_id, 500).unwrap();  // +500 -> 2000
-    update_collateral(&env, asset_id, 300).unwrap();  // +300 -> 2300
+    update_collateral(&env, asset_id, 500).unwrap(); // +500 -> 2000
+    update_collateral(&env, asset_id, 300).unwrap(); // +300 -> 2300
     update_collateral(&env, asset_id, -200).unwrap(); // -200 -> 2100
     update_collateral(&env, asset_id, -100).unwrap(); // -100 -> 2000
-    
+
     // Verify final collateral
     let final_collateral = get_total_collateral(&env, asset_id).unwrap();
     assert_eq!(final_collateral, 2000);
@@ -328,17 +432,25 @@ fn test_collateralization_ratio_after_supply_change() {
     let creator = Address::generate(&env);
     let backing_token = Address::generate(&env);
     let asset_id = 1u64;
-    
+
     // Create asset with 150% collateralization
     // supply: 1000, price: 10, collateral: 15000
-    create_test_asset(&env, asset_id, creator.clone(), backing_token.clone(), 1000, 15000, 10);
-    
+    create_test_asset(
+        &env,
+        asset_id,
+        creator.clone(),
+        backing_token.clone(),
+        1000,
+        15000,
+        10,
+    );
+
     let initial_ratio = get_collateralization_ratio(&env, asset_id).unwrap();
     assert_eq!(initial_ratio, 15000);
-    
+
     // Increase supply (minting) without adding collateral
     update_supply(&env, asset_id, 500).unwrap(); // supply now 1500
-    
+
     // Ratio should decrease: (15000 / (1500 * 10)) * 10000 = 10000 bps (100%)
     let new_ratio = get_collateralization_ratio(&env, asset_id).unwrap();
     assert_eq!(new_ratio, 10000);
@@ -350,17 +462,25 @@ fn test_collateralization_ratio_after_collateral_change() {
     let creator = Address::generate(&env);
     let backing_token = Address::generate(&env);
     let asset_id = 1u64;
-    
+
     // Create asset with 150% collateralization
     // supply: 1000, price: 10, collateral: 15000
-    create_test_asset(&env, asset_id, creator.clone(), backing_token.clone(), 1000, 15000, 10);
-    
+    create_test_asset(
+        &env,
+        asset_id,
+        creator.clone(),
+        backing_token.clone(),
+        1000,
+        15000,
+        10,
+    );
+
     let initial_ratio = get_collateralization_ratio(&env, asset_id).unwrap();
     assert_eq!(initial_ratio, 15000);
-    
+
     // Add collateral
     update_collateral(&env, asset_id, 5000).unwrap(); // collateral now 20000
-    
+
     // Ratio should increase: (20000 / (1000 * 10)) * 10000 = 20000 bps (200%)
     let new_ratio = get_collateralization_ratio(&env, asset_id).unwrap();
     assert_eq!(new_ratio, 20000);

--- a/contracts/tipjar/tests/threshold_sig_tests.rs
+++ b/contracts/tipjar/tests/threshold_sig_tests.rs
@@ -4,8 +4,8 @@ extern crate std;
 
 use soroban_sdk::{testutils::Address as _, vec, Address, Env, Vec};
 use tipjar::{
-    threshold_sig::{ThresholdTipStatus},
-    ThresholdError, TipJarContract, TipJarContractClient, TipJarError,
+    threshold_sig::ThresholdTipStatus, ThresholdError, TipJarContract, TipJarContractClient,
+    TipJarError,
 };
 
 fn setup() -> (Env, TipJarContractClient<'static>, Address, Address) {

--- a/contracts/tipjar/tests/tip_message_tests.rs
+++ b/contracts/tipjar/tests/tip_message_tests.rs
@@ -10,11 +10,25 @@ use tipjar::{DataKey, TipJarContract, TipJarContractClient, TipJarError, TipMeta
 
 // ── helpers ──────────────────────────────────────────────────────────────────
 
-fn setup() -> (Env, TipJarContractClient<'static>, Address, Address, Address) {
+fn setup() -> (
+    Env,
+    TipJarContractClient<'static>,
+    Address,
+    Address,
+    Address,
+) {
     setup_with_expiry(0)
 }
 
-fn setup_with_expiry(expiry_seconds: u64) -> (Env, TipJarContractClient<'static>, Address, Address, Address) {
+fn setup_with_expiry(
+    expiry_seconds: u64,
+) -> (
+    Env,
+    TipJarContractClient<'static>,
+    Address,
+    Address,
+    Address,
+) {
     let env = Env::default();
     env.mock_all_auths();
 
@@ -45,7 +59,8 @@ fn test_tip_with_message_stores_metadata() {
     let (env, client, sender, creator, token) = setup();
 
     let msg = String::from_str(&env, "Great content, keep it up!");
-    let tip_index = client.tip_with_message(&sender, &creator, &token, &500i128, &Some(msg.clone()));
+    let tip_index =
+        client.tip_with_message(&sender, &creator, &token, &500i128, &Some(msg.clone()));
 
     assert_eq!(tip_index, 0);
 
@@ -168,13 +183,12 @@ fn test_storage_efficiency_tip_count_increments() {
     for i in 0u64..3 {
         client.tip_with_message(&sender, &creator, &token, &100i128, &None);
         // Verify the count key matches expected value.
-        let count: u64 = env
-            .as_contract(&client.address, || {
-                env.storage()
-                    .persistent()
-                    .get::<DataKey, u64>(&DataKey::TipCount(creator.clone()))
-                    .unwrap_or(0)
-            });
+        let count: u64 = env.as_contract(&client.address, || {
+            env.storage()
+                .persistent()
+                .get::<DataKey, u64>(&DataKey::TipCount(creator.clone()))
+                .unwrap_or(0)
+        });
         assert_eq!(count, i + 1);
     }
 }
@@ -216,5 +230,8 @@ fn test_process_expired_tips_refunds_unclaimed_locked_tip() {
     // Sender should be refunded and lock should be removed.
     assert_eq!(token_client.balance(&sender), 1_000i128);
     let result = client.try_tip_locked(&sender, &creator, &token, &500i128, &unlock_time);
-    assert!(result.is_ok(), "locked tip should still be creatable after refund");
+    assert!(
+        result.is_ok(),
+        "locked tip should still be creatable after refund"
+    );
 }

--- a/contracts/tipjar/tests/twap_oracle_tests.rs
+++ b/contracts/tipjar/tests/twap_oracle_tests.rs
@@ -12,7 +12,14 @@ use tipjar::{TipJarContract, TipJarContractClient, TipJarError};
 
 const PRECISION: i128 = 10_000_000;
 
-fn setup() -> (Env, TipJarContractClient<'static>, Address, Address, Address, Address) {
+fn setup() -> (
+    Env,
+    TipJarContractClient<'static>,
+    Address,
+    Address,
+    Address,
+    Address,
+) {
     let env = Env::default();
     env.mock_all_auths();
 
@@ -51,8 +58,13 @@ fn test_create_oracle_returns_id() {
     let (env, client, _admin, updater, base, quote) = setup();
 
     let id = client.twap_create_oracle(
-        &updater, &updater, &base, &quote,
-        &1_800u64, &10u32, &(PRECISION),
+        &updater,
+        &updater,
+        &base,
+        &quote,
+        &1_800u64,
+        &10u32,
+        &(PRECISION),
     );
     assert_eq!(id, 1);
 }
@@ -62,8 +74,13 @@ fn test_create_oracle_stores_config() {
     let (env, client, _admin, updater, base, quote) = setup();
 
     let id = client.twap_create_oracle(
-        &updater, &updater, &base, &quote,
-        &3_600u64, &20u32, &(2 * PRECISION),
+        &updater,
+        &updater,
+        &base,
+        &quote,
+        &3_600u64,
+        &20u32,
+        &(2 * PRECISION),
     );
 
     let oracle = client.twap_get_oracle(&id);
@@ -78,8 +95,12 @@ fn test_create_oracle_stores_config() {
 fn test_create_oracle_increments_id() {
     let (env, client, _admin, updater, base, quote) = setup();
 
-    let id1 = client.twap_create_oracle(&updater, &updater, &base, &quote, &1_800u64, &10u32, &PRECISION);
-    let id2 = client.twap_create_oracle(&updater, &updater, &base, &quote, &1_800u64, &10u32, &PRECISION);
+    let id1 = client.twap_create_oracle(
+        &updater, &updater, &base, &quote, &1_800u64, &10u32, &PRECISION,
+    );
+    let id2 = client.twap_create_oracle(
+        &updater, &updater, &base, &quote, &1_800u64, &10u32, &PRECISION,
+    );
     assert_eq!(id1, 1);
     assert_eq!(id2, 2);
 }
@@ -88,9 +109,8 @@ fn test_create_oracle_increments_id() {
 fn test_create_oracle_invalid_price_fails() {
     let (env, client, _admin, updater, base, quote) = setup();
 
-    let result = client.try_twap_create_oracle(
-        &updater, &updater, &base, &quote, &1_800u64, &10u32, &0i128,
-    );
+    let result =
+        client.try_twap_create_oracle(&updater, &updater, &base, &quote, &1_800u64, &10u32, &0i128);
     assert_eq!(result, Err(Ok(TipJarError::TwapInvalidPrice)));
 }
 
@@ -109,9 +129,13 @@ fn test_create_oracle_window_too_large_fails() {
     let (env, client, _admin, updater, base, quote) = setup();
 
     let result = client.try_twap_create_oracle(
-        &updater, &updater, &base, &quote,
+        &updater,
+        &updater,
+        &base,
+        &quote,
         &(8 * 24 * 3600u64), // 8 days — exceeds max
-        &10u32, &PRECISION,
+        &10u32,
+        &PRECISION,
     );
     assert_eq!(result, Err(Ok(TipJarError::TwapInvalidWindow)));
 }
@@ -233,7 +257,13 @@ fn test_get_latest_price_returns_seed() {
     let (env, client, _admin, updater, base, quote) = setup();
 
     let id = client.twap_create_oracle(
-        &updater, &updater, &base, &quote, &1_800u64, &10u32, &(5 * PRECISION),
+        &updater,
+        &updater,
+        &base,
+        &quote,
+        &1_800u64,
+        &10u32,
+        &(5 * PRECISION),
     );
 
     let price = client.twap_get_latest_price(&id);
@@ -262,7 +292,13 @@ fn test_twap_with_single_observation_returns_spot() {
     let (env, client, _admin, updater, base, quote) = setup();
 
     let id = client.twap_create_oracle(
-        &updater, &updater, &base, &quote, &1_800u64, &10u32, &(3 * PRECISION),
+        &updater,
+        &updater,
+        &base,
+        &quote,
+        &1_800u64,
+        &10u32,
+        &(3 * PRECISION),
     );
 
     // Only seed observation — TWAP falls back to spot price
@@ -276,9 +312,8 @@ fn test_twap_constant_price_equals_spot() {
     let (env, client, _admin, updater, base, quote) = setup();
 
     let price = 4 * PRECISION;
-    let id = client.twap_create_oracle(
-        &updater, &updater, &base, &quote, &1_800u64, &10u32, &price,
-    );
+    let id =
+        client.twap_create_oracle(&updater, &updater, &base, &quote, &1_800u64, &10u32, &price);
 
     // Record the same price multiple times
     for _ in 0..5 {
@@ -297,7 +332,13 @@ fn test_twap_averages_rising_prices() {
     let (env, client, _admin, updater, base, quote) = setup();
 
     let id = client.twap_create_oracle(
-        &updater, &updater, &base, &quote, &3_600u64, &20u32, &(1 * PRECISION),
+        &updater,
+        &updater,
+        &base,
+        &quote,
+        &3_600u64,
+        &20u32,
+        &(1 * PRECISION),
     );
 
     // Record prices 1, 2, 3, 4, 5 at equal intervals
@@ -341,7 +382,13 @@ fn test_get_observations_returns_seed() {
     let (env, client, _admin, updater, base, quote) = setup();
 
     let id = client.twap_create_oracle(
-        &updater, &updater, &base, &quote, &1_800u64, &10u32, &(2 * PRECISION),
+        &updater,
+        &updater,
+        &base,
+        &quote,
+        &1_800u64,
+        &10u32,
+        &(2 * PRECISION),
     );
 
     let obs = client.twap_get_observations(&id, &5u32);

--- a/contracts/tipjar/tests/vesting_schedule_tests.rs
+++ b/contracts/tipjar/tests/vesting_schedule_tests.rs
@@ -2,10 +2,19 @@
 
 extern crate std;
 
-use soroban_sdk::{testutils::{Address as _, Ledger}, Address, Env, String};
-use tipjar::{DataKey, VestingSchedule, TipJarContract, TipJarContractClient, TipJarError};
+use soroban_sdk::{
+    testutils::{Address as _, Ledger},
+    Address, Env, String,
+};
+use tipjar::{DataKey, TipJarContract, TipJarContractClient, TipJarError, VestingSchedule};
 
-fn setup() -> (Env, TipJarContractClient<'static>, Address, Address, Address) {
+fn setup() -> (
+    Env,
+    TipJarContractClient<'static>,
+    Address,
+    Address,
+    Address,
+) {
     let env = Env::default();
     env.mock_all_auths();
 
@@ -35,8 +44,8 @@ fn test_create_vesting_schedule() {
         &creator,
         &token,
         &1000i128,
-        &86400u64,  // 1 day cliff
-        &2592000u64 // 30 days total vesting
+        &86400u64,   // 1 day cliff
+        &2592000u64, // 30 days total vesting
     );
 
     assert_eq!(schedule_id, 0);
@@ -62,7 +71,7 @@ fn test_vested_amount_before_cliff() {
         &token,
         &1000i128,
         &86400u64,
-        &2592000u64
+        &2592000u64,
     );
 
     // Before cliff: 0 vested
@@ -79,8 +88,8 @@ fn test_vested_amount_after_cliff() {
         &creator,
         &token,
         &1000i128,
-        &86400u64,  // 1 day cliff
-        &2592000u64 // 30 days total
+        &86400u64,   // 1 day cliff
+        &2592000u64, // 30 days total
     );
 
     // Advance time past cliff (1 day + 1 second)
@@ -103,7 +112,7 @@ fn test_vested_amount_at_full_vesting() {
         &token,
         &1000i128,
         &86400u64,
-        &2592000u64
+        &2592000u64,
     );
 
     // Advance time past total vesting duration
@@ -118,12 +127,8 @@ fn test_linear_vesting_progression() {
     let (env, client, tipper, creator, token) = setup();
 
     let schedule_id = client.create_vesting_schedule(
-        &tipper,
-        &creator,
-        &token,
-        &3000i128,
-        &0u64,        // No cliff
-        &3000u64      // 3000 seconds total
+        &tipper, &creator, &token, &3000i128, &0u64,    // No cliff
+        &3000u64, // 3000 seconds total
     );
 
     // At 50% of vesting period (1500 seconds)
@@ -142,12 +147,8 @@ fn test_withdraw_vested_after_cliff() {
     let (env, client, tipper, creator, token) = setup();
 
     let schedule_id = client.create_vesting_schedule(
-        &tipper,
-        &creator,
-        &token,
-        &3000i128,
-        &1000u64,   // 1000 second cliff
-        &3000u64    // 3000 second total vesting
+        &tipper, &creator, &token, &3000i128, &1000u64, // 1000 second cliff
+        &3000u64, // 3000 second total vesting
     );
 
     // Advance past cliff
@@ -165,12 +166,8 @@ fn test_withdraw_vested_partial_then_full() {
     let (env, client, tipper, creator, token) = setup();
 
     let schedule_id = client.create_vesting_schedule(
-        &tipper,
-        &creator,
-        &token,
-        &1000i128,
-        &0u64,      // No cliff
-        &2000u64    // 2000 seconds total
+        &tipper, &creator, &token, &1000i128, &0u64,    // No cliff
+        &2000u64, // 2000 seconds total
     );
 
     // First withdrawal at 25% vesting (500 seconds in)
@@ -198,7 +195,7 @@ fn test_no_vested_before_cliff() {
         &token,
         &1000i128,
         &86400u64,
-        &2592000u64
+        &2592000u64,
     );
 
     // Try to withdraw before cliff
@@ -211,12 +208,8 @@ fn test_cliff_duration_cannot_exceed_vesting() {
     let (env, client, tipper, creator, token) = setup();
 
     let result = client.try_create_vesting_schedule(
-        &tipper,
-        &creator,
-        &token,
-        &1000i128,
-        &3000u64,   // Cliff 3000 seconds
-        &2000u64    // But vesting only 2000 seconds
+        &tipper, &creator, &token, &1000i128, &3000u64, // Cliff 3000 seconds
+        &2000u64, // But vesting only 2000 seconds
     );
 
     assert_eq!(result, Err(Ok(TipJarError::CliffExceedsVesting)));
@@ -230,9 +223,9 @@ fn test_invalid_amount() {
         &tipper,
         &creator,
         &token,
-        &0i128,     // Invalid amount
+        &0i128, // Invalid amount
         &86400u64,
-        &2592000u64
+        &2592000u64,
     );
 
     assert_eq!(result, Err(Ok(TipJarError::InvalidAmount)));
@@ -243,12 +236,7 @@ fn test_invalid_vesting_duration() {
     let (env, client, tipper, creator, token) = setup();
 
     let result = client.try_create_vesting_schedule(
-        &tipper,
-        &creator,
-        &token,
-        &1000i128,
-        &0u64,
-        &0u64       // Invalid duration
+        &tipper, &creator, &token, &1000i128, &0u64, &0u64, // Invalid duration
     );
 
     assert_eq!(result, Err(Ok(TipJarError::InvalidVestingDuration)));
@@ -259,23 +247,9 @@ fn test_get_creator_vesting_schedules() {
     let (env, client, tipper, creator, token) = setup();
 
     // Create multiple schedules
-    let id1 = client.create_vesting_schedule(
-        &tipper,
-        &creator,
-        &token,
-        &1000i128,
-        &0u64,
-        &1000u64
-    );
+    let id1 = client.create_vesting_schedule(&tipper, &creator, &token, &1000i128, &0u64, &1000u64);
 
-    let id2 = client.create_vesting_schedule(
-        &tipper,
-        &creator,
-        &token,
-        &2000i128,
-        &0u64,
-        &2000u64
-    );
+    let id2 = client.create_vesting_schedule(&tipper, &creator, &token, &2000i128, &0u64, &2000u64);
 
     let schedules = client.get_creator_vesting_schedules(&creator);
     assert_eq!(schedules.len(), 2);
@@ -288,14 +262,8 @@ fn test_unauthorized_withdrawal() {
     let (env, client, tipper, creator, token) = setup();
     let other_creator = Address::generate(&env);
 
-    let schedule_id = client.create_vesting_schedule(
-        &tipper,
-        &creator,
-        &token,
-        &1000i128,
-        &0u64,
-        &1000u64
-    );
+    let schedule_id =
+        client.create_vesting_schedule(&tipper, &creator, &token, &1000i128, &0u64, &1000u64);
 
     env.ledger().with_mut(|ledger| ledger.timestamp += 500);
 
@@ -324,14 +292,8 @@ fn test_nonexistent_schedule() {
 fn test_available_vested_amount() {
     let (env, client, tipper, creator, token) = setup();
 
-    let schedule_id = client.create_vesting_schedule(
-        &tipper,
-        &creator,
-        &token,
-        &1000i128,
-        &0u64,
-        &2000u64
-    );
+    let schedule_id =
+        client.create_vesting_schedule(&tipper, &creator, &token, &1000i128, &0u64, &2000u64);
 
     // At 50% vesting
     env.ledger().with_mut(|ledger| ledger.timestamp += 1000);
@@ -353,12 +315,8 @@ fn test_no_cliff_vesting() {
     let (env, client, tipper, creator, token) = setup();
 
     let schedule_id = client.create_vesting_schedule(
-        &tipper,
-        &creator,
-        &token,
-        &2000i128,
-        &0u64,      // No cliff
-        &2000u64
+        &tipper, &creator, &token, &2000i128, &0u64, // No cliff
+        &2000u64,
     );
 
     // At 1% of duration, should have vested

--- a/contracts/tipjar/tests/withdrawal_limits_tests.rs
+++ b/contracts/tipjar/tests/withdrawal_limits_tests.rs
@@ -10,7 +10,14 @@ use tipjar::{TipJarContract, TipJarContractClient, TipJarError};
 
 // ── helpers ───────────────────────────────────────────────────────────────────
 
-fn setup() -> (Env, TipJarContractClient<'static>, Address, Address, Address, Address) {
+fn setup() -> (
+    Env,
+    TipJarContractClient<'static>,
+    Address,
+    Address,
+    Address,
+    Address,
+) {
     let env = Env::default();
     env.mock_all_auths();
 
@@ -25,10 +32,16 @@ fn setup() -> (Env, TipJarContractClient<'static>, Address, Address, Address, Ad
     client.add_token(&admin, &token_id);
 
     let sender = Address::generate(&env);
-    soroban_sdk::token::StellarAssetClient::new(&env, &token_id)
-        .mint(&sender, &1_000_000i128);
+    soroban_sdk::token::StellarAssetClient::new(&env, &token_id).mint(&sender, &1_000_000i128);
 
-    (env, client, admin, sender, Address::generate(&env), token_id)
+    (
+        env,
+        client,
+        admin,
+        sender,
+        Address::generate(&env),
+        token_id,
+    )
 }
 
 // ── get_withdrawal_limits ─────────────────────────────────────────────────────

--- a/indexer/src/indexer/event_listener.rs
+++ b/indexer/src/indexer/event_listener.rs
@@ -44,7 +44,11 @@ impl EventIndexer {
             max_retries,
             start_ledger,
         ));
-        Self { listener, pool, contract_id }
+        Self {
+            listener,
+            pool,
+            contract_id,
+        }
     }
 
     /// Starts the monitoring loop.
@@ -136,15 +140,24 @@ impl EventIndexer {
 /// Extracts (event_type, sender, recipient, amount) from parsed event data.
 fn classify(topic: &str, parsed: &Value) -> (String, Option<String>, Option<String>, Option<i64>) {
     let fields = parsed.get("fields").unwrap_or(parsed);
-    let sender    = fields.get("sender").and_then(|v| v.as_str()).map(str::to_owned);
-    let creator   = fields.get("creator").and_then(|v| v.as_str()).map(str::to_owned);
-    let amount    = fields.get("amount").and_then(|v| v.as_str()).and_then(|s| s.parse::<i64>().ok())
+    let sender = fields
+        .get("sender")
+        .and_then(|v| v.as_str())
+        .map(str::to_owned);
+    let creator = fields
+        .get("creator")
+        .and_then(|v| v.as_str())
+        .map(str::to_owned);
+    let amount = fields
+        .get("amount")
+        .and_then(|v| v.as_str())
+        .and_then(|s| s.parse::<i64>().ok())
         .or_else(|| fields.get("amount").and_then(|v| v.as_i64()));
 
     let (event_type, recipient) = match topic {
-        "tip"      => ("tip".to_owned(),      creator),
-        "withdraw" => ("withdraw".to_owned(),  creator),
-        other      => (other.to_owned(),       creator),
+        "tip" => ("tip".to_owned(), creator),
+        "withdraw" => ("withdraw".to_owned(), creator),
+        other => (other.to_owned(), creator),
     };
 
     (event_type, sender, recipient, amount)

--- a/indexer/src/indexer/event_processor.rs
+++ b/indexer/src/indexer/event_processor.rs
@@ -34,13 +34,24 @@ pub struct WithdrawalEventData {
 /// { "topic": ["tip", "<creator>", "<token>"], "value": ["<sender>", "<amount>"] }
 /// ```
 pub fn parse_tip_event(raw: &Value) -> Result<TipEventData> {
-    let topic = raw.get("topic").and_then(|v| v.as_array()).ok_or_else(|| anyhow!("missing topic array"))?;
+    let topic = raw
+        .get("topic")
+        .and_then(|v| v.as_array())
+        .ok_or_else(|| anyhow!("missing topic array"))?;
     let creator = str_at(topic, 1, "creator")?;
-    let token   = str_at(topic, 2, "token")?;
-    let value   = raw.get("value").and_then(|v| v.as_array()).ok_or_else(|| anyhow!("tip value is not an array"))?;
-    let sender  = str_at(value, 0, "sender")?;
-    let amount  = str_at(value, 1, "amount")?;
-    Ok(TipEventData { creator, token, sender, amount })
+    let token = str_at(topic, 2, "token")?;
+    let value = raw
+        .get("value")
+        .and_then(|v| v.as_array())
+        .ok_or_else(|| anyhow!("tip value is not an array"))?;
+    let sender = str_at(value, 0, "sender")?;
+    let amount = str_at(value, 1, "amount")?;
+    Ok(TipEventData {
+        creator,
+        token,
+        sender,
+        amount,
+    })
 }
 
 /// Parses a raw Horizon/RPC event value into [`WithdrawalEventData`].
@@ -50,11 +61,18 @@ pub fn parse_tip_event(raw: &Value) -> Result<TipEventData> {
 /// { "topic": ["withdraw", "<creator>", "<token>"], "value": "<amount>" }
 /// ```
 pub fn parse_withdrawal_event(raw: &Value) -> Result<WithdrawalEventData> {
-    let topic   = raw.get("topic").and_then(|v| v.as_array()).ok_or_else(|| anyhow!("missing topic array"))?;
+    let topic = raw
+        .get("topic")
+        .and_then(|v| v.as_array())
+        .ok_or_else(|| anyhow!("missing topic array"))?;
     let creator = str_at(topic, 1, "creator")?;
-    let token   = str_at(topic, 2, "token")?;
-    let amount  = val_to_string(raw.get("value").unwrap_or(&Value::Null));
-    Ok(WithdrawalEventData { creator, token, amount })
+    let token = str_at(topic, 2, "token")?;
+    let amount = val_to_string(raw.get("value").unwrap_or(&Value::Null));
+    Ok(WithdrawalEventData {
+        creator,
+        token,
+        amount,
+    })
 }
 
 /// POSTs `payload` to `url` with up to 3 attempts (backoff: 1 s, 2 s, 4 s).

--- a/security/src/alerting.rs
+++ b/security/src/alerting.rs
@@ -7,10 +7,20 @@ use uuid::Uuid;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "kind")]
 pub enum Alert {
-    RateLimited { address: String },
-    AnomalyDetected { tx_hash: String, sender: String, score: f64 },
-    Blacklisted { address: String },
-    CircuitBreakerTripped { reason: String },
+    RateLimited {
+        address: String,
+    },
+    AnomalyDetected {
+        tx_hash: String,
+        sender: String,
+        score: f64,
+    },
+    Blacklisted {
+        address: String,
+    },
+    CircuitBreakerTripped {
+        reason: String,
+    },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/security/src/anomaly_detector.rs
+++ b/security/src/anomaly_detector.rs
@@ -14,7 +14,11 @@ struct Stats {
 
 impl Stats {
     fn new() -> Self {
-        Self { count: 0, mean: 0.0, m2: 0.0 }
+        Self {
+            count: 0,
+            mean: 0.0,
+            m2: 0.0,
+        }
     }
 
     fn update(&mut self, value: f64) {

--- a/security/src/circuit_breaker.rs
+++ b/security/src/circuit_breaker.rs
@@ -1,11 +1,11 @@
+use chrono::{DateTime, Utc};
 /// Automated circuit breaker — trips after too many anomalies in a time window.
 use std::sync::Mutex;
-use chrono::{DateTime, Utc};
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum CircuitState {
-    Closed,   // normal operation
-    Open,     // tripped — all transactions blocked
+    Closed, // normal operation
+    Open,   // tripped — all transactions blocked
 }
 
 pub struct CircuitBreaker {

--- a/security/src/monitor.rs
+++ b/security/src/monitor.rs
@@ -38,7 +38,12 @@ impl SecurityMonitor {
         circuit_breaker: CircuitBreaker,
         alerting: AlertingService,
     ) -> Self {
-        Self { rate_limiter, anomaly_detector, circuit_breaker, alerting }
+        Self {
+            rate_limiter,
+            anomaly_detector,
+            circuit_breaker,
+            alerting,
+        }
     }
 
     /// Evaluate a transaction against all security controls.
@@ -51,7 +56,9 @@ impl SecurityMonitor {
         // 2. Blacklist check
         if self.rate_limiter.is_blacklisted(&tx.sender) {
             self.alerting
-                .send_alert(Alert::Blacklisted { address: tx.sender.clone() })
+                .send_alert(Alert::Blacklisted {
+                    address: tx.sender.clone(),
+                })
                 .await;
             return SecurityCheck::Blocked;
         }
@@ -59,7 +66,9 @@ impl SecurityMonitor {
         // 3. Rate limiting
         if !self.rate_limiter.check(&tx.sender) {
             self.alerting
-                .send_alert(Alert::RateLimited { address: tx.sender.clone() })
+                .send_alert(Alert::RateLimited {
+                    address: tx.sender.clone(),
+                })
                 .await;
             return SecurityCheck::RateLimited;
         }

--- a/security/src/rate_limiter.rs
+++ b/security/src/rate_limiter.rs
@@ -1,7 +1,7 @@
+use chrono::{DateTime, Utc};
 /// Rate limiter using an in-memory sliding window per address.
 use std::collections::HashMap;
 use std::sync::Mutex;
-use chrono::{DateTime, Utc};
 
 pub struct RateLimiter {
     /// max transactions per window
@@ -69,10 +69,16 @@ impl RateLimiter {
     }
 
     pub fn is_blacklisted(&self, address: &str) -> bool {
-        self.blacklist.lock().unwrap().contains(&address.to_string())
+        self.blacklist
+            .lock()
+            .unwrap()
+            .contains(&address.to_string())
     }
 
     pub fn is_whitelisted(&self, address: &str) -> bool {
-        self.whitelist.lock().unwrap().contains(&address.to_string())
+        self.whitelist
+            .lock()
+            .unwrap()
+            .contains(&address.to_string())
     }
 }

--- a/security/tests/security_monitor_tests.rs
+++ b/security/tests/security_monitor_tests.rs
@@ -30,9 +30,15 @@ fn tx(sender: &str, amount: i64) -> Transaction {
 async fn test_rate_limit_enforced() {
     let monitor = make_monitor(3, 1_000_000, 100);
     for _ in 0..3 {
-        assert_eq!(monitor.check_transaction(&tx("alice", 100)).await, SecurityCheck::Approved);
+        assert_eq!(
+            monitor.check_transaction(&tx("alice", 100)).await,
+            SecurityCheck::Approved
+        );
     }
-    assert_eq!(monitor.check_transaction(&tx("alice", 100)).await, SecurityCheck::RateLimited);
+    assert_eq!(
+        monitor.check_transaction(&tx("alice", 100)).await,
+        SecurityCheck::RateLimited
+    );
 }
 
 #[tokio::test]
@@ -40,7 +46,10 @@ async fn test_whitelist_bypasses_rate_limit() {
     let monitor = make_monitor(1, 1_000_000, 100);
     monitor.whitelist("vip");
     for _ in 0..5 {
-        assert_eq!(monitor.check_transaction(&tx("vip", 100)).await, SecurityCheck::Approved);
+        assert_eq!(
+            monitor.check_transaction(&tx("vip", 100)).await,
+            SecurityCheck::Approved
+        );
     }
 }
 
@@ -50,7 +59,10 @@ async fn test_whitelist_bypasses_rate_limit() {
 async fn test_blacklist_blocks_address() {
     let monitor = make_monitor(10, 1_000_000, 100);
     monitor.blacklist("bad-actor");
-    assert_eq!(monitor.check_transaction(&tx("bad-actor", 100)).await, SecurityCheck::Blocked);
+    assert_eq!(
+        monitor.check_transaction(&tx("bad-actor", 100)).await,
+        SecurityCheck::Blocked
+    );
 }
 
 #[tokio::test]
@@ -58,7 +70,10 @@ async fn test_unblacklist_restores_access() {
     let monitor = make_monitor(10, 1_000_000, 100);
     monitor.blacklist("addr");
     monitor.unblacklist("addr");
-    assert_eq!(monitor.check_transaction(&tx("addr", 100)).await, SecurityCheck::Approved);
+    assert_eq!(
+        monitor.check_transaction(&tx("addr", 100)).await,
+        SecurityCheck::Approved
+    );
 }
 
 // ── Anomaly detection ─────────────────────────────────────────────────────────
@@ -77,7 +92,10 @@ async fn test_anomaly_detected_on_huge_amount() {
 async fn test_normal_amounts_approved() {
     let monitor = make_monitor(100, 1_000_000, 100);
     for _ in 0..5 {
-        assert_eq!(monitor.check_transaction(&tx("carol", 100)).await, SecurityCheck::Approved);
+        assert_eq!(
+            monitor.check_transaction(&tx("carol", 100)).await,
+            SecurityCheck::Approved
+        );
     }
 }
 
@@ -90,14 +108,23 @@ async fn test_circuit_breaker_trips_after_threshold() {
     monitor.check_transaction(&tx("x", 1_000_000)).await;
     monitor.check_transaction(&tx("y", 1_000_000)).await;
     // Circuit should now be open
-    assert_eq!(monitor.check_transaction(&tx("z", 1)).await, SecurityCheck::CircuitOpen);
+    assert_eq!(
+        monitor.check_transaction(&tx("z", 1)).await,
+        SecurityCheck::CircuitOpen
+    );
 }
 
 #[tokio::test]
 async fn test_circuit_breaker_reset() {
     let monitor = make_monitor(100, 1, 1);
     monitor.check_transaction(&tx("x", 1_000_000)).await;
-    assert_eq!(monitor.check_transaction(&tx("y", 1)).await, SecurityCheck::CircuitOpen);
+    assert_eq!(
+        monitor.check_transaction(&tx("y", 1)).await,
+        SecurityCheck::CircuitOpen
+    );
     monitor.reset_circuit_breaker();
-    assert_eq!(monitor.check_transaction(&tx("y", 1)).await, SecurityCheck::Approved);
+    assert_eq!(
+        monitor.check_transaction(&tx("y", 1)).await,
+        SecurityCheck::Approved
+    );
 }

--- a/simulator/src/main.rs
+++ b/simulator/src/main.rs
@@ -55,7 +55,10 @@ fn main() -> Result<()> {
 
             for i in 0..tips {
                 let result = sim.simulate_tip(&sender, &creator, amount);
-                println!("  tip[{i}]: ok={} cpu={}", result.ok, result.cpu_instructions);
+                println!(
+                    "  tip[{i}]: ok={} cpu={}",
+                    result.ok, result.cpu_instructions
+                );
             }
 
             debugger::dump_balances(&sim, &[("creator", &creator)]);
@@ -63,7 +66,10 @@ fn main() -> Result<()> {
 
             println!("==> Simulating withdrawal");
             let result = sim.simulate_withdraw(&creator);
-            println!("  withdraw: ok={} cpu={}", result.ok, result.cpu_instructions);
+            println!(
+                "  withdraw: ok={} cpu={}",
+                result.ok, result.cpu_instructions
+            );
             debugger::dump_balances(&sim, &[("creator", &creator)]);
 
             if save {

--- a/simulator/src/simulator.rs
+++ b/simulator/src/simulator.rs
@@ -51,7 +51,14 @@ impl Simulator {
             eprintln!("[sim] contract={contract:?}  token={token:?}  admin={admin:?}");
         }
 
-        Self { env, contract, token, token_admin, admin, verbose }
+        Self {
+            env,
+            contract,
+            token,
+            token_admin,
+            admin,
+            verbose,
+        }
     }
 
     fn client(&self) -> TipJarContractClient {
@@ -87,7 +94,11 @@ impl Simulator {
         if self.verbose {
             eprintln!("[sim] tip {amount} → creator={creator:?}  ok={ok}  cpu={cpu}");
         }
-        SimResult { ok, error, cpu_instructions: cpu }
+        SimResult {
+            ok,
+            error,
+            cpu_instructions: cpu,
+        }
     }
 
     /// Simulate a withdrawal and return a `SimResult`.
@@ -100,7 +111,11 @@ impl Simulator {
         if self.verbose {
             eprintln!("[sim] withdraw creator={creator:?}  ok={ok}  cpu={cpu}");
         }
-        SimResult { ok, error, cpu_instructions: cpu }
+        SimResult {
+            ok,
+            error,
+            cpu_instructions: cpu,
+        }
     }
 
     /// Query the withdrawable balance for a creator.

--- a/simulator/tests/simulator_tests.rs
+++ b/simulator/tests/simulator_tests.rs
@@ -38,7 +38,10 @@ fn test_cpu_instructions_reported() {
 
     let r = sim.simulate_tip(&sender, &creator, 100);
     assert!(r.ok);
-    assert!(r.cpu_instructions > 0, "cpu instructions should be non-zero");
+    assert!(
+        r.cpu_instructions > 0,
+        "cpu instructions should be non-zero"
+    );
 }
 
 #[test]

--- a/tests/integration/tip_flow_test.rs
+++ b/tests/integration/tip_flow_test.rs
@@ -27,7 +27,11 @@ impl Ctx {
         let c = TipJarContractClient::new(&env, &contract_id);
         c.init(&admin);
         c.add_token(&admin, &token);
-        Ctx { env, contract_id, token }
+        Ctx {
+            env,
+            contract_id,
+            token,
+        }
     }
 
     fn c(&self) -> TipJarContractClient {
@@ -87,7 +91,10 @@ fn test_withdrawal() {
     ctx.c().withdraw(&creator, &ctx.token);
     assert_eq!(ctx.c().get_withdrawable_balance(&creator, &ctx.token), 0);
     assert_eq!(ctx.c().get_total_tips(&creator, &ctx.token), 500);
-    assert_eq!(token::Client::new(&ctx.env, &ctx.token).balance(&creator), 500);
+    assert_eq!(
+        token::Client::new(&ctx.env, &ctx.token).balance(&creator),
+        500
+    );
 }
 
 #[test]
@@ -103,7 +110,11 @@ fn test_full_withdrawal() {
 fn test_insufficient_balance_rejected() {
     let ctx = Ctx::new();
     let creator = ctx.creator();
-    let err = ctx.c().try_withdraw(&creator, &ctx.token).unwrap_err().unwrap();
+    let err = ctx
+        .c()
+        .try_withdraw(&creator, &ctx.token)
+        .unwrap_err()
+        .unwrap();
     assert_eq!(err, TipJarError::NothingToWithdraw.into());
 }
 
@@ -112,7 +123,11 @@ fn test_invalid_amount_rejected() {
     let ctx = Ctx::new();
     let (tipper, creator) = (ctx.tipper(), ctx.creator());
     for bad in [0i128, -1i128] {
-        let err = ctx.c().try_tip(&tipper, &creator, &ctx.token, &bad).unwrap_err().unwrap();
+        let err = ctx
+            .c()
+            .try_tip(&tipper, &creator, &ctx.token, &bad)
+            .unwrap_err()
+            .unwrap();
         assert_eq!(err, TipJarError::InvalidAmount.into());
     }
 }

--- a/tools/gas-estimator/src/lib.rs
+++ b/tools/gas-estimator/src/lib.rs
@@ -131,7 +131,12 @@ pub fn stroops_to_xlm(stroops: i128) -> f64 {
 }
 
 /// Build a `GasEstimate` from raw budget numbers.
-pub fn make_estimate(function_name: &str, storage_variant: &str, cpu: u64, mem: u64) -> GasEstimate {
+pub fn make_estimate(
+    function_name: &str,
+    storage_variant: &str,
+    cpu: u64,
+    mem: u64,
+) -> GasEstimate {
     let cost = compute_cost_stroops(cpu, mem);
     GasEstimate {
         function_name: function_name.to_string(),
@@ -151,7 +156,11 @@ pub fn make_batch_estimate(
     estimate: &GasEstimate,
 ) -> BatchEstimate {
     let total_cost = compute_cost_stroops(estimate.cpu_instructions, estimate.memory_bytes);
-    let per_item = if size > 0 { total_cost / size as i128 } else { 0 };
+    let per_item = if size > 0 {
+        total_cost / size as i128
+    } else {
+        0
+    };
     BatchEstimate {
         operation: operation.to_string(),
         batch_size: size,
@@ -247,8 +256,12 @@ pub fn generate_suggestions(estimates: &[GasEstimate]) -> Vec<Suggestion> {
     }
 
     // Cold vs warm overhead hint for `tip`
-    let cold = estimates.iter().find(|e| e.function_name == "tip" && e.storage_variant == "cold");
-    let warm = estimates.iter().find(|e| e.function_name == "tip" && e.storage_variant == "warm");
+    let cold = estimates
+        .iter()
+        .find(|e| e.function_name == "tip" && e.storage_variant == "cold");
+    let warm = estimates
+        .iter()
+        .find(|e| e.function_name == "tip" && e.storage_variant == "warm");
     if let (Some(c), Some(w)) = (cold, warm) {
         if w.cpu_instructions > 0 {
             let overhead_pct = (c.cpu_instructions as f64 - w.cpu_instructions as f64)
@@ -269,8 +282,12 @@ pub fn generate_suggestions(estimates: &[GasEstimate]) -> Vec<Suggestion> {
     }
 
     // tip_with_fee congestion comparison
-    let fee_low = estimates.iter().find(|e| e.function_name == "tip_with_fee" && e.storage_variant == "low-congestion");
-    let fee_high = estimates.iter().find(|e| e.function_name == "tip_with_fee" && e.storage_variant == "high-congestion");
+    let fee_low = estimates
+        .iter()
+        .find(|e| e.function_name == "tip_with_fee" && e.storage_variant == "low-congestion");
+    let fee_high = estimates
+        .iter()
+        .find(|e| e.function_name == "tip_with_fee" && e.storage_variant == "high-congestion");
     if let (Some(low), Some(high)) = (fee_low, fee_high) {
         if low.cpu_instructions > 0 {
             let overhead_pct = (high.cpu_instructions as f64 - low.cpu_instructions as f64)
@@ -298,29 +315,72 @@ pub fn generate_comparisons(estimates: &[GasEstimate]) -> Vec<Comparison> {
 
     // (label, baseline_fn, baseline_variant, candidate_fn, candidate_variant)
     let pairs: &[(&str, &str, &str, &str, &str)] = &[
-        ("tip: cold vs warm storage",
-            "tip", "cold", "tip", "warm"),
-        ("tip vs tip_with_fee (low congestion)",
-            "tip", "cold", "tip_with_fee", "low-congestion"),
-        ("tip_with_fee: low vs high congestion",
-            "tip_with_fee", "low-congestion", "tip_with_fee", "high-congestion"),
-        ("tip vs tip_split (3 recipients)",
-            "tip", "cold", "tip_split", "3-recipients"),
-        ("tip_split: 3 vs 10 recipients",
-            "tip_split", "3-recipients", "tip_split", "10-recipients"),
-        ("withdraw vs get_withdrawable_balance",
-            "withdraw", "warm", "get_withdrawable_balance", "warm"),
-        ("create_subscription vs execute_subscription_payment",
-            "create_subscription", "cold", "execute_subscription_payment", "warm"),
-        ("execute_conditional_tip vs tip (cold)",
-            "tip", "cold", "execute_conditional_tip", "cold"),
-        ("get_leaderboard: 1 vs 10 creators",
-            "get_leaderboard", "1-creator", "get_leaderboard", "10-creators"),
+        ("tip: cold vs warm storage", "tip", "cold", "tip", "warm"),
+        (
+            "tip vs tip_with_fee (low congestion)",
+            "tip",
+            "cold",
+            "tip_with_fee",
+            "low-congestion",
+        ),
+        (
+            "tip_with_fee: low vs high congestion",
+            "tip_with_fee",
+            "low-congestion",
+            "tip_with_fee",
+            "high-congestion",
+        ),
+        (
+            "tip vs tip_split (3 recipients)",
+            "tip",
+            "cold",
+            "tip_split",
+            "3-recipients",
+        ),
+        (
+            "tip_split: 3 vs 10 recipients",
+            "tip_split",
+            "3-recipients",
+            "tip_split",
+            "10-recipients",
+        ),
+        (
+            "withdraw vs get_withdrawable_balance",
+            "withdraw",
+            "warm",
+            "get_withdrawable_balance",
+            "warm",
+        ),
+        (
+            "create_subscription vs execute_subscription_payment",
+            "create_subscription",
+            "cold",
+            "execute_subscription_payment",
+            "warm",
+        ),
+        (
+            "execute_conditional_tip vs tip (cold)",
+            "tip",
+            "cold",
+            "execute_conditional_tip",
+            "cold",
+        ),
+        (
+            "get_leaderboard: 1 vs 10 creators",
+            "get_leaderboard",
+            "1-creator",
+            "get_leaderboard",
+            "10-creators",
+        ),
     ];
 
     for (label, base_fn, base_var, cand_fn, cand_var) in pairs {
-        let base = estimates.iter().find(|e| e.function_name == *base_fn && e.storage_variant == *base_var);
-        let cand = estimates.iter().find(|e| e.function_name == *cand_fn && e.storage_variant == *cand_var);
+        let base = estimates
+            .iter()
+            .find(|e| e.function_name == *base_fn && e.storage_variant == *base_var);
+        let cand = estimates
+            .iter()
+            .find(|e| e.function_name == *cand_fn && e.storage_variant == *cand_var);
         if let (Some(b), Some(c)) = (base, cand) {
             let delta = c.cpu_instructions as i64 - b.cpu_instructions as i64;
             let delta_pct = if b.cpu_instructions > 0 {
@@ -360,9 +420,8 @@ pub fn append_to_history(history_path: &str, report: &EstimationReport) -> std::
             suggestions: report.suggestions.clone(),
         },
     };
-    let line = serde_json::to_string(&entry).map_err(|e| {
-        std::io::Error::new(std::io::ErrorKind::Other, e.to_string())
-    })?;
+    let line = serde_json::to_string(&entry)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e.to_string()))?;
     let mut file = std::fs::OpenOptions::new()
         .create(true)
         .append(true)

--- a/tools/gas-estimator/src/main.rs
+++ b/tools/gas-estimator/src/main.rs
@@ -161,10 +161,17 @@ fn main() -> Result<()> {
 // ── Table output ──────────────────────────────────────────────────────────────
 
 fn print_table(report: &EstimationReport) {
-    println!("╔══════════════════════════════════════════════════════════════════════════════════╗");
+    println!(
+        "╔══════════════════════════════════════════════════════════════════════════════════╗"
+    );
     println!("║                  TipJar Gas Cost Estimation Report                              ║");
-    println!("╚══════════════════════════════════════════════════════════════════════════════════╝");
-    println!("  Generated : {}", report.timestamp.format("%Y-%m-%d %H:%M:%S UTC"));
+    println!(
+        "╚══════════════════════════════════════════════════════════════════════════════════╝"
+    );
+    println!(
+        "  Generated : {}",
+        report.timestamp.format("%Y-%m-%d %H:%M:%S UTC")
+    );
     println!("  Network   : {}", report.network);
     println!();
 
@@ -201,8 +208,12 @@ fn print_table(report: &EstimationReport) {
             let extrap = if b.is_extrapolated { "yes" } else { "no" };
             println!(
                 "  {:<35} {:>5}  {:>6}  {:>18}  {:>16.8}  {:>16.8}",
-                b.operation, b.batch_size, extrap,
-                b.total_cpu_instructions, b.total_cost_xlm, b.cost_per_item_xlm,
+                b.operation,
+                b.batch_size,
+                extrap,
+                b.total_cpu_instructions,
+                b.total_cost_xlm,
+                b.cost_per_item_xlm,
             );
         }
         println!();
@@ -213,7 +224,11 @@ fn print_table(report: &EstimationReport) {
         println!("Cost Comparisons");
         println!("{}", "─".repeat(90));
         for c in &report.comparisons {
-            let (arrow, sign) = if c.delta_cpu >= 0 { ("▲", "+") } else { ("▼", "") };
+            let (arrow, sign) = if c.delta_cpu >= 0 {
+                ("▲", "+")
+            } else {
+                ("▼", "")
+            };
             println!(
                 "  {:<55}  {}{}{:.1}%  ({}{} CPU)",
                 c.label, arrow, sign, c.delta_pct, sign, c.delta_cpu
@@ -228,8 +243,8 @@ fn print_table(report: &EstimationReport) {
         println!("{}", "─".repeat(90));
         for s in &report.suggestions {
             let icon = match s.severity {
-                Severity::Info     => "ℹ️ ",
-                Severity::Warning  => "⚠️ ",
+                Severity::Info => "ℹ️ ",
+                Severity::Warning => "⚠️ ",
                 Severity::Critical => "🔴",
             };
             println!("  {} [{}]  {}", icon, s.function, s.message);
@@ -246,7 +261,10 @@ fn print_table(report: &EstimationReport) {
 fn print_markdown(report: &EstimationReport) {
     println!("# TipJar Gas Cost Estimation Report");
     println!();
-    println!("**Generated:** {}  ", report.timestamp.format("%Y-%m-%d %H:%M:%S UTC"));
+    println!(
+        "**Generated:** {}  ",
+        report.timestamp.format("%Y-%m-%d %H:%M:%S UTC")
+    );
     println!("**Network:** {}  ", report.network);
     println!();
 
@@ -258,9 +276,12 @@ fn print_markdown(report: &EstimationReport) {
         let badge = md_badge(e.cpu_instructions);
         println!(
             "| `{}` | {} | {} {} | {} | `{:.8}` |",
-            e.function_name, e.storage_variant,
-            e.cpu_instructions, badge,
-            e.memory_bytes, e.estimated_cost_xlm,
+            e.function_name,
+            e.storage_variant,
+            e.cpu_instructions,
+            badge,
+            e.memory_bytes,
+            e.estimated_cost_xlm,
         );
     }
     println!();
@@ -274,8 +295,12 @@ fn print_markdown(report: &EstimationReport) {
             let extrap = if b.is_extrapolated { "✓" } else { "" };
             println!(
                 "| `{}` | {} | {} | {} | `{:.8}` | `{:.8}` |",
-                b.operation, b.batch_size, extrap,
-                b.total_cpu_instructions, b.total_cost_xlm, b.cost_per_item_xlm,
+                b.operation,
+                b.batch_size,
+                extrap,
+                b.total_cpu_instructions,
+                b.total_cost_xlm,
+                b.cost_per_item_xlm,
             );
         }
         println!();
@@ -290,8 +315,7 @@ fn print_markdown(report: &EstimationReport) {
             let sign = if c.delta_cpu >= 0 { "+" } else { "" };
             println!(
                 "| {} | {} | {} | {}{} | {}{:.1}% |",
-                c.label, c.baseline_cpu, c.candidate_cpu,
-                sign, c.delta_cpu, sign, c.delta_pct,
+                c.label, c.baseline_cpu, c.candidate_cpu, sign, c.delta_cpu, sign, c.delta_pct,
             );
         }
         println!();
@@ -302,8 +326,8 @@ fn print_markdown(report: &EstimationReport) {
         println!();
         for s in &report.suggestions {
             let level = match s.severity {
-                Severity::Info     => "INFO",
-                Severity::Warning  => "⚠️ WARNING",
+                Severity::Info => "INFO",
+                Severity::Warning => "⚠️ WARNING",
                 Severity::Critical => "🔴 CRITICAL",
             };
             println!("- **[{}] `{}`** — {}", level, s.function, s.message);
@@ -358,7 +382,10 @@ fn compare_baseline(baseline: &EstimationReport, current: &EstimationReport) -> 
                 key, base.cpu_instructions, cur.cpu_instructions, delta_pct, flag
             );
         } else {
-            println!("  {:<45} {:>14} {:>14}  (new)", key, "—", cur.cpu_instructions);
+            println!(
+                "  {:<45} {:>14} {:>14}  (new)",
+                key, "—", cur.cpu_instructions
+            );
         }
     }
 

--- a/tools/gas-estimator/tests/estimate.rs
+++ b/tools/gas-estimator/tests/estimate.rs
@@ -18,8 +18,8 @@ extern crate std;
 
 use chrono::Utc;
 use gas_estimator::{
-    generate_comparisons, generate_suggestions, make_batch_estimate, make_estimate,
-    append_to_history, EstimationReport, GasEstimate,
+    append_to_history, generate_comparisons, generate_suggestions, make_batch_estimate,
+    make_estimate, EstimationReport, GasEstimate,
 };
 use soroban_sdk::{
     testutils::{Address as _, Ledger as _},
@@ -191,12 +191,19 @@ fn measure_get_total_tips_warm() -> GasEstimate {
 // ── tip_split — 3 and 10 recipients ──────────────────────────────────────────
 
 fn build_recipients(env: &Env, count: u32) -> SorobanVec<TipRecipient> {
-    assert!(count >= 2 && count <= 10, "tip_split requires 2–10 recipients");
+    assert!(
+        count >= 2 && count <= 10,
+        "tip_split requires 2–10 recipients"
+    );
     let mut recipients = SorobanVec::new(env);
     let share_each = 10_000u32 / count;
     let remainder = 10_000u32 - share_each * count;
     for i in 0..count {
-        let pct = if i == 0 { share_each + remainder } else { share_each };
+        let pct = if i == 0 {
+            share_each + remainder
+        } else {
+            share_each
+        };
         recipients.push_back(TipRecipient {
             creator: Address::generate(env),
             percentage: pct,
@@ -246,7 +253,11 @@ fn measure_get_leaderboard_1() -> GasEstimate {
     client.tip(&sender, &creator, &token_id, &1_000);
 
     env.budget().reset_default();
-    client.get_leaderboard(&tipjar::TimePeriod::AllTime, &tipjar::ParticipantKind::Creator, &10u32);
+    client.get_leaderboard(
+        &tipjar::TimePeriod::AllTime,
+        &tipjar::ParticipantKind::Creator,
+        &10u32,
+    );
     let cpu = env.budget().cpu_instruction_count();
     let mem = env.budget().memory_bytes_count();
     println!("[GAS] get_leaderboard (1-creator)  cpu={cpu}  mem={mem}");
@@ -264,7 +275,11 @@ fn measure_get_leaderboard_10() -> GasEstimate {
     }
 
     env.budget().reset_default();
-    client.get_leaderboard(&tipjar::TimePeriod::AllTime, &tipjar::ParticipantKind::Creator, &10u32);
+    client.get_leaderboard(
+        &tipjar::TimePeriod::AllTime,
+        &tipjar::ParticipantKind::Creator,
+        &10u32,
+    );
     let cpu = env.budget().cpu_instruction_count();
     let mem = env.budget().memory_bytes_count();
     println!("[GAS] get_leaderboard (10-creators)  cpu={cpu}  mem={mem}");
@@ -407,8 +422,14 @@ fn run_all_estimates() {
     // ── Batch estimates ───────────────────────────────────────────────────────
     // tip_batch is not yet implemented in the contract; extrapolate from
     // cold (first item) + warm (remaining N-1 items) single-tip measurements.
-    let tip_cold = estimates.iter().find(|e| e.function_name == "tip" && e.storage_variant == "cold").unwrap();
-    let tip_warm = estimates.iter().find(|e| e.function_name == "tip" && e.storage_variant == "warm").unwrap();
+    let tip_cold = estimates
+        .iter()
+        .find(|e| e.function_name == "tip" && e.storage_variant == "cold")
+        .unwrap();
+    let tip_warm = estimates
+        .iter()
+        .find(|e| e.function_name == "tip" && e.storage_variant == "warm")
+        .unwrap();
 
     let batch_estimates: std::vec::Vec<_> = [10u32, 25, 50, 100]
         .iter()
@@ -462,8 +483,11 @@ fn run_all_estimates() {
     for b in &report.batch_estimates {
         println!(
             "  {:<30} {:>5} {:>18} {:>16.8} {:>16.8}",
-            b.operation, b.batch_size, b.total_cpu_instructions,
-            b.total_cost_xlm, b.cost_per_item_xlm,
+            b.operation,
+            b.batch_size,
+            b.total_cpu_instructions,
+            b.total_cost_xlm,
+            b.cost_per_item_xlm,
         );
     }
 

--- a/tools/gas/gas_analyzer.rs
+++ b/tools/gas/gas_analyzer.rs
@@ -40,7 +40,10 @@ fn main() -> Result<()> {
 
     println!("=== TipJar Gas Analysis Report ===");
     println!("Generated: {}\n", report.timestamp);
-    println!("{:<45} {:>18} {:>14}", "Function", "CPU Instructions", "Memory Bytes");
+    println!(
+        "{:<45} {:>18} {:>14}",
+        "Function", "CPU Instructions", "Memory Bytes"
+    );
     println!("{}", "-".repeat(80));
 
     let mut any_recommendation = false;

--- a/tools/gas/gas_profiler.rs
+++ b/tools/gas/gas_profiler.rs
@@ -64,8 +64,8 @@ fn main() -> Result<()> {
 
     // Optional baseline comparison
     if let Some(baseline_path) = cli.baseline {
-        let baseline_json = std::fs::read_to_string(&baseline_path)
-            .context("failed to read baseline report")?;
+        let baseline_json =
+            std::fs::read_to_string(&baseline_path).context("failed to read baseline report")?;
         let baseline: GasReport = serde_json::from_str(&baseline_json)?;
         compare(&baseline, &report);
     }
@@ -77,14 +77,26 @@ fn main() -> Result<()> {
 fn parse_bench_output(output: &str) -> Vec<BenchResult> {
     let mut results = Vec::new();
     for line in output.lines() {
-        let Some(rest) = line.strip_prefix("[BENCH] ") else { continue };
+        let Some(rest) = line.strip_prefix("[BENCH] ") else {
+            continue;
+        };
         // Split on ": cpu="
-        let Some((func, metrics)) = rest.split_once(": cpu=") else { continue };
+        let Some((func, metrics)) = rest.split_once(": cpu=") else {
+            continue;
+        };
         // metrics = "12345 instructions, mem=6789 bytes"
-        let Some((cpu_part, mem_part)) = metrics.split_once(" instructions, mem=") else { continue };
-        let Some((mem_val, _)) = mem_part.split_once(" bytes") else { continue };
-        let Ok(cpu) = cpu_part.trim().parse::<u64>() else { continue };
-        let Ok(mem) = mem_val.trim().parse::<u64>() else { continue };
+        let Some((cpu_part, mem_part)) = metrics.split_once(" instructions, mem=") else {
+            continue;
+        };
+        let Some((mem_val, _)) = mem_part.split_once(" bytes") else {
+            continue;
+        };
+        let Ok(cpu) = cpu_part.trim().parse::<u64>() else {
+            continue;
+        };
+        let Ok(mem) = mem_val.trim().parse::<u64>() else {
+            continue;
+        };
         results.push(BenchResult {
             function: func.trim().to_string(),
             cpu_instructions: cpu,
@@ -96,7 +108,10 @@ fn parse_bench_output(output: &str) -> Vec<BenchResult> {
 
 fn compare(baseline: &GasReport, current: &GasReport) {
     println!("\n=== Gas Regression Report ===");
-    println!("{:<40} {:>15} {:>15} {:>10}", "Function", "Baseline CPU", "Current CPU", "Delta %");
+    println!(
+        "{:<40} {:>15} {:>15} {:>10}",
+        "Function", "Baseline CPU", "Current CPU", "Delta %"
+    );
     println!("{}", "-".repeat(85));
 
     let mut regression = false;
@@ -105,8 +120,14 @@ fn compare(baseline: &GasReport, current: &GasReport) {
             let delta_pct = (cur.cpu_instructions as f64 - base.cpu_instructions as f64)
                 / base.cpu_instructions as f64
                 * 100.0;
-            let flag = if delta_pct > 10.0 { " ⚠ REGRESSION" } else { "" };
-            if delta_pct > 10.0 { regression = true; }
+            let flag = if delta_pct > 10.0 {
+                " ⚠ REGRESSION"
+            } else {
+                ""
+            };
+            if delta_pct > 10.0 {
+                regression = true;
+            }
             println!(
                 "{:<40} {:>15} {:>15} {:>9.1}%{}",
                 cur.function, base.cpu_instructions, cur.cpu_instructions, delta_pct, flag


### PR DESCRIPTION
Closes #264

- Add time_lock_puzzle module with puzzle/, solver/ submodules
- PuzzleDifficulty enum (Easy/Medium/Hard) with configurable iteration counts
- generate_commitment() using SHA-256(secret XOR nonce) for on-chain hashing
- calculate_iterations() supporting difficulty tiers and custom overrides
- verify_solution() for commitment validation
- solve_puzzle() enforcing unlock time and commitment checks
- cancel_puzzle() for creator-initiated refunds
- Status tracking via PuzzleStatus (Active/Solved/Cancelled)
- Storage helpers: get/save puzzle, creator/recipient index lists
- Contract methods: create_time_lock_puzzle, solve_time_lock_puzzle, cancel_time_lock_puzzle, get_time_lock_puzzle, get_puzzle_status, is_puzzle_unlocked, get_creator_puzzles, get_recipient_puzzles
- New DataKey variants: TimeLockPuzzle, TimeLockPuzzleCounter, CreatorPuzzles, RecipientPuzzles
- New TipJarError codes 105-111 for puzzle-specific failures