### PR TITLE
feat: implement tip atomic swaps

### DIFF
--- a/contracts/tipjar/src/lib.rs
+++ b/contracts/tipjar/src/lib.rs
@@ -36,6 +36,9 @@ pub mod conditions;
 // Dynamic fee adjustment
 pub mod fees;
 
+// Atomic hash-time-locked swaps
+pub mod swap;
+
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct TipWithMessage {
@@ -245,6 +248,10 @@ pub enum DataKey {
     Subscription(Address, Address),
     /// Human-readable reason stored when the contract is paused.
     PauseReason,
+    /// Global atomic swap counter (u64).
+    SwapCounter,
+    /// Atomic swap record by ID.
+    Swap(u64),
 }
 
 #[contracterror]
@@ -291,6 +298,16 @@ pub enum TipJarError {
     InvalidPercentage = 30,
     /// Contract is paused; state-changing operations are blocked.
     ContractPaused = 31,
+    /// Swap ID does not exist.
+    SwapNotFound = 32,
+    /// Swap is not in Pending state.
+    SwapNotPending = 33,
+    /// Provided preimage does not match the hash lock.
+    InvalidPreimage = 34,
+    /// Time lock has not yet expired.
+    TimeLockNotExpired = 35,
+    /// Time lock is not in the future.
+    InvalidTimeLock = 36,
 }
 
 #[contract]
@@ -926,5 +943,38 @@ impl TipJarContract {
                 (sender.clone(), share, r.percentage),
             );
         }
+    }
+
+    // ── atomic swaps ─────────────────────────────────────────────────────────
+
+    /// Creates a hash-time-locked swap and escrows tokens from `initiator`.
+    pub fn create_swap(
+        env: Env,
+        initiator: Address,
+        recipient: Address,
+        token: Address,
+        amount: i128,
+        hash_lock: BytesN<32>,
+        time_lock: u64,
+    ) -> u64 {
+        Self::require_not_paused(&env);
+        swap::create_swap(&env, initiator, recipient, token, amount, hash_lock, time_lock)
+    }
+
+    /// Executes a pending swap by revealing the preimage.
+    pub fn execute_swap(env: Env, id: u64, preimage: BytesN<32>) {
+        Self::require_not_paused(&env);
+        swap::execute_swap(&env, id, preimage);
+    }
+
+    /// Refunds a pending swap to the initiator after the time lock expires.
+    pub fn refund_swap(env: Env, id: u64) {
+        Self::require_not_paused(&env);
+        swap::refund_swap(&env, id);
+    }
+
+    /// Returns the swap record for the given ID.
+    pub fn get_swap(env: Env, id: u64) -> swap::AtomicSwap {
+        swap::get_swap(&env, id)
     }
 }

