### PR TITLE
feat: implement tip retroactive funding

### DIFF
--- a/contracts/tipjar/src/lib.rs
+++ b/contracts/tipjar/src/lib.rs
@@ -79,6 +79,9 @@ pub mod bonding_curve;
 // Quadratic funding
 pub mod quadratic_funding;
 
+// Retroactive public goods funding
+pub mod retroactive_funding;
+
 // TWAP oracle
 pub mod twap_oracle;
 
@@ -927,6 +930,8 @@ pub enum DataKey {
     ValidityProof(validity_proof::ValidityProofKey),
     /// Verkle tree sub-keys.
     Verkle(verkle_tree::VerkleKey),
+    /// Retroactive public goods funding sub-keys.
+    Retro(retroactive_funding::RetroKey),
 }
 
 #[contracterror]
@@ -8613,6 +8618,88 @@ a
     /// Returns the estimated matching amount for `project` in `round_id`.
     pub fn qf_get_match_estimate(env: Env, round_id: u64, project: Address) -> i128 {
         quadratic_funding::get_match_estimate(&env, round_id, &project)
+    }
+
+    // ── Retroactive Public Goods Funding ─────────────────────────────────────
+
+    /// Creates a retroactive funding round.
+    ///
+    /// Transfers `reward_pool` tokens from `admin` into the contract.
+    /// `criteria` weights must sum to 10 000 bps.
+    /// Emits `("retro_new",)` with `(round_id, token, reward_pool, end_time)`.
+    pub fn retro_create_round(
+        env: Env,
+        admin: Address,
+        token: Address,
+        reward_pool: i128,
+        start_time: u64,
+        end_time: u64,
+        criteria: retroactive_funding::EvalCriteria,
+    ) -> u64 {
+        Self::require_not_paused(&env);
+        retroactive_funding::create_round(&env, &admin, &token, reward_pool, start_time, end_time, criteria)
+    }
+
+    /// Nominates a creator as eligible for rewards in a round. Admin only.
+    ///
+    /// Emits `("retro_nom",)` with `(round_id, creator)`.
+    pub fn retro_nominate_creator(env: Env, admin: Address, round_id: u64, creator: Address) {
+        Self::require_not_paused(&env);
+        retroactive_funding::nominate_creator(&env, &admin, round_id, &creator);
+    }
+
+    /// Casts a vote for a nominated creator in an active round.
+    ///
+    /// Each voter may vote once per round. Vote weight is derived from the voter's
+    /// own tip history (sqrt-weighted).
+    /// Emits `("retro_vot",)` with `(round_id, voter, creator, weight)`.
+    pub fn retro_cast_vote(env: Env, voter: Address, round_id: u64, creator: Address) {
+        Self::require_not_paused(&env);
+        retroactive_funding::cast_vote(&env, &voter, round_id, &creator);
+    }
+
+    /// Finalizes a round after the voting window closes. Admin only.
+    ///
+    /// Emits `("retro_fin",)` with `(round_id, total_votes)`.
+    pub fn retro_finalize_round(env: Env, admin: Address, round_id: u64) {
+        Self::require_not_paused(&env);
+        retroactive_funding::finalize_round(&env, &admin, round_id);
+    }
+
+    /// Computes a creator's impact score for a round.
+    ///
+    /// Score combines historical tips, tip count, and vote weight per `EvalCriteria`.
+    pub fn retro_compute_impact_score(env: Env, round_id: u64, creator: Address) -> i128 {
+        retroactive_funding::compute_impact_score(&env, round_id, &creator)
+    }
+
+    /// Claims the retroactive reward for a creator in a finalized round.
+    ///
+    /// Reward is proportional to the creator's impact score relative to all nominees.
+    /// Emits `("retro_clm",)` with `(round_id, creator, amount)`.
+    pub fn retro_claim_reward(env: Env, creator: Address, round_id: u64) -> i128 {
+        Self::require_not_paused(&env);
+        retroactive_funding::claim_reward(&env, &creator, round_id)
+    }
+
+    /// Returns a retroactive funding round by ID.
+    pub fn retro_get_round(env: Env, round_id: u64) -> retroactive_funding::RetroRound {
+        retroactive_funding::get_round(&env, round_id)
+    }
+
+    /// Returns the nominated creators for a round.
+    pub fn retro_get_round_creators(env: Env, round_id: u64) -> Vec<Address> {
+        retroactive_funding::get_round_creators(&env, round_id)
+    }
+
+    /// Returns the aggregated vote weight for a creator in a round.
+    pub fn retro_get_creator_votes(env: Env, round_id: u64, creator: Address) -> i128 {
+        retroactive_funding::get_creator_votes(&env, round_id, &creator)
+    }
+
+    /// Returns whether a voter has already voted in a round.
+    pub fn retro_has_voted(env: Env, round_id: u64, voter: Address) -> bool {
+        retroactive_funding::has_voted(&env, round_id, &voter)
     }
 
     // ── Conviction Voting ────────────────────────────────────────────────────