--- a/contracts/tipjar/src/swap.rs
+++ b/contracts/tipjar/src/swap.rs
@@ -1,0 +1,176 @@
+//! Atomic hash-time-locked swap (HTLC) functionality for trustless tip token exchanges.
+
+use soroban_sdk::{contracttype, symbol_short, token, Address, Bytes, BytesN, Env};
+
+use crate::{DataKey, TipJarError};
+
+/// Status of an atomic swap.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum SwapStatus {
+    /// Awaiting execution or refund.
+    Pending,
+    /// Recipient claimed the funds with the correct preimage.
+    Completed,
+    /// Initiator reclaimed the funds after the time lock expired.
+    Refunded,
+}
+
+/// An atomic hash-time-locked swap between two parties.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AtomicSwap {
+    /// Unique swap identifier.
+    pub id: u64,
+    /// Address that created and funded the swap.
+    pub initiator: Address,
+    /// Address that may claim the funds by revealing the preimage.
+    pub recipient: Address,
+    /// Token contract address.
+    pub token: Address,
+    /// Amount of tokens escrowed.
+    pub amount: i128,
+    /// SHA-256 hash of the secret preimage.
+    pub hash_lock: BytesN<32>,
+    /// Ledger timestamp after which the initiator may refund.
+    pub time_lock: u64,
+    /// Current lifecycle status.
+    pub status: SwapStatus,
+}
+
+// ── storage helpers ──────────────────────────────────────────────────────────
+
+fn next_swap_id(env: &Env) -> u64 {
+    let id: u64 = env
+        .storage()
+        .instance()
+        .get(&DataKey::SwapCounter)
+        .unwrap_or(0u64);
+    let next = id + 1;
+    env.storage()
+        .instance()
+        .set(&DataKey::SwapCounter, &next);
+    next
+}
+
+fn load_swap(env: &Env, id: u64) -> AtomicSwap {
+    env.storage()
+        .persistent()
+        .get(&DataKey::Swap(id))
+        .unwrap_or_else(|| soroban_sdk::panic_with_error!(env, TipJarError::SwapNotFound))
+}
+
+fn save_swap(env: &Env, swap: &AtomicSwap) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::Swap(swap.id), swap);
+}
+
+// ── public interface ─────────────────────────────────────────────────────────
+
+/// Creates a new hash-time-locked swap and escrows `amount` tokens from `initiator`.
+///
+/// * `hash_lock` – SHA-256 hash of the secret the recipient must reveal.
+/// * `time_lock` – Unix timestamp (seconds) after which the initiator may refund.
+pub fn create_swap(
+    env: &Env,
+    initiator: Address,
+    recipient: Address,
+    token: Address,
+    amount: i128,
+    hash_lock: BytesN<32>,
+    time_lock: u64,
+) -> u64 {
+    initiator.require_auth();
+
+    if amount <= 0 {
+        soroban_sdk::panic_with_error!(env, TipJarError::InvalidAmount);
+    }
+    if time_lock <= env.ledger().timestamp() {
+        soroban_sdk::panic_with_error!(env, TipJarError::InvalidTimeLock);
+    }
+
+    // Escrow tokens into this contract.
+    token::Client::new(env, &token).transfer(
+        &initiator,
+        &env.current_contract_address(),
+        &amount,
+    );
+
+    let id = next_swap_id(env);
+    let swap = AtomicSwap {
+        id,
+        initiator: initiator.clone(),
+        recipient: recipient.clone(),
+        token,
+        amount,
+        hash_lock,
+        time_lock,
+        status: SwapStatus::Pending,
+    };
+    save_swap(env, &swap);
+
+    env.events()
+        .publish((symbol_short!("swap_new"),), (id, initiator, recipient, amount));
+
+    id
+}
+
+/// Executes a pending swap by revealing the preimage.
+///
+/// The SHA-256 hash of `preimage` must match the stored `hash_lock`.
+pub fn execute_swap(env: &Env, id: u64, preimage: BytesN<32>) {
+    let mut swap = load_swap(env, id);
+
+    if swap.status != SwapStatus::Pending {
+        soroban_sdk::panic_with_error!(env, TipJarError::SwapNotPending);
+    }
+
+    // Verify hash lock: sha256(preimage) == hash_lock.
+    let digest: BytesN<32> = env.crypto().sha256(&Bytes::from(&preimage)).into();
+    if digest != swap.hash_lock {
+        soroban_sdk::panic_with_error!(env, TipJarError::InvalidPreimage);
+    }
+
+    swap.status = SwapStatus::Completed;
+    save_swap(env, &swap);
+
+    token::Client::new(env, &swap.token).transfer(
+        &env.current_contract_address(),
+        &swap.recipient,
+        &swap.amount,
+    );
+
+    env.events()
+        .publish((symbol_short!("swap_done"),), (id,));
+}
+
+/// Refunds a pending swap to the initiator after the time lock has expired.
+pub fn refund_swap(env: &Env, id: u64) {
+    let mut swap = load_swap(env, id);
+
+    if swap.status != SwapStatus::Pending {
+        soroban_sdk::panic_with_error!(env, TipJarError::SwapNotPending);
+    }
+    if env.ledger().timestamp() < swap.time_lock {
+        soroban_sdk::panic_with_error!(env, TipJarError::TimeLockNotExpired);
+    }
+
+    swap.initiator.require_auth();
+    swap.status = SwapStatus::Refunded;
+    save_swap(env, &swap);
+
+    token::Client::new(env, &swap.token).transfer(
+        &env.current_contract_address(),
+        &swap.initiator,
+        &swap.amount,
+    );
+
+    env.events()
+        .publish((symbol_short!("swap_rfnd"),), (id,));
+}
+
+/// Returns the swap record for the given ID.
+pub fn get_swap(env: &Env, id: u64) -> AtomicSwap {
+    load_swap(env, id)
+}

--- a/tests/swap_tests.rs
+++ b/tests/swap_tests.rs
@@ -122,7 +122,7 @@ fn test_execute_swap_rejects_wrong_preimage() {
     let ctx = TestContext::new();
     let (_initiator, _recipient, _preimage, _hash_lock, _time_lock) = setup_swap(&ctx);
 
-    let wrong = BytesN::from_array(&ctx.env, b"wrong_preimage_wrong_preimage!!!!");
+    let wrong = BytesN::from_array(&ctx.env, b"wrong_preimage_wrong_preimage!!!");
     let result = ctx.tipjar_client.try_execute_swap(&1, &wrong);
     assert_error_contains(result, TipJarError::InvalidPreimage);
 }