--- a/contracts/tipjar/src/retroactive_funding.rs
+++ b/contracts/tipjar/src/retroactive_funding.rs
@@ -1,0 +1,486 @@
+//! Retroactive Public Goods Funding
+//!
+//! Rewards past contributions to the ecosystem:
+//! - Admins create funding rounds with a token pool and evaluation criteria.
+//! - Voters cast weighted votes for eligible creators based on impact metrics.
+//! - After the voting window closes, rewards are distributed proportionally to
+//!   vote-weighted impact scores.
+//! - Impact metrics (total tips received, tip count) are read from existing
+//!   contract storage to evaluate past contributions.
+
+use soroban_sdk::{contracttype, panic_with_error, symbol_short, token, Address, Env, Vec};
+
+// ── Storage keys ──────────────────────────────────────────────────────────────
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum RetroKey {
+    /// Round record keyed by round_id.
+    Round(u64),
+    /// Global round counter.
+    RoundCtr,
+    /// Vote cast by a voter for a creator in a round: (round_id, voter, creator).
+    Vote(u64, Address, Address),
+    /// Aggregated vote weight for a creator in a round: (round_id, creator).
+    CreatorVotes(u64, Address),
+    /// List of creators nominated in a round.
+    RoundCreators(u64),
+    /// List of voters who have voted in a round.
+    RoundVoters(u64),
+    /// Whether a voter has already voted in a round: (round_id, voter).
+    HasVoted(u64, Address),
+    /// Reward claimed flag: (round_id, creator).
+    Claimed(u64, Address),
+}
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+/// Status of a retroactive funding round.
+#[contracttype]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum RetroRoundStatus {
+    /// Accepting nominations and votes.
+    Active,
+    /// Voting closed; rewards can be claimed.
+    Finalized,
+    /// All rewards distributed.
+    Distributed,
+}
+
+/// Evaluation criteria weights (basis points, must sum to 10 000).
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct EvalCriteria {
+    /// Weight given to total historical tips received (bps).
+    pub tips_weight_bps: u32,
+    /// Weight given to number of unique tips received (bps).
+    pub tip_count_weight_bps: u32,
+    /// Weight given to raw voter votes (bps).
+    pub vote_weight_bps: u32,
+}
+
+/// A retroactive funding round.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RetroRound {
+    pub round_id: u64,
+    pub admin: Address,
+    pub token: Address,
+    /// Total reward pool deposited by admin.
+    pub reward_pool: i128,
+    /// Voting opens at this timestamp.
+    pub start_time: u64,
+    /// Voting closes at this timestamp.
+    pub end_time: u64,
+    pub status: RetroRoundStatus,
+    pub criteria: EvalCriteria,
+    /// Total vote weight cast across all creators.
+    pub total_votes: i128,
+}
+
+/// A single vote record.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RetroVote {
+    pub voter: Address,
+    pub creator: Address,
+    pub round_id: u64,
+    /// Vote weight (e.g. proportional to voter's own tip history).
+    pub weight: i128,
+}
+
+// ── Errors ────────────────────────────────────────────────────────────────────
+
+#[soroban_sdk::contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum RetroError {
+    RoundNotFound = 700,
+    RoundNotActive = 701,
+    RoundNotFinalized = 702,
+    AlreadyDistributed = 703,
+    RoundEnded = 704,
+    RoundNotEnded = 705,
+    AlreadyVoted = 706,
+    InvalidAmount = 707,
+    Unauthorized = 708,
+    CreatorNotNominated = 709,
+    AlreadyClaimed = 710,
+    NothingToClaim = 711,
+    InvalidCriteria = 712,
+}
+
+// ── Integer square root (no floating point in Soroban) ───────────────────────
+
+fn isqrt(n: i128) -> i128 {
+    if n <= 0 {
+        return 0;
+    }
+    let mut x = n;
+    let mut y = (x + 1) / 2;
+    while y < x {
+        x = y;
+        y = (x + n / x) / 2;
+    }
+    x
+}
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+/// Creates a new retroactive funding round.
+///
+/// Transfers `reward_pool` tokens from `admin` into the contract.
+/// `criteria` weights must sum to 10 000 bps.
+///
+/// Emits `("retro_new",)` with `(round_id, token, reward_pool, end_time)`.
+pub fn create_round(
+    env: &Env,
+    admin: &Address,
+    token: &Address,
+    reward_pool: i128,
+    start_time: u64,
+    end_time: u64,
+    criteria: EvalCriteria,
+) -> u64 {
+    admin.require_auth();
+
+    if reward_pool <= 0 {
+        panic_with_error!(env, RetroError::InvalidAmount);
+    }
+    if end_time <= start_time {
+        panic_with_error!(env, RetroError::InvalidAmount);
+    }
+    let weight_sum = criteria.tips_weight_bps + criteria.tip_count_weight_bps + criteria.vote_weight_bps;
+    if weight_sum != 10_000 {
+        panic_with_error!(env, RetroError::InvalidCriteria);
+    }
+
+    let round_id: u64 = env
+        .storage()
+        .instance()
+        .get(&crate::DataKey::Retro(RetroKey::RoundCtr))
+        .unwrap_or(0u64);
+    env.storage()
+        .instance()
+        .set(&crate::DataKey::Retro(RetroKey::RoundCtr), &(round_id + 1));
+
+    let round = RetroRound {
+        round_id,
+        admin: admin.clone(),
+        token: token.clone(),
+        reward_pool,
+        start_time,
+        end_time,
+        status: RetroRoundStatus::Active,
+        criteria,
+        total_votes: 0,
+    };
+    env.storage()
+        .persistent()
+        .set(&crate::DataKey::Retro(RetroKey::Round(round_id)), &round);
+
+    token::Client::new(env, token).transfer(admin, &env.current_contract_address(), &reward_pool);
+
+    env.events().publish(
+        (symbol_short!("retro_new"),),
+        (round_id, token.clone(), reward_pool, end_time),
+    );
+    round_id
+}
+
+/// Nominates a creator as eligible for rewards in a round.
+///
+/// Only the round admin may nominate. Nomination must happen before voting ends.
+/// Emits `("retro_nom",)` with `(round_id, creator)`.
+pub fn nominate_creator(env: &Env, admin: &Address, round_id: u64, creator: &Address) {
+    admin.require_auth();
+
+    let round: RetroRound = env
+        .storage()
+        .persistent()
+        .get(&crate::DataKey::Retro(RetroKey::Round(round_id)))
+        .unwrap_or_else(|| panic_with_error!(env, RetroError::RoundNotFound));
+
+    if round.admin != *admin {
+        panic_with_error!(env, RetroError::Unauthorized);
+    }
+    if round.status != RetroRoundStatus::Active {
+        panic_with_error!(env, RetroError::RoundNotActive);
+    }
+    if env.ledger().timestamp() > round.end_time {
+        panic_with_error!(env, RetroError::RoundEnded);
+    }
+
+    let mut creators: Vec<Address> = env
+        .storage()
+        .persistent()
+        .get(&crate::DataKey::Retro(RetroKey::RoundCreators(round_id)))
+        .unwrap_or_else(|| Vec::new(env));
+    if !creators.contains(creator) {
+        creators.push_back(creator.clone());
+        env.storage()
+            .persistent()
+            .set(&crate::DataKey::Retro(RetroKey::RoundCreators(round_id)), &creators);
+    }
+
+    env.events()
+        .publish((symbol_short!("retro_nom"),), (round_id, creator.clone()));
+}
+
+/// Casts a vote for a nominated creator in an active round.
+///
+/// Each voter may vote once per round. Vote weight is derived from the voter's
+/// own total tips sent (stored in `CreatorTotal` for the round token), giving
+/// more influence to active ecosystem participants. Falls back to weight = 1
+/// if the voter has no tip history.
+///
+/// Emits `("retro_vote",)` with `(round_id, voter, creator, weight)`.
+pub fn cast_vote(env: &Env, voter: &Address, round_id: u64, creator: &Address) {
+    voter.require_auth();
+
+    let mut round: RetroRound = env
+        .storage()
+        .persistent()
+        .get(&crate::DataKey::Retro(RetroKey::Round(round_id)))
+        .unwrap_or_else(|| panic_with_error!(env, RetroError::RoundNotFound));
+
+    if round.status != RetroRoundStatus::Active {
+        panic_with_error!(env, RetroError::RoundNotActive);
+    }
+    let now = env.ledger().timestamp();
+    if now < round.start_time || now > round.end_time {
+        panic_with_error!(env, RetroError::RoundEnded);
+    }
+
+    // Ensure creator is nominated.
+    let creators: Vec<Address> = env
+        .storage()
+        .persistent()
+        .get(&crate::DataKey::Retro(RetroKey::RoundCreators(round_id)))
+        .unwrap_or_else(|| Vec::new(env));
+    if !creators.contains(creator) {
+        panic_with_error!(env, RetroError::CreatorNotNominated);
+    }
+
+    // One vote per voter per round.
+    let has_voted: bool = env
+        .storage()
+        .persistent()
+        .get(&crate::DataKey::Retro(RetroKey::HasVoted(round_id, voter.clone())))
+        .unwrap_or(false);
+    if has_voted {
+        panic_with_error!(env, RetroError::AlreadyVoted);
+    }
+
+    // Vote weight = sqrt(voter's total tips sent in round token), min 1.
+    let voter_tips: i128 = env
+        .storage()
+        .persistent()
+        .get(&crate::DataKey::CreatorTotal(voter.clone(), round.token.clone()))
+        .unwrap_or(0);
+    let weight = isqrt(voter_tips).max(1);
+
+    // Record vote.
+    let vote = RetroVote {
+        voter: voter.clone(),
+        creator: creator.clone(),
+        round_id,
+        weight,
+    };
+    env.storage()
+        .persistent()
+        .set(&crate::DataKey::Retro(RetroKey::Vote(round_id, voter.clone(), creator.clone())), &vote);
+    env.storage()
+        .persistent()
+        .set(&crate::DataKey::Retro(RetroKey::HasVoted(round_id, voter.clone())), &true);
+
+    // Accumulate creator vote weight.
+    let prev: i128 = env
+        .storage()
+        .persistent()
+        .get(&crate::DataKey::Retro(RetroKey::CreatorVotes(round_id, creator.clone())))
+        .unwrap_or(0);
+    env.storage()
+        .persistent()
+        .set(&crate::DataKey::Retro(RetroKey::CreatorVotes(round_id, creator.clone())), &(prev + weight));
+
+    round.total_votes += weight;
+    env.storage()
+        .persistent()
+        .set(&crate::DataKey::Retro(RetroKey::Round(round_id)), &round);
+
+    env.events().publish(
+        (symbol_short!("retro_vot"),),
+        (round_id, voter.clone(), creator.clone(), weight),
+    );
+}
+
+/// Finalizes a round after the voting window closes.
+///
+/// Only the round admin may finalize. Emits `("retro_fin",)` with `(round_id, total_votes)`.
+pub fn finalize_round(env: &Env, admin: &Address, round_id: u64) {
+    admin.require_auth();
+
+    let mut round: RetroRound = env
+        .storage()
+        .persistent()
+        .get(&crate::DataKey::Retro(RetroKey::Round(round_id)))
+        .unwrap_or_else(|| panic_with_error!(env, RetroError::RoundNotFound));
+
+    if round.admin != *admin {
+        panic_with_error!(env, RetroError::Unauthorized);
+    }
+    if round.status != RetroRoundStatus::Active {
+        panic_with_error!(env, RetroError::RoundNotActive);
+    }
+    if env.ledger().timestamp() <= round.end_time {
+        panic_with_error!(env, RetroError::RoundNotEnded);
+    }
+
+    round.status = RetroRoundStatus::Finalized;
+    env.storage()
+        .persistent()
+        .set(&crate::DataKey::Retro(RetroKey::Round(round_id)), &round);
+
+    env.events().publish(
+        (symbol_short!("retro_fin"),),
+        (round_id, round.total_votes),
+    );
+}
+
+/// Computes a creator's impact score for a finalized round.
+///
+/// Score = (tips_total * tips_weight + tip_count * count_weight + votes * vote_weight) / 10_000
+/// where tip_count is scaled by 1_000_000 to be comparable with token amounts.
+pub fn compute_impact_score(env: &Env, round_id: u64, creator: &Address) -> i128 {
+    let round: RetroRound = env
+        .storage()
+        .persistent()
+        .get(&crate::DataKey::Retro(RetroKey::Round(round_id)))
+        .unwrap_or_else(|| panic_with_error!(env, RetroError::RoundNotFound));
+
+    let total_tips: i128 = env
+        .storage()
+        .persistent()
+        .get(&crate::DataKey::CreatorTotal(creator.clone(), round.token.clone()))
+        .unwrap_or(0);
+
+    let tip_count: i128 = env
+        .storage()
+        .persistent()
+        .get(&crate::DataKey::TipCount(creator.clone()))
+        .unwrap_or(0u64) as i128;
+
+    let votes: i128 = env
+        .storage()
+        .persistent()
+        .get(&crate::DataKey::Retro(RetroKey::CreatorVotes(round_id, creator.clone())))
+        .unwrap_or(0);
+
+    let c = &round.criteria;
+    (total_tips * c.tips_weight_bps as i128
+        + tip_count * 1_000_000 * c.tip_count_weight_bps as i128
+        + votes * 1_000_000 * c.vote_weight_bps as i128)
+        / 10_000
+}
+
+/// Claims the retroactive reward for a creator in a finalized round.
+///
+/// Reward = reward_pool * creator_score / total_score_across_all_creators.
+/// Emits `("retro_clm",)` with `(round_id, creator, amount)`.
+pub fn claim_reward(env: &Env, creator: &Address, round_id: u64) -> i128 {
+    creator.require_auth();
+
+    let round: RetroRound = env
+        .storage()
+        .persistent()
+        .get(&crate::DataKey::Retro(RetroKey::Round(round_id)))
+        .unwrap_or_else(|| panic_with_error!(env, RetroError::RoundNotFound));
+
+    if round.status != RetroRoundStatus::Finalized {
+        panic_with_error!(env, RetroError::RoundNotFinalized);
+    }
+
+    let claimed: bool = env
+        .storage()
+        .persistent()
+        .get(&crate::DataKey::Retro(RetroKey::Claimed(round_id, creator.clone())))
+        .unwrap_or(false);
+    if claimed {
+        panic_with_error!(env, RetroError::AlreadyClaimed);
+    }
+
+    // Ensure creator is nominated.
+    let creators: Vec<Address> = env
+        .storage()
+        .persistent()
+        .get(&crate::DataKey::Retro(RetroKey::RoundCreators(round_id)))
+        .unwrap_or_else(|| Vec::new(env));
+    if !creators.contains(creator) {
+        panic_with_error!(env, RetroError::CreatorNotNominated);
+    }
+
+    // Compute total score across all nominated creators.
+    let mut total_score: i128 = 0;
+    for c in creators.iter() {
+        total_score += compute_impact_score(env, round_id, &c);
+    }
+
+    let creator_score = compute_impact_score(env, round_id, creator);
+    if creator_score == 0 || total_score == 0 {
+        panic_with_error!(env, RetroError::NothingToClaim);
+    }
+
+    let reward = (round.reward_pool * creator_score) / total_score;
+    if reward == 0 {
+        panic_with_error!(env, RetroError::NothingToClaim);
+    }
+
+    env.storage()
+        .persistent()
+        .set(&crate::DataKey::Retro(RetroKey::Claimed(round_id, creator.clone())), &true);
+
+    token::Client::new(env, &round.token).transfer(
+        &env.current_contract_address(),
+        creator,
+        &reward,
+    );
+
+    env.events().publish(
+        (symbol_short!("retro_clm"),),
+        (round_id, creator.clone(), reward),
+    );
+    reward
+}
+
+/// Returns a round by ID.
+pub fn get_round(env: &Env, round_id: u64) -> RetroRound {
+    env.storage()
+        .persistent()
+        .get(&crate::DataKey::Retro(RetroKey::Round(round_id)))
+        .unwrap_or_else(|| panic_with_error!(env, RetroError::RoundNotFound))
+}
+
+/// Returns the nominated creators for a round.
+pub fn get_round_creators(env: &Env, round_id: u64) -> Vec<Address> {
+    env.storage()
+        .persistent()
+        .get(&crate::DataKey::Retro(RetroKey::RoundCreators(round_id)))
+        .unwrap_or_else(|| Vec::new(env))
+}
+
+/// Returns the aggregated vote weight for a creator in a round.
+pub fn get_creator_votes(env: &Env, round_id: u64, creator: &Address) -> i128 {
+    env.storage()
+        .persistent()
+        .get(&crate::DataKey::Retro(RetroKey::CreatorVotes(round_id, creator.clone())))
+        .unwrap_or(0)
+}
+
+/// Returns whether a voter has already voted in a round.
+pub fn has_voted(env: &Env, round_id: u64, voter: &Address) -> bool {
+    env.storage()
+        .persistent()
+        .get(&crate::DataKey::Retro(RetroKey::HasVoted(round_id, voter.clone())))
+        .unwrap_or(false)
+}