--- a/tests/swap_tests.rs
+++ b/tests/swap_tests.rs
@@ -1,0 +1,205 @@
+mod common;
+use common::*;
+use soroban_sdk::{Bytes, BytesN};
+use tipjar::{swap::AtomicSwap, swap::SwapStatus, TipJarError};
+
+const ONE_HOUR: u64 = 3_600;
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+/// Returns a 32-byte preimage and its SHA-256 hash lock.
+fn make_hash_lock(ctx: &TestContext, secret: &[u8; 32]) -> (BytesN<32>, BytesN<32>) {
+    let preimage = BytesN::from_array(&ctx.env, secret);
+    let hash: BytesN<32> = ctx
+        .env
+        .crypto()
+        .sha256(&Bytes::from(&preimage))
+        .into();
+    (preimage, hash)
+}
+
+fn setup_swap(ctx: &TestContext) -> (soroban_sdk::Address, soroban_sdk::Address, BytesN<32>, BytesN<32>, u64) {
+    let initiator = ctx.create_user();
+    let recipient = ctx.create_user();
+    ctx.mint_tokens(&initiator, &ctx.token_1, 1_000);
+
+    let (preimage, hash_lock) = make_hash_lock(ctx, b"super_secret_preimage_32bytes!!!");
+    let time_lock = ctx.get_current_time() + ONE_HOUR;
+
+    let id = ctx.tipjar_client.create_swap(
+        &initiator,
+        &recipient,
+        &ctx.token_1,
+        &500,
+        &hash_lock,
+        &time_lock,
+    );
+    assert_eq!(id, 1);
+    (initiator, recipient, preimage, hash_lock, time_lock)
+}
+
+// ── create_swap ───────────────────────────────────────────────────────────────
+
+#[test]
+fn test_create_swap_escrows_tokens() {
+    let ctx = TestContext::new();
+    let (initiator, _recipient, _preimage, _hash_lock, _time_lock) = setup_swap(&ctx);
+
+    // Initiator paid 500; contract holds it.
+    assert_balance_equals(&ctx, &initiator, &ctx.token_1, 500);
+    assert_balance_equals(&ctx, &ctx.contract_id, &ctx.token_1, 500);
+}
+
+#[test]
+fn test_create_swap_stores_correct_data() {
+    let ctx = TestContext::new();
+    let (initiator, recipient, _preimage, hash_lock, time_lock) = setup_swap(&ctx);
+
+    let swap: AtomicSwap = ctx.tipjar_client.get_swap(&1);
+    assert_eq!(swap.id, 1);
+    assert_eq!(swap.initiator, initiator);
+    assert_eq!(swap.recipient, recipient);
+    assert_eq!(swap.amount, 500);
+    assert_eq!(swap.hash_lock, hash_lock);
+    assert_eq!(swap.time_lock, time_lock);
+    assert_eq!(swap.status, SwapStatus::Pending);
+}
+
+#[test]
+fn test_create_swap_rejects_zero_amount() {
+    let ctx = TestContext::new();
+    let initiator = ctx.create_user();
+    let recipient = ctx.create_user();
+    let (_, hash_lock) = make_hash_lock(&ctx, b"super_secret_preimage_32bytes!!!");
+
+    let result = ctx.tipjar_client.try_create_swap(
+        &initiator,
+        &recipient,
+        &ctx.token_1,
+        &0,
+        &hash_lock,
+        &(ctx.get_current_time() + ONE_HOUR),
+    );
+    assert_error_contains(result, TipJarError::InvalidAmount);
+}
+
+#[test]
+fn test_create_swap_rejects_expired_time_lock() {
+    let ctx = TestContext::new();
+    let initiator = ctx.create_user();
+    let recipient = ctx.create_user();
+    let (_, hash_lock) = make_hash_lock(&ctx, b"super_secret_preimage_32bytes!!!");
+
+    let result = ctx.tipjar_client.try_create_swap(
+        &initiator,
+        &recipient,
+        &ctx.token_1,
+        &100,
+        &hash_lock,
+        &ctx.get_current_time(), // not in the future
+    );
+    assert_error_contains(result, TipJarError::InvalidTimeLock);
+}
+
+// ── execute_swap ──────────────────────────────────────────────────────────────
+
+#[test]
+fn test_execute_swap_transfers_to_recipient() {
+    let ctx = TestContext::new();
+    let (_initiator, recipient, preimage, _hash_lock, _time_lock) = setup_swap(&ctx);
+
+    ctx.tipjar_client.execute_swap(&1, &preimage);
+
+    assert_balance_equals(&ctx, &recipient, &ctx.token_1, 500);
+    assert_balance_equals(&ctx, &ctx.contract_id, &ctx.token_1, 0);
+
+    let swap: AtomicSwap = ctx.tipjar_client.get_swap(&1);
+    assert_eq!(swap.status, SwapStatus::Completed);
+}
+
+#[test]
+fn test_execute_swap_rejects_wrong_preimage() {
+    let ctx = TestContext::new();
+    let (_initiator, _recipient, _preimage, _hash_lock, _time_lock) = setup_swap(&ctx);
+
+    let wrong = BytesN::from_array(&ctx.env, b"wrong_preimage_wrong_preimage!!!!");
+    let result = ctx.tipjar_client.try_execute_swap(&1, &wrong);
+    assert_error_contains(result, TipJarError::InvalidPreimage);
+}
+
+#[test]
+fn test_execute_swap_rejects_already_completed() {
+    let ctx = TestContext::new();
+    let (_initiator, _recipient, preimage, _hash_lock, _time_lock) = setup_swap(&ctx);
+
+    ctx.tipjar_client.execute_swap(&1, &preimage);
+
+    let result = ctx.tipjar_client.try_execute_swap(&1, &preimage);
+    assert_error_contains(result, TipJarError::SwapNotPending);
+}
+
+// ── refund_swap ───────────────────────────────────────────────────────────────
+
+#[test]
+fn test_refund_swap_returns_tokens_after_expiry() {
+    let ctx = TestContext::new();
+    let (initiator, _recipient, _preimage, _hash_lock, _time_lock) = setup_swap(&ctx);
+
+    ctx.advance_time(ONE_HOUR + 1);
+    ctx.tipjar_client.refund_swap(&1);
+
+    assert_balance_equals(&ctx, &initiator, &ctx.token_1, 1_000);
+    assert_balance_equals(&ctx, &ctx.contract_id, &ctx.token_1, 0);
+
+    let swap: AtomicSwap = ctx.tipjar_client.get_swap(&1);
+    assert_eq!(swap.status, SwapStatus::Refunded);
+}
+
+#[test]
+fn test_refund_swap_rejects_before_expiry() {
+    let ctx = TestContext::new();
+    let (_initiator, _recipient, _preimage, _hash_lock, _time_lock) = setup_swap(&ctx);
+
+    let result = ctx.tipjar_client.try_refund_swap(&1);
+    assert_error_contains(result, TipJarError::TimeLockNotExpired);
+}
+
+#[test]
+fn test_refund_swap_rejects_already_completed() {
+    let ctx = TestContext::new();
+    let (_initiator, _recipient, preimage, _hash_lock, _time_lock) = setup_swap(&ctx);
+
+    ctx.tipjar_client.execute_swap(&1, &preimage);
+    ctx.advance_time(ONE_HOUR + 1);
+
+    let result = ctx.tipjar_client.try_refund_swap(&1);
+    assert_error_contains(result, TipJarError::SwapNotPending);
+}
+
+// ── get_swap ──────────────────────────────────────────────────────────────────
+
+#[test]
+fn test_get_swap_panics_for_unknown_id() {
+    let ctx = TestContext::new();
+    let result = ctx.tipjar_client.try_get_swap(&99);
+    assert!(result.is_err());
+}
+
+// ── counter increments ────────────────────────────────────────────────────────
+
+#[test]
+fn test_swap_ids_increment() {
+    let ctx = TestContext::new();
+    let initiator = ctx.create_user();
+    let recipient = ctx.create_user();
+    ctx.mint_tokens(&initiator, &ctx.token_1, 2_000);
+
+    let (_, hash_lock) = make_hash_lock(&ctx, b"super_secret_preimage_32bytes!!!");
+    let time_lock = ctx.get_current_time() + ONE_HOUR;
+
+    let id1 = ctx.tipjar_client.create_swap(&initiator, &recipient, &ctx.token_1, &100, &hash_lock, &time_lock);
+    let id2 = ctx.tipjar_client.create_swap(&initiator, &recipient, &ctx.token_1, &100, &hash_lock, &time_lock);
+
+    assert_eq!(id1, 1);
+    assert_eq!(id2, 2);
+}


### PR DESCRIPTION
closes #265 
Add hash-time-locked contract (HTLC) swap functionality for trustless tip token exchanges.

- Add AtomicSwap struct and SwapStatus enum (Pending/Completed/Refunded)
- Implement create_swap: escrows tokens with hash lock and time lock
- Implement execute_swap: releases funds on correct SHA-256 preimage
- Implement refund_swap: returns funds to initiator after time lock expiry
- Implement get_swap: read-only swap record lookup
- Add DataKey::SwapCounter and DataKey::Swap(u64) storage entries
- Add error variants: SwapNotFound, SwapNotPending, InvalidPreimage, TimeLockNotExpired, InvalidTimeLock
- Expose four contract methods on TipJarContract
- Add 12 tests covering full swap lifecycle in tests/swap_tests.rs