--- a/contracts/tipjar/tests/retroactive_funding_tests.rs
+++ b/contracts/tipjar/tests/retroactive_funding_tests.rs
@@ -1,0 +1,359 @@
+#![cfg(test)]
+
+extern crate std;
+
+use soroban_sdk::{testutils::Address as _, Address, Env};
+use tipjar::{
+    retroactive_funding::{EvalCriteria, RetroRoundStatus},
+    TipJarContract, TipJarContractClient,
+};
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+fn setup() -> (Env, TipJarContractClient<'static>, Address, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, TipJarContract);
+    let client = TipJarContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let token = env.register_stellar_asset_contract(token_admin.clone());
+
+    client.init(&admin);
+    client.add_token(&admin, &token);
+
+    (env, client, admin, token)
+}
+
+fn mint(env: &Env, token: &Address, to: &Address, amount: i128) {
+    soroban_sdk::token::StellarAssetClient::new(env, token).mint(to, &amount);
+}
+
+fn advance_time(env: &Env, seconds: u64) {
+    env.ledger().with_mut(|l| l.timestamp += seconds);
+}
+
+fn equal_criteria() -> EvalCriteria {
+    EvalCriteria {
+        tips_weight_bps: 3_334,
+        tip_count_weight_bps: 3_333,
+        vote_weight_bps: 3_333,
+    }
+}
+
+fn vote_only_criteria() -> EvalCriteria {
+    EvalCriteria {
+        tips_weight_bps: 0,
+        tip_count_weight_bps: 0,
+        vote_weight_bps: 10_000,
+    }
+}
+
+// ── create_round ──────────────────────────────────────────────────────────────
+
+#[test]
+fn test_create_round_basic() {
+    let (env, client, admin, token) = setup();
+    mint(&env, &token, &admin, 1_000);
+
+    let now = env.ledger().timestamp();
+    let round_id = client.retro_create_round(
+        &admin, &token, &1_000, &now, &(now + 3600), &equal_criteria(),
+    );
+    assert_eq!(round_id, 0);
+
+    let round = client.retro_get_round(&round_id);
+    assert_eq!(round.reward_pool, 1_000);
+    assert_eq!(round.status, RetroRoundStatus::Active);
+    assert_eq!(round.total_votes, 0);
+}
+
+#[test]
+fn test_create_multiple_rounds() {
+    let (env, client, admin, token) = setup();
+    mint(&env, &token, &admin, 3_000);
+
+    let now = env.ledger().timestamp();
+    let r0 = client.retro_create_round(&admin, &token, &1_000, &now, &(now + 3600), &equal_criteria());
+    let r1 = client.retro_create_round(&admin, &token, &1_000, &now, &(now + 7200), &equal_criteria());
+    let r2 = client.retro_create_round(&admin, &token, &1_000, &now, &(now + 86400), &equal_criteria());
+
+    assert_eq!(r0, 0);
+    assert_eq!(r1, 1);
+    assert_eq!(r2, 2);
+}
+
+#[test]
+#[should_panic]
+fn test_create_round_invalid_criteria() {
+    let (env, client, admin, token) = setup();
+    mint(&env, &token, &admin, 1_000);
+
+    let now = env.ledger().timestamp();
+    // weights sum to 9_000, not 10_000 — should panic
+    client.retro_create_round(
+        &admin,
+        &token,
+        &1_000,
+        &now,
+        &(now + 3600),
+        &EvalCriteria {
+            tips_weight_bps: 3_000,
+            tip_count_weight_bps: 3_000,
+            vote_weight_bps: 3_000,
+        },
+    );
+}
+
+// ── nominate_creator ──────────────────────────────────────────────────────────
+
+#[test]
+fn test_nominate_creator() {
+    let (env, client, admin, token) = setup();
+    mint(&env, &token, &admin, 1_000);
+
+    let now = env.ledger().timestamp();
+    let round_id = client.retro_create_round(&admin, &token, &1_000, &now, &(now + 3600), &equal_criteria());
+
+    let creator = Address::generate(&env);
+    client.retro_nominate_creator(&admin, &round_id, &creator);
+
+    let creators = client.retro_get_round_creators(&round_id);
+    assert_eq!(creators.len(), 1);
+    assert_eq!(creators.get(0).unwrap(), creator);
+}
+
+#[test]
+fn test_nominate_creator_idempotent() {
+    let (env, client, admin, token) = setup();
+    mint(&env, &token, &admin, 1_000);
+
+    let now = env.ledger().timestamp();
+    let round_id = client.retro_create_round(&admin, &token, &1_000, &now, &(now + 3600), &equal_criteria());
+
+    let creator = Address::generate(&env);
+    client.retro_nominate_creator(&admin, &round_id, &creator);
+    client.retro_nominate_creator(&admin, &round_id, &creator); // duplicate — no-op
+
+    let creators = client.retro_get_round_creators(&round_id);
+    assert_eq!(creators.len(), 1);
+}
+
+// ── cast_vote ─────────────────────────────────────────────────────────────────
+
+#[test]
+fn test_cast_vote_basic() {
+    let (env, client, admin, token) = setup();
+    mint(&env, &token, &admin, 1_000);
+
+    let now = env.ledger().timestamp();
+    let round_id = client.retro_create_round(&admin, &token, &1_000, &now, &(now + 3600), &vote_only_criteria());
+
+    let creator = Address::generate(&env);
+    client.retro_nominate_creator(&admin, &round_id, &creator);
+
+    let voter = Address::generate(&env);
+    client.retro_cast_vote(&voter, &round_id, &creator);
+
+    // voter with no tip history gets weight = 1
+    let votes = client.retro_get_creator_votes(&round_id, &creator);
+    assert_eq!(votes, 1);
+    assert!(client.retro_has_voted(&round_id, &voter));
+}
+
+#[test]
+#[should_panic]
+fn test_cast_vote_twice_panics() {
+    let (env, client, admin, token) = setup();
+    mint(&env, &token, &admin, 1_000);
+
+    let now = env.ledger().timestamp();
+    let round_id = client.retro_create_round(&admin, &token, &1_000, &now, &(now + 3600), &vote_only_criteria());
+
+    let creator = Address::generate(&env);
+    client.retro_nominate_creator(&admin, &round_id, &creator);
+
+    let voter = Address::generate(&env);
+    client.retro_cast_vote(&voter, &round_id, &creator);
+    client.retro_cast_vote(&voter, &round_id, &creator); // should panic
+}
+
+#[test]
+#[should_panic]
+fn test_cast_vote_unnominated_creator_panics() {
+    let (env, client, admin, token) = setup();
+    mint(&env, &token, &admin, 1_000);
+
+    let now = env.ledger().timestamp();
+    let round_id = client.retro_create_round(&admin, &token, &1_000, &now, &(now + 3600), &vote_only_criteria());
+
+    let creator = Address::generate(&env);
+    let voter = Address::generate(&env);
+    // creator not nominated — should panic
+    client.retro_cast_vote(&voter, &round_id, &creator);
+}
+
+#[test]
+fn test_multiple_voters() {
+    let (env, client, admin, token) = setup();
+    mint(&env, &token, &admin, 1_000);
+
+    let now = env.ledger().timestamp();
+    let round_id = client.retro_create_round(&admin, &token, &1_000, &now, &(now + 3600), &vote_only_criteria());
+
+    let creator = Address::generate(&env);
+    client.retro_nominate_creator(&admin, &round_id, &creator);
+
+    for _ in 0..5 {
+        let voter = Address::generate(&env);
+        client.retro_cast_vote(&voter, &round_id, &creator);
+    }
+
+    let votes = client.retro_get_creator_votes(&round_id, &creator);
+    assert_eq!(votes, 5); // 5 voters × weight 1 each
+}
+
+// ── finalize_round ────────────────────────────────────────────────────────────
+
+#[test]
+fn test_finalize_round() {
+    let (env, client, admin, token) = setup();
+    mint(&env, &token, &admin, 1_000);
+
+    let now = env.ledger().timestamp();
+    let round_id = client.retro_create_round(&admin, &token, &1_000, &now, &(now + 3600), &vote_only_criteria());
+
+    advance_time(&env, 3601);
+    client.retro_finalize_round(&admin, &round_id);
+
+    let round = client.retro_get_round(&round_id);
+    assert_eq!(round.status, RetroRoundStatus::Finalized);
+}
+
+#[test]
+#[should_panic]
+fn test_finalize_before_end_panics() {
+    let (env, client, admin, token) = setup();
+    mint(&env, &token, &admin, 1_000);
+
+    let now = env.ledger().timestamp();
+    let round_id = client.retro_create_round(&admin, &token, &1_000, &now, &(now + 3600), &vote_only_criteria());
+
+    // voting window still open — should panic
+    client.retro_finalize_round(&admin, &round_id);
+}
+
+// ── compute_impact_score ──────────────────────────────────────────────────────
+
+#[test]
+fn test_compute_impact_score_vote_only() {
+    let (env, client, admin, token) = setup();
+    mint(&env, &token, &admin, 1_000);
+
+    let now = env.ledger().timestamp();
+    let round_id = client.retro_create_round(&admin, &token, &1_000, &now, &(now + 3600), &vote_only_criteria());
+
+    let creator = Address::generate(&env);
+    client.retro_nominate_creator(&admin, &round_id, &creator);
+
+    // 3 voters, each weight 1
+    for _ in 0..3 {
+        let voter = Address::generate(&env);
+        client.retro_cast_vote(&voter, &round_id, &creator);
+    }
+
+    let score = client.retro_compute_impact_score(&round_id, &creator);
+    // score = (0 * 0 + 0 * 0 + 3 * 1_000_000 * 10_000) / 10_000 = 3_000_000
+    assert_eq!(score, 3_000_000);
+}
+
+// ── claim_reward ──────────────────────────────────────────────────────────────
+
+#[test]
+fn test_claim_reward_single_creator() {
+    let (env, client, admin, token) = setup();
+    mint(&env, &token, &admin, 1_000);
+
+    let now = env.ledger().timestamp();
+    let round_id = client.retro_create_round(&admin, &token, &1_000, &now, &(now + 3600), &vote_only_criteria());
+
+    let creator = Address::generate(&env);
+    client.retro_nominate_creator(&admin, &round_id, &creator);
+
+    let voter = Address::generate(&env);
+    client.retro_cast_vote(&voter, &round_id, &creator);
+
+    advance_time(&env, 3601);
+    client.retro_finalize_round(&admin, &round_id);
+
+    let reward = client.retro_claim_reward(&creator, &round_id);
+    // Only creator → gets 100% of pool
+    assert_eq!(reward, 1_000);
+}
+
+#[test]
+fn test_claim_reward_two_creators_equal_votes() {
+    let (env, client, admin, token) = setup();
+    mint(&env, &token, &admin, 1_000);
+
+    let now = env.ledger().timestamp();
+    let round_id = client.retro_create_round(&admin, &token, &1_000, &now, &(now + 3600), &vote_only_criteria());
+
+    let creator_a = Address::generate(&env);
+    let creator_b = Address::generate(&env);
+    client.retro_nominate_creator(&admin, &round_id, &creator_a);
+    client.retro_nominate_creator(&admin, &round_id, &creator_b);
+
+    // 1 vote each
+    client.retro_cast_vote(&Address::generate(&env), &round_id, &creator_a);
+    client.retro_cast_vote(&Address::generate(&env), &round_id, &creator_b);
+
+    advance_time(&env, 3601);
+    client.retro_finalize_round(&admin, &round_id);
+
+    let reward_a = client.retro_claim_reward(&creator_a, &round_id);
+    let reward_b = client.retro_claim_reward(&creator_b, &round_id);
+
+    // Equal scores → equal split (integer division may leave 1 stroop in contract)
+    assert_eq!(reward_a, 500);
+    assert_eq!(reward_b, 500);
+}
+
+#[test]
+#[should_panic]
+fn test_claim_reward_twice_panics() {
+    let (env, client, admin, token) = setup();
+    mint(&env, &token, &admin, 1_000);
+
+    let now = env.ledger().timestamp();
+    let round_id = client.retro_create_round(&admin, &token, &1_000, &now, &(now + 3600), &vote_only_criteria());
+
+    let creator = Address::generate(&env);
+    client.retro_nominate_creator(&admin, &round_id, &creator);
+    client.retro_cast_vote(&Address::generate(&env), &round_id, &creator);
+
+    advance_time(&env, 3601);
+    client.retro_finalize_round(&admin, &round_id);
+
+    client.retro_claim_reward(&creator, &round_id);
+    client.retro_claim_reward(&creator, &round_id); // should panic
+}
+
+#[test]
+#[should_panic]
+fn test_claim_reward_before_finalize_panics() {
+    let (env, client, admin, token) = setup();
+    mint(&env, &token, &admin, 1_000);
+
+    let now = env.ledger().timestamp();
+    let round_id = client.retro_create_round(&admin, &token, &1_000, &now, &(now + 3600), &vote_only_criteria());
+
+    let creator = Address::generate(&env);
+    client.retro_nominate_creator(&admin, &round_id, &creator);
+    client.retro_cast_vote(&Address::generate(&env), &round_id, &creator);
+
+    // Not finalized yet — should panic
+    client.retro_claim_reward(&creator, &round_id);
+}


### PR DESCRIPTION
Closes #246

---

## Summary

Adds a retroactive public goods funding mechanism to reward past contributions.

## Changes

- **`contracts/tipjar/src/retroactive_funding.rs`** — new module implementing:
  - `EvalCriteria` — configurable basis-point weights for tips received, tip count, and votes (must sum to 10 000)
  - `RetroRound` / `RetroVote` — on-chain storage types
  - `RetroError` — 13 error codes (700–712)
  - Sqrt-weighted voting for Sybil resistance
  - Functions: `create_round`, `nominate_creator`, `cast_vote`, `finalize_round`, `compute_impact_score`, `claim_reward`, plus query helpers

- **`contracts/tipjar/src/lib.rs`** — module declaration, `DataKey::Retro` variant, 10 public contract methods (`retro_*`)

- **`contracts/tipjar/tests/retroactive_funding_tests.rs`** — 14 tests covering all happy paths and error cases

## Design

- Vote weight = `sqrt(voter total tips sent)`, min 1 — active participants have more influence without whale dominance
- Rewards use a pull pattern (per-creator claim) to avoid gas exhaustion
- Impact score = weighted sum of historical tips, tip count, and votes per `EvalCriteria`

## Testing

14 unit tests covering: round creation, criteria validation, creator nomination, voting (basic, double-vote, unnominated), finalization, impact scoring, and reward claiming.