### PR TITLE
feat: implement tip stop loss orders and market making (#320, #321)

### DIFF
--- a/contracts/tipjar/Cargo.toml
+++ b/contracts/tipjar/Cargo.toml
@@ -123,3 +123,11 @@ path = "tests/rental_tests.rs"
 name = "portfolio_rebalancing_tests"
 path = "tests/portfolio_rebalancing_tests.rs"
 
+[[test]]
+name = "stop_loss_tests"
+path = "tests/stop_loss_tests.rs"
+
+[[test]]
+name = "market_making_tests"
+path = "tests/market_making_tests.rs"
+

--- a/contracts/tipjar/src/lib.rs
+++ b/contracts/tipjar/src/lib.rs
@@ -64,6 +64,12 @@ pub mod options;
 // Prediction markets
 pub mod prediction_market;
 
+// Stop loss orders for automatic position closure at trigger prices.
+pub mod stop_loss;
+
+// Automated market making for providing liquidity and earning fees.
+pub mod market_making;
+
 // Tip futures contracts
 pub mod futures;
 
@@ -988,6 +994,10 @@ pub enum DataKey {
     RepToken(reputation_tokens::RepTokenKey),
     /// Composable NFT sub-keys.
     Nft(composable_nft::NftKey),
+    /// Stop loss order sub-keys.
+    StopLoss(stop_loss::StopLossKey),
+    /// Market making sub-keys.
+    MarketMaking(market_making::MarketMakingKey),
 }
 
 #[contracterror]
@@ -11334,5 +11344,221 @@ impl TipJarContract {
     /// Get composition history for an NFT.
     pub fn nft_get_history(env: Env, nft_id: u64) -> Vec<composable_nft::CompositionEvent> {
         composable_nft::get_composition_history(&env, nft_id)
+    }
+
+    // ── Stop Loss Orders (#320) ───────────────────────────────────────────────
+
+    /// Places a stop loss order, escrowing `amount` of `token`.
+    ///
+    /// `kind` selects StopLoss, StopLimit, or TrailingStop.
+    /// `current_price` seeds the trailing-stop peak (pass 0 to use `stop_price`).
+    /// Returns the new order ID.
+    pub fn sl_place_order(
+        env: Env,
+        owner: Address,
+        token: Address,
+        amount: i128,
+        stop_price: i128,
+        limit_price: i128,
+        trail_amount: i128,
+        kind: stop_loss::StopOrderKind,
+        current_price: i128,
+    ) -> u64 {
+        Self::require_not_paused(&env);
+        let whitelisted: bool = env
+            .storage()
+            .instance()
+            .get(&DataKey::TokenWhitelist(token.clone()))
+            .unwrap_or(false);
+        if !whitelisted {
+            panic_with_error!(&env, TipJarError::TokenNotWhitelisted);
+        }
+        stop_loss::place_order(
+            &env,
+            &owner,
+            &token,
+            amount,
+            stop_price,
+            limit_price,
+            trail_amount,
+            kind,
+            current_price,
+        )
+    }
+
+    /// Updates the trailing stop peak for an order given the latest market price.
+    pub fn sl_update_price(env: Env, order_id: u64, current_price: i128) {
+        stop_loss::update_price(&env, order_id, current_price);
+    }
+
+    /// Checks whether `current_price` triggers the order; marks it Triggered if so.
+    /// Returns `true` when triggered.
+    pub fn sl_check_trigger(env: Env, order_id: u64, current_price: i128) -> bool {
+        stop_loss::check_trigger(&env, order_id, current_price)
+    }
+
+    /// Executes a triggered stop loss order, returning escrowed tokens to the owner.
+    pub fn sl_execute_order(env: Env, caller: Address, order_id: u64, execution_price: i128) {
+        Self::require_not_paused(&env);
+        stop_loss::execute_order(&env, &caller, order_id, execution_price);
+    }
+
+    /// Cancels an active stop loss order and refunds escrowed tokens to the owner.
+    pub fn sl_cancel_order(env: Env, owner: Address, order_id: u64) {
+        Self::require_not_paused(&env);
+        stop_loss::cancel_order(&env, &owner, order_id);
+    }
+
+    /// Returns a stop loss order by ID.
+    pub fn sl_get_order(env: Env, order_id: u64) -> Option<stop_loss::StopOrder> {
+        stop_loss::get_order(&env, order_id)
+    }
+
+    /// Returns all stop loss order IDs owned by `owner`.
+    pub fn sl_get_owner_orders(env: Env, owner: Address) -> Vec<u64> {
+        stop_loss::get_owner_orders(&env, &owner)
+    }
+
+    /// Returns all currently active stop loss order IDs.
+    pub fn sl_get_active_orders(env: Env) -> Vec<u64> {
+        stop_loss::get_active_orders(&env)
+    }
+
+    // ── Market Making (#321) ──────────────────────────────────────────────────
+
+    /// Registers a new market maker and deposits initial inventory.
+    ///
+    /// Returns the new maker_id.
+    pub fn mm_register(
+        env: Env,
+        maker: Address,
+        base_token: Address,
+        quote_token: Address,
+        spread_bps: u32,
+        base_deposit: i128,
+        quote_deposit: i128,
+        max_trade_size: i128,
+    ) -> u64 {
+        Self::require_not_paused(&env);
+        let base_wl: bool = env
+            .storage()
+            .instance()
+            .get(&DataKey::TokenWhitelist(base_token.clone()))
+            .unwrap_or(false);
+        let quote_wl: bool = env
+            .storage()
+            .instance()
+            .get(&DataKey::TokenWhitelist(quote_token.clone()))
+            .unwrap_or(false);
+        if !base_wl || !quote_wl {
+            panic_with_error!(&env, TipJarError::TokenNotWhitelisted);
+        }
+        market_making::register_maker(
+            &env,
+            &maker,
+            &base_token,
+            &quote_token,
+            spread_bps,
+            base_deposit,
+            quote_deposit,
+            max_trade_size,
+        )
+    }
+
+    /// Returns the current bid/ask quote for a market maker at `mid_price`.
+    pub fn mm_get_quote(env: Env, maker_id: u64, mid_price: i128) -> market_making::Quote {
+        market_making::get_quote(&env, maker_id, mid_price)
+    }
+
+    /// Executes a buy trade against a market maker (taker buys base, pays quote).
+    pub fn mm_buy(
+        env: Env,
+        taker: Address,
+        maker_id: u64,
+        base_amount: i128,
+        mid_price: i128,
+        max_quote: i128,
+    ) -> market_making::TradeResult {
+        Self::require_not_paused(&env);
+        market_making::execute_buy(&env, &taker, maker_id, base_amount, mid_price, max_quote)
+    }
+
+    /// Executes a sell trade against a market maker (taker sells base, receives quote).
+    pub fn mm_sell(
+        env: Env,
+        taker: Address,
+        maker_id: u64,
+        base_amount: i128,
+        mid_price: i128,
+        min_quote: i128,
+    ) -> market_making::TradeResult {
+        Self::require_not_paused(&env);
+        market_making::execute_sell(&env, &taker, maker_id, base_amount, mid_price, min_quote)
+    }
+
+    /// Deposits additional inventory into a market maker position.
+    pub fn mm_deposit(
+        env: Env,
+        maker: Address,
+        maker_id: u64,
+        base_amount: i128,
+        quote_amount: i128,
+    ) {
+        Self::require_not_paused(&env);
+        market_making::deposit_inventory(&env, &maker, maker_id, base_amount, quote_amount);
+    }
+
+    /// Withdraws inventory and fees from a market maker position.
+    pub fn mm_withdraw(
+        env: Env,
+        maker: Address,
+        maker_id: u64,
+        base_amount: i128,
+        quote_amount: i128,
+    ) {
+        Self::require_not_paused(&env);
+        market_making::withdraw_inventory(&env, &maker, maker_id, base_amount, quote_amount);
+    }
+
+    /// Updates the spread for a market maker.
+    pub fn mm_update_spread(env: Env, maker: Address, maker_id: u64, new_spread_bps: u32) {
+        Self::require_not_paused(&env);
+        market_making::update_spread(&env, &maker, maker_id, new_spread_bps);
+    }
+
+    /// Pauses (`active=false`) or resumes (`active=true`) a market maker.
+    pub fn mm_set_status(env: Env, maker: Address, maker_id: u64, active: bool) {
+        Self::require_not_paused(&env);
+        market_making::set_maker_status(&env, &maker, maker_id, active);
+    }
+
+    /// Closes a market maker and returns all inventory + fees to the owner.
+    pub fn mm_close(env: Env, maker: Address, maker_id: u64) {
+        Self::require_not_paused(&env);
+        market_making::close_maker(&env, &maker, maker_id);
+    }
+
+    /// Returns a market maker by ID.
+    pub fn mm_get_maker(env: Env, maker_id: u64) -> Option<market_making::MarketMaker> {
+        market_making::get_maker(&env, maker_id)
+    }
+
+    /// Returns all maker IDs owned by `maker`.
+    pub fn mm_get_owner_makers(env: Env, maker: Address) -> Vec<u64> {
+        market_making::get_owner_makers(&env, &maker)
+    }
+
+    /// Returns all active maker IDs.
+    pub fn mm_get_active_makers(env: Env) -> Vec<u64> {
+        market_making::get_active_makers(&env)
+    }
+
+    /// Returns maker IDs for a specific token pair.
+    pub fn mm_get_pair_makers(
+        env: Env,
+        base_token: Address,
+        quote_token: Address,
+    ) -> Vec<u64> {
+        market_making::get_pair_makers(&env, &base_token, &quote_token)
     }
 }

--- a/contracts/tipjar/src/market_making/mod.rs
+++ b/contracts/tipjar/src/market_making/mod.rs
@@ -1,0 +1,731 @@
+//! Tip Market Making System
+//!
+//! Provides automated market making for tip tokens: market makers post bid/ask
+//! quotes, earn fees from matched trades, and manage inventory risk.
+
+use soroban_sdk::{contracttype, panic_with_error, symbol_short, token, Address, Env, Vec};
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+/// Status of a market maker position.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq, Copy)]
+pub enum MakerStatus {
+    Active,
+    Paused,
+    Closed,
+}
+
+/// A market maker's configuration and live state.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct MarketMaker {
+    pub maker_id: u64,
+    pub maker: Address,
+    /// Base token (e.g. tip token).
+    pub base_token: Address,
+    /// Quote token (e.g. USDC).
+    pub quote_token: Address,
+    /// Spread in basis points (e.g. 50 = 0.5%).
+    pub spread_bps: u32,
+    /// Base token inventory deposited by the maker.
+    pub base_inventory: i128,
+    /// Quote token inventory deposited by the maker.
+    pub quote_inventory: i128,
+    /// Maximum single-trade size in base token units.
+    pub max_trade_size: i128,
+    /// Accumulated fees earned in quote token.
+    pub fees_earned: i128,
+    /// Total base volume traded.
+    pub total_base_volume: i128,
+    /// Total quote volume traded.
+    pub total_quote_volume: i128,
+    /// Number of trades executed.
+    pub trade_count: u64,
+    pub status: MakerStatus,
+    pub created_at: u64,
+    pub updated_at: u64,
+}
+
+/// A quote posted by a market maker (bid or ask).
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Quote {
+    pub maker_id: u64,
+    /// Mid-price used to derive bid/ask (× PRICE_PRECISION).
+    pub mid_price: i128,
+    /// Bid price = mid_price × (1 - spread/2).
+    pub bid_price: i128,
+    /// Ask price = mid_price × (1 + spread/2).
+    pub ask_price: i128,
+    /// Maximum base amount available at this quote.
+    pub available_base: i128,
+    /// Maximum quote amount available at this quote.
+    pub available_quote: i128,
+    pub timestamp: u64,
+}
+
+/// Result of a trade against a market maker.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TradeResult {
+    pub maker_id: u64,
+    pub base_amount: i128,
+    pub quote_amount: i128,
+    pub fee_amount: i128,
+    pub price: i128,
+    pub timestamp: u64,
+}
+
+/// Storage sub-keys for market making data.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum MarketMakingKey {
+    /// MarketMaker record keyed by maker_id.
+    Maker(u64),
+    /// Global maker ID counter.
+    Counter,
+    /// List of maker IDs owned by an address.
+    OwnerMakers(Address),
+    /// List of all active maker IDs.
+    ActiveMakers,
+    /// Maker IDs for a token pair (base, quote).
+    PairMakers(Address, Address),
+}
+
+// ── Constants ────────────────────────────────────────────────────────────────
+
+pub const PRICE_PRECISION: i128 = 1_000_000;
+/// Maximum spread: 10% (1000 bps).
+pub const MAX_SPREAD_BPS: u32 = 1_000;
+/// Fee charged per trade: 0.1% (10 bps) of quote amount.
+pub const TRADE_FEE_BPS: u32 = 10;
+
+// ── Errors ───────────────────────────────────────────────────────────────────
+
+#[soroban_sdk::contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum MarketMakingError {
+    MakerNotFound = 800,
+    MakerNotActive = 801,
+    Unauthorized = 802,
+    InvalidSpread = 803,
+    InvalidInventory = 804,
+    InvalidTradeSize = 805,
+    InsufficientBaseInventory = 806,
+    InsufficientQuoteInventory = 807,
+    TradeSizeExceedsMax = 808,
+    TokenNotWhitelisted = 809,
+    IdenticalTokens = 810,
+}
+
+// ── Public API ───────────────────────────────────────────────────────────────
+
+/// Registers a new market maker and deposits initial inventory.
+///
+/// Returns the new maker_id.
+/// Emits `("mm_reg",)` with data `(maker_id, maker, base_token, quote_token, spread_bps)`.
+pub fn register_maker(
+    env: &Env,
+    maker: &Address,
+    base_token: &Address,
+    quote_token: &Address,
+    spread_bps: u32,
+    base_deposit: i128,
+    quote_deposit: i128,
+    max_trade_size: i128,
+) -> u64 {
+    maker.require_auth();
+
+    if base_token == quote_token {
+        panic_with_error!(env, MarketMakingError::IdenticalTokens);
+    }
+    if spread_bps == 0 || spread_bps > MAX_SPREAD_BPS {
+        panic_with_error!(env, MarketMakingError::InvalidSpread);
+    }
+    if base_deposit < 0 || quote_deposit < 0 || (base_deposit == 0 && quote_deposit == 0) {
+        panic_with_error!(env, MarketMakingError::InvalidInventory);
+    }
+    if max_trade_size <= 0 {
+        panic_with_error!(env, MarketMakingError::InvalidTradeSize);
+    }
+
+    let maker_id: u64 = env
+        .storage()
+        .instance()
+        .get(&crate::DataKey::MarketMaking(MarketMakingKey::Counter))
+        .unwrap_or(0u64);
+    env.storage()
+        .instance()
+        .set(&crate::DataKey::MarketMaking(MarketMakingKey::Counter), &(maker_id + 1));
+
+    let now = env.ledger().timestamp();
+    let mm = MarketMaker {
+        maker_id,
+        maker: maker.clone(),
+        base_token: base_token.clone(),
+        quote_token: quote_token.clone(),
+        spread_bps,
+        base_inventory: base_deposit,
+        quote_inventory: quote_deposit,
+        max_trade_size,
+        fees_earned: 0,
+        total_base_volume: 0,
+        total_quote_volume: 0,
+        trade_count: 0,
+        status: MakerStatus::Active,
+        created_at: now,
+        updated_at: now,
+    };
+
+    env.storage()
+        .persistent()
+        .set(&crate::DataKey::MarketMaking(MarketMakingKey::Maker(maker_id)), &mm);
+
+    _add_owner_maker(env, maker, maker_id);
+    _add_active_maker(env, maker_id);
+    _add_pair_maker(env, base_token, quote_token, maker_id);
+
+    // Transfer inventory into contract escrow
+    if base_deposit > 0 {
+        token::Client::new(env, base_token).transfer(
+            maker,
+            &env.current_contract_address(),
+            &base_deposit,
+        );
+    }
+    if quote_deposit > 0 {
+        token::Client::new(env, quote_token).transfer(
+            maker,
+            &env.current_contract_address(),
+            &quote_deposit,
+        );
+    }
+
+    env.events().publish(
+        (symbol_short!("mm_reg"),),
+        (maker_id, maker.clone(), base_token.clone(), quote_token.clone(), spread_bps),
+    );
+
+    maker_id
+}
+
+/// Computes the current bid/ask quote for a market maker given a mid-price.
+///
+/// Does not modify state; purely a view function.
+pub fn get_quote(env: &Env, maker_id: u64, mid_price: i128) -> Quote {
+    let mm: MarketMaker = _get_maker_or_panic(env, maker_id);
+
+    if mm.status != MakerStatus::Active {
+        panic_with_error!(env, MarketMakingError::MakerNotActive);
+    }
+
+    let half_spread = (mid_price * mm.spread_bps as i128) / (2 * 10_000);
+    let bid_price = mid_price.saturating_sub(half_spread);
+    let ask_price = mid_price.saturating_add(half_spread);
+
+    // Available base at ask, available quote at bid
+    let available_base = mm.base_inventory.min(mm.max_trade_size);
+    let available_quote = mm.quote_inventory.min(
+        (mm.max_trade_size * bid_price) / PRICE_PRECISION,
+    );
+
+    Quote {
+        maker_id,
+        mid_price,
+        bid_price,
+        ask_price,
+        available_base,
+        available_quote,
+        timestamp: env.ledger().timestamp(),
+    }
+}
+
+/// Executes a buy trade against a market maker (taker buys base, pays quote).
+///
+/// `base_amount` — amount of base token the taker wants to buy.
+/// `max_quote`   — maximum quote tokens the taker is willing to pay (slippage guard).
+///
+/// Emits `("mm_buy",)` with data `(maker_id, taker, base_amount, quote_paid, fee)`.
+pub fn execute_buy(
+    env: &Env,
+    taker: &Address,
+    maker_id: u64,
+    base_amount: i128,
+    mid_price: i128,
+    max_quote: i128,
+) -> TradeResult {
+    taker.require_auth();
+
+    let mut mm: MarketMaker = _get_maker_or_panic(env, maker_id);
+
+    if mm.status != MakerStatus::Active {
+        panic_with_error!(env, MarketMakingError::MakerNotActive);
+    }
+    if base_amount <= 0 || base_amount > mm.max_trade_size {
+        panic_with_error!(env, MarketMakingError::TradeSizeExceedsMax);
+    }
+    if mm.base_inventory < base_amount {
+        panic_with_error!(env, MarketMakingError::InsufficientBaseInventory);
+    }
+
+    // Ask price = mid × (1 + spread/2)
+    let half_spread = (mid_price * mm.spread_bps as i128) / (2 * 10_000);
+    let ask_price = mid_price.saturating_add(half_spread);
+    let quote_needed = (base_amount * ask_price) / PRICE_PRECISION;
+    let fee = (quote_needed * TRADE_FEE_BPS as i128) / 10_000;
+    let total_quote = quote_needed + fee;
+
+    if total_quote > max_quote {
+        panic_with_error!(env, MarketMakingError::InsufficientQuoteInventory);
+    }
+
+    // State updates (CEI)
+    mm.base_inventory -= base_amount;
+    mm.quote_inventory += quote_needed;
+    mm.fees_earned += fee;
+    mm.total_base_volume += base_amount;
+    mm.total_quote_volume += quote_needed;
+    mm.trade_count += 1;
+    mm.updated_at = env.ledger().timestamp();
+
+    env.storage()
+        .persistent()
+        .set(&crate::DataKey::MarketMaking(MarketMakingKey::Maker(maker_id)), &mm);
+
+    // Transfers: taker pays quote, receives base
+    token::Client::new(env, &mm.quote_token).transfer(
+        taker,
+        &env.current_contract_address(),
+        &total_quote,
+    );
+    token::Client::new(env, &mm.base_token).transfer(
+        &env.current_contract_address(),
+        taker,
+        &base_amount,
+    );
+
+    let result = TradeResult {
+        maker_id,
+        base_amount,
+        quote_amount: total_quote,
+        fee_amount: fee,
+        price: ask_price,
+        timestamp: mm.updated_at,
+    };
+
+    env.events().publish(
+        (symbol_short!("mm_buy"),),
+        (maker_id, taker.clone(), base_amount, total_quote, fee),
+    );
+
+    result
+}
+
+/// Executes a sell trade against a market maker (taker sells base, receives quote).
+///
+/// `base_amount` — amount of base token the taker wants to sell.
+/// `min_quote`   — minimum quote tokens the taker expects to receive (slippage guard).
+///
+/// Emits `("mm_sell",)` with data `(maker_id, taker, base_amount, quote_received, fee)`.
+pub fn execute_sell(
+    env: &Env,
+    taker: &Address,
+    maker_id: u64,
+    base_amount: i128,
+    mid_price: i128,
+    min_quote: i128,
+) -> TradeResult {
+    taker.require_auth();
+
+    let mut mm: MarketMaker = _get_maker_or_panic(env, maker_id);
+
+    if mm.status != MakerStatus::Active {
+        panic_with_error!(env, MarketMakingError::MakerNotActive);
+    }
+    if base_amount <= 0 || base_amount > mm.max_trade_size {
+        panic_with_error!(env, MarketMakingError::TradeSizeExceedsMax);
+    }
+
+    // Bid price = mid × (1 - spread/2)
+    let half_spread = (mid_price * mm.spread_bps as i128) / (2 * 10_000);
+    let bid_price = mid_price.saturating_sub(half_spread);
+    let quote_gross = (base_amount * bid_price) / PRICE_PRECISION;
+    let fee = (quote_gross * TRADE_FEE_BPS as i128) / 10_000;
+    let quote_net = quote_gross.saturating_sub(fee);
+
+    if mm.quote_inventory < quote_gross {
+        panic_with_error!(env, MarketMakingError::InsufficientQuoteInventory);
+    }
+    if quote_net < min_quote {
+        panic_with_error!(env, MarketMakingError::InsufficientQuoteInventory);
+    }
+
+    // State updates (CEI)
+    mm.base_inventory += base_amount;
+    mm.quote_inventory -= quote_gross;
+    mm.fees_earned += fee;
+    mm.total_base_volume += base_amount;
+    mm.total_quote_volume += quote_gross;
+    mm.trade_count += 1;
+    mm.updated_at = env.ledger().timestamp();
+
+    env.storage()
+        .persistent()
+        .set(&crate::DataKey::MarketMaking(MarketMakingKey::Maker(maker_id)), &mm);
+
+    // Transfers: taker pays base, receives quote
+    token::Client::new(env, &mm.base_token).transfer(
+        taker,
+        &env.current_contract_address(),
+        &base_amount,
+    );
+    token::Client::new(env, &mm.quote_token).transfer(
+        &env.current_contract_address(),
+        taker,
+        &quote_net,
+    );
+
+    let result = TradeResult {
+        maker_id,
+        base_amount,
+        quote_amount: quote_net,
+        fee_amount: fee,
+        price: bid_price,
+        timestamp: mm.updated_at,
+    };
+
+    env.events().publish(
+        (symbol_short!("mm_sell"),),
+        (maker_id, taker.clone(), base_amount, quote_net, fee),
+    );
+
+    result
+}
+
+/// Adds more inventory to an existing market maker position.
+///
+/// Only the maker owner may call this.
+/// Emits `("mm_dep",)` with data `(maker_id, base_added, quote_added)`.
+pub fn deposit_inventory(
+    env: &Env,
+    maker: &Address,
+    maker_id: u64,
+    base_amount: i128,
+    quote_amount: i128,
+) {
+    maker.require_auth();
+
+    let mut mm: MarketMaker = _get_maker_or_panic(env, maker_id);
+
+    if mm.maker != *maker {
+        panic_with_error!(env, MarketMakingError::Unauthorized);
+    }
+    if mm.status == MakerStatus::Closed {
+        panic_with_error!(env, MarketMakingError::MakerNotActive);
+    }
+    if base_amount < 0 || quote_amount < 0 || (base_amount == 0 && quote_amount == 0) {
+        panic_with_error!(env, MarketMakingError::InvalidInventory);
+    }
+
+    mm.base_inventory += base_amount;
+    mm.quote_inventory += quote_amount;
+    mm.updated_at = env.ledger().timestamp();
+
+    env.storage()
+        .persistent()
+        .set(&crate::DataKey::MarketMaking(MarketMakingKey::Maker(maker_id)), &mm);
+
+    if base_amount > 0 {
+        token::Client::new(env, &mm.base_token).transfer(
+            maker,
+            &env.current_contract_address(),
+            &base_amount,
+        );
+    }
+    if quote_amount > 0 {
+        token::Client::new(env, &mm.quote_token).transfer(
+            maker,
+            &env.current_contract_address(),
+            &quote_amount,
+        );
+    }
+
+    env.events()
+        .publish((symbol_short!("mm_dep"),), (maker_id, base_amount, quote_amount));
+}
+
+/// Withdraws inventory and accumulated fees from a market maker position.
+///
+/// Only the maker owner may call this.
+/// Emits `("mm_wdr",)` with data `(maker_id, base_withdrawn, quote_withdrawn, fees_withdrawn)`.
+pub fn withdraw_inventory(
+    env: &Env,
+    maker: &Address,
+    maker_id: u64,
+    base_amount: i128,
+    quote_amount: i128,
+) {
+    maker.require_auth();
+
+    let mut mm: MarketMaker = _get_maker_or_panic(env, maker_id);
+
+    if mm.maker != *maker {
+        panic_with_error!(env, MarketMakingError::Unauthorized);
+    }
+    if base_amount > mm.base_inventory {
+        panic_with_error!(env, MarketMakingError::InsufficientBaseInventory);
+    }
+    if quote_amount > mm.quote_inventory + mm.fees_earned {
+        panic_with_error!(env, MarketMakingError::InsufficientQuoteInventory);
+    }
+
+    // Withdraw fees first, then inventory
+    let mut fees_withdrawn: i128 = 0;
+    let mut quote_from_inventory = quote_amount;
+    if mm.fees_earned > 0 && quote_amount > 0 {
+        fees_withdrawn = mm.fees_earned.min(quote_amount);
+        mm.fees_earned -= fees_withdrawn;
+        quote_from_inventory = quote_amount - fees_withdrawn;
+    }
+
+    mm.base_inventory -= base_amount;
+    mm.quote_inventory -= quote_from_inventory;
+    mm.updated_at = env.ledger().timestamp();
+
+    env.storage()
+        .persistent()
+        .set(&crate::DataKey::MarketMaking(MarketMakingKey::Maker(maker_id)), &mm);
+
+    if base_amount > 0 {
+        token::Client::new(env, &mm.base_token).transfer(
+            &env.current_contract_address(),
+            maker,
+            &base_amount,
+        );
+    }
+    if quote_amount > 0 {
+        token::Client::new(env, &mm.quote_token).transfer(
+            &env.current_contract_address(),
+            maker,
+            &quote_amount,
+        );
+    }
+
+    env.events().publish(
+        (symbol_short!("mm_wdr"),),
+        (maker_id, base_amount, quote_amount, fees_withdrawn),
+    );
+}
+
+/// Updates the spread for a market maker. Only the maker owner may call this.
+///
+/// Emits `("mm_sprd",)` with data `(maker_id, new_spread_bps)`.
+pub fn update_spread(env: &Env, maker: &Address, maker_id: u64, new_spread_bps: u32) {
+    maker.require_auth();
+
+    let mut mm: MarketMaker = _get_maker_or_panic(env, maker_id);
+
+    if mm.maker != *maker {
+        panic_with_error!(env, MarketMakingError::Unauthorized);
+    }
+    if new_spread_bps == 0 || new_spread_bps > MAX_SPREAD_BPS {
+        panic_with_error!(env, MarketMakingError::InvalidSpread);
+    }
+
+    mm.spread_bps = new_spread_bps;
+    mm.updated_at = env.ledger().timestamp();
+
+    env.storage()
+        .persistent()
+        .set(&crate::DataKey::MarketMaking(MarketMakingKey::Maker(maker_id)), &mm);
+
+    env.events()
+        .publish((symbol_short!("mm_sprd"),), (maker_id, new_spread_bps));
+}
+
+/// Pauses or resumes a market maker. Only the maker owner may call this.
+///
+/// Emits `("mm_pause",)` or `("mm_resume",)` with data `(maker_id,)`.
+pub fn set_maker_status(env: &Env, maker: &Address, maker_id: u64, active: bool) {
+    maker.require_auth();
+
+    let mut mm: MarketMaker = _get_maker_or_panic(env, maker_id);
+
+    if mm.maker != *maker {
+        panic_with_error!(env, MarketMakingError::Unauthorized);
+    }
+    if mm.status == MakerStatus::Closed {
+        panic_with_error!(env, MarketMakingError::MakerNotActive);
+    }
+
+    mm.status = if active { MakerStatus::Active } else { MakerStatus::Paused };
+    mm.updated_at = env.ledger().timestamp();
+
+    env.storage()
+        .persistent()
+        .set(&crate::DataKey::MarketMaking(MarketMakingKey::Maker(maker_id)), &mm);
+
+    if active {
+        env.events().publish((symbol_short!("mm_res"),), (maker_id,));
+    } else {
+        env.events().publish((symbol_short!("mm_pau"),), (maker_id,));
+    }
+}
+
+/// Closes a market maker and withdraws all remaining inventory + fees to the owner.
+///
+/// Emits `("mm_close",)` with data `(maker_id, base_returned, quote_returned)`.
+pub fn close_maker(env: &Env, maker: &Address, maker_id: u64) {
+    maker.require_auth();
+
+    let mut mm: MarketMaker = _get_maker_or_panic(env, maker_id);
+
+    if mm.maker != *maker {
+        panic_with_error!(env, MarketMakingError::Unauthorized);
+    }
+    if mm.status == MakerStatus::Closed {
+        panic_with_error!(env, MarketMakingError::MakerNotActive);
+    }
+
+    let base_return = mm.base_inventory;
+    let quote_return = mm.quote_inventory + mm.fees_earned;
+
+    mm.base_inventory = 0;
+    mm.quote_inventory = 0;
+    mm.fees_earned = 0;
+    mm.status = MakerStatus::Closed;
+    mm.updated_at = env.ledger().timestamp();
+
+    env.storage()
+        .persistent()
+        .set(&crate::DataKey::MarketMaking(MarketMakingKey::Maker(maker_id)), &mm);
+
+    _remove_active_maker(env, maker_id);
+
+    if base_return > 0 {
+        token::Client::new(env, &mm.base_token).transfer(
+            &env.current_contract_address(),
+            maker,
+            &base_return,
+        );
+    }
+    if quote_return > 0 {
+        token::Client::new(env, &mm.quote_token).transfer(
+            &env.current_contract_address(),
+            maker,
+            &quote_return,
+        );
+    }
+
+    env.events()
+        .publish((symbol_short!("mm_close"),), (maker_id, base_return, quote_return));
+}
+
+/// Returns a market maker by ID.
+pub fn get_maker(env: &Env, maker_id: u64) -> Option<MarketMaker> {
+    env.storage()
+        .persistent()
+        .get(&crate::DataKey::MarketMaking(MarketMakingKey::Maker(maker_id)))
+}
+
+/// Returns all maker IDs owned by `maker`.
+pub fn get_owner_makers(env: &Env, maker: &Address) -> Vec<u64> {
+    env.storage()
+        .persistent()
+        .get(&crate::DataKey::MarketMaking(MarketMakingKey::OwnerMakers(maker.clone())))
+        .unwrap_or_else(|| Vec::new(env))
+}
+
+/// Returns all active maker IDs.
+pub fn get_active_makers(env: &Env) -> Vec<u64> {
+    env.storage()
+        .persistent()
+        .get(&crate::DataKey::MarketMaking(MarketMakingKey::ActiveMakers))
+        .unwrap_or_else(|| Vec::new(env))
+}
+
+/// Returns maker IDs for a specific token pair.
+pub fn get_pair_makers(env: &Env, base_token: &Address, quote_token: &Address) -> Vec<u64> {
+    env.storage()
+        .persistent()
+        .get(&crate::DataKey::MarketMaking(MarketMakingKey::PairMakers(
+            base_token.clone(),
+            quote_token.clone(),
+        )))
+        .unwrap_or_else(|| Vec::new(env))
+}
+
+// ── Internal helpers ─────────────────────────────────────────────────────────
+
+fn _get_maker_or_panic(env: &Env, maker_id: u64) -> MarketMaker {
+    env.storage()
+        .persistent()
+        .get(&crate::DataKey::MarketMaking(MarketMakingKey::Maker(maker_id)))
+        .unwrap_or_else(|| panic_with_error!(env, MarketMakingError::MakerNotFound))
+}
+
+fn _add_owner_maker(env: &Env, maker: &Address, maker_id: u64) {
+    let mut ids: Vec<u64> = env
+        .storage()
+        .persistent()
+        .get(&crate::DataKey::MarketMaking(MarketMakingKey::OwnerMakers(maker.clone())))
+        .unwrap_or_else(|| Vec::new(env));
+    if !ids.contains(&maker_id) {
+        ids.push_back(maker_id);
+        env.storage().persistent().set(
+            &crate::DataKey::MarketMaking(MarketMakingKey::OwnerMakers(maker.clone())),
+            &ids,
+        );
+    }
+}
+
+fn _add_active_maker(env: &Env, maker_id: u64) {
+    let mut ids: Vec<u64> = env
+        .storage()
+        .persistent()
+        .get(&crate::DataKey::MarketMaking(MarketMakingKey::ActiveMakers))
+        .unwrap_or_else(|| Vec::new(env));
+    if !ids.contains(&maker_id) {
+        ids.push_back(maker_id);
+        env.storage()
+            .persistent()
+            .set(&crate::DataKey::MarketMaking(MarketMakingKey::ActiveMakers), &ids);
+    }
+}
+
+fn _remove_active_maker(env: &Env, maker_id: u64) {
+    let ids: Vec<u64> = env
+        .storage()
+        .persistent()
+        .get(&crate::DataKey::MarketMaking(MarketMakingKey::ActiveMakers))
+        .unwrap_or_else(|| Vec::new(env));
+    let mut remaining = Vec::new(env);
+    for id in ids.iter() {
+        if id != maker_id {
+            remaining.push_back(id);
+        }
+    }
+    env.storage()
+        .persistent()
+        .set(&crate::DataKey::MarketMaking(MarketMakingKey::ActiveMakers), &remaining);
+}
+
+fn _add_pair_maker(env: &Env, base: &Address, quote: &Address, maker_id: u64) {
+    let mut ids: Vec<u64> = env
+        .storage()
+        .persistent()
+        .get(&crate::DataKey::MarketMaking(MarketMakingKey::PairMakers(
+            base.clone(),
+            quote.clone(),
+        )))
+        .unwrap_or_else(|| Vec::new(env));
+    if !ids.contains(&maker_id) {
+        ids.push_back(maker_id);
+        env.storage().persistent().set(
+            &crate::DataKey::MarketMaking(MarketMakingKey::PairMakers(base.clone(), quote.clone())),
+            &ids,
+        );
+    }
+}

--- a/contracts/tipjar/src/stop_loss/mod.rs
+++ b/contracts/tipjar/src/stop_loss/mod.rs
@@ -1,0 +1,390 @@
+//! Tip Stop Loss Orders
+//!
+//! Allows users to place stop loss orders that automatically close positions
+//! when a price falls below (or rises above) a trigger price.
+//! Supports standard stop loss, stop limit, and trailing stop orders.
+
+use soroban_sdk::{contracttype, panic_with_error, symbol_short, token, Address, Env, Vec};
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+/// Kind of stop loss order.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq, Copy)]
+pub enum StopOrderKind {
+    /// Triggers a market sell when price ≤ stop_price.
+    StopLoss,
+    /// Triggers a limit sell at limit_price when price ≤ stop_price.
+    StopLimit,
+    /// Stop price trails the market by `trail_amount`; triggers on reversal.
+    TrailingStop,
+}
+
+/// Status of a stop loss order.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq, Copy)]
+pub enum StopOrderStatus {
+    Active,
+    Triggered,
+    Executed,
+    Cancelled,
+}
+
+/// A stop loss order record.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct StopOrder {
+    pub order_id: u64,
+    pub owner: Address,
+    /// Token being protected (sold on trigger).
+    pub token: Address,
+    /// Amount of token held in escrow for this order.
+    pub amount: i128,
+    /// Price (× PRICE_PRECISION) at which the order triggers.
+    pub stop_price: i128,
+    /// For StopLimit: the minimum acceptable execution price.
+    pub limit_price: i128,
+    /// For TrailingStop: distance below the peak price that triggers execution.
+    pub trail_amount: i128,
+    /// Highest observed price since order creation (used for trailing stops).
+    pub peak_price: i128,
+    pub kind: StopOrderKind,
+    pub status: StopOrderStatus,
+    pub created_at: u64,
+    pub triggered_at: u64,
+    pub executed_at: u64,
+}
+
+/// Storage sub-keys for stop loss data.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum StopLossKey {
+    /// Order record keyed by order_id.
+    Order(u64),
+    /// Global order ID counter.
+    Counter,
+    /// List of order IDs owned by an address.
+    OwnerOrders(Address),
+    /// List of all active order IDs (for price monitoring).
+    ActiveOrders,
+}
+
+// ── Price precision ──────────────────────────────────────────────────────────
+
+/// All prices are stored as integer multiples of PRICE_PRECISION.
+pub const PRICE_PRECISION: i128 = 1_000_000;
+
+// ── Errors ───────────────────────────────────────────────────────────────────
+
+#[soroban_sdk::contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum StopLossError {
+    OrderNotFound = 700,
+    OrderNotActive = 701,
+    Unauthorized = 702,
+    InvalidAmount = 703,
+    InvalidStopPrice = 704,
+    InvalidLimitPrice = 705,
+    InvalidTrailAmount = 706,
+    PriceNotTriggered = 707,
+    LimitPriceNotMet = 708,
+    TokenNotWhitelisted = 709,
+}
+
+// ── Public API ───────────────────────────────────────────────────────────────
+
+/// Places a new stop loss order. Tokens are transferred into escrow.
+///
+/// Returns the new order ID.
+/// Emits `("sl_place",)` with data `(order_id, owner, token, amount, stop_price, kind)`.
+pub fn place_order(
+    env: &Env,
+    owner: &Address,
+    token: &Address,
+    amount: i128,
+    stop_price: i128,
+    limit_price: i128,
+    trail_amount: i128,
+    kind: StopOrderKind,
+    current_price: i128,
+) -> u64 {
+    owner.require_auth();
+
+    if amount <= 0 {
+        panic_with_error!(env, StopLossError::InvalidAmount);
+    }
+    if stop_price <= 0 {
+        panic_with_error!(env, StopLossError::InvalidStopPrice);
+    }
+    if matches!(kind, StopOrderKind::StopLimit) && limit_price <= 0 {
+        panic_with_error!(env, StopLossError::InvalidLimitPrice);
+    }
+    if matches!(kind, StopOrderKind::TrailingStop) && trail_amount <= 0 {
+        panic_with_error!(env, StopLossError::InvalidTrailAmount);
+    }
+
+    let order_id: u64 = env
+        .storage()
+        .instance()
+        .get(&crate::DataKey::StopLoss(StopLossKey::Counter))
+        .unwrap_or(0u64);
+    env.storage()
+        .instance()
+        .set(&crate::DataKey::StopLoss(StopLossKey::Counter), &(order_id + 1));
+
+    let now = env.ledger().timestamp();
+    let peak = if current_price > 0 { current_price } else { stop_price };
+
+    let order = StopOrder {
+        order_id,
+        owner: owner.clone(),
+        token: token.clone(),
+        amount,
+        stop_price,
+        limit_price,
+        trail_amount,
+        peak_price: peak,
+        kind,
+        status: StopOrderStatus::Active,
+        created_at: now,
+        triggered_at: 0,
+        executed_at: 0,
+    };
+
+    env.storage()
+        .persistent()
+        .set(&crate::DataKey::StopLoss(StopLossKey::Order(order_id)), &order);
+
+    _add_owner_order(env, owner, order_id);
+    _add_active_order(env, order_id);
+
+    // Transfer tokens into escrow
+    token::Client::new(env, token).transfer(owner, &env.current_contract_address(), &amount);
+
+    env.events().publish(
+        (symbol_short!("sl_place"),),
+        (order_id, owner.clone(), token.clone(), amount, stop_price, kind),
+    );
+
+    order_id
+}
+
+/// Updates the peak price for a trailing stop order and adjusts stop_price accordingly.
+///
+/// Should be called whenever a new market price is observed.
+/// Emits `("sl_trail",)` with data `(order_id, new_stop_price)`.
+pub fn update_price(env: &Env, order_id: u64, current_price: i128) {
+    let mut order: StopOrder = _get_order_or_panic(env, order_id);
+
+    if order.status != StopOrderStatus::Active {
+        return;
+    }
+
+    if !matches!(order.kind, StopOrderKind::TrailingStop) {
+        return;
+    }
+
+    if current_price > order.peak_price {
+        order.peak_price = current_price;
+        // Raise the stop price to trail the new peak
+        let new_stop = current_price.saturating_sub(order.trail_amount);
+        if new_stop > order.stop_price {
+            order.stop_price = new_stop;
+            env.storage().persistent().set(
+                &crate::DataKey::StopLoss(StopLossKey::Order(order_id)),
+                &order,
+            );
+            env.events()
+                .publish((symbol_short!("sl_trail"),), (order_id, new_stop));
+        }
+    }
+}
+
+/// Checks whether `current_price` triggers the order and marks it as Triggered.
+///
+/// Returns `true` if the order was triggered.
+/// Emits `("sl_trig",)` with data `(order_id, current_price)`.
+pub fn check_trigger(env: &Env, order_id: u64, current_price: i128) -> bool {
+    let mut order: StopOrder = _get_order_or_panic(env, order_id);
+
+    if order.status != StopOrderStatus::Active {
+        return false;
+    }
+
+    // Update trailing stop peak before checking trigger
+    if matches!(order.kind, StopOrderKind::TrailingStop) && current_price > order.peak_price {
+        order.peak_price = current_price;
+        let new_stop = current_price.saturating_sub(order.trail_amount);
+        if new_stop > order.stop_price {
+            order.stop_price = new_stop;
+        }
+    }
+
+    if current_price <= order.stop_price {
+        order.status = StopOrderStatus::Triggered;
+        order.triggered_at = env.ledger().timestamp();
+        env.storage().persistent().set(
+            &crate::DataKey::StopLoss(StopLossKey::Order(order_id)),
+            &order,
+        );
+        env.events()
+            .publish((symbol_short!("sl_trig"),), (order_id, current_price));
+        return true;
+    }
+
+    false
+}
+
+/// Executes a triggered stop loss order, transferring escrowed tokens to `recipient`.
+///
+/// For StopLimit orders, `execution_price` must be ≥ `limit_price`.
+/// Emits `("sl_exec",)` with data `(order_id, amount, execution_price)`.
+pub fn execute_order(env: &Env, caller: &Address, order_id: u64, execution_price: i128) {
+    caller.require_auth();
+
+    let mut order: StopOrder = _get_order_or_panic(env, order_id);
+
+    if order.status != StopOrderStatus::Triggered {
+        panic_with_error!(env, StopLossError::OrderNotActive);
+    }
+
+    // For stop-limit, verify execution price meets the limit
+    if matches!(order.kind, StopOrderKind::StopLimit) {
+        if execution_price < order.limit_price {
+            panic_with_error!(env, StopLossError::LimitPriceNotMet);
+        }
+    }
+
+    order.status = StopOrderStatus::Executed;
+    order.executed_at = env.ledger().timestamp();
+    env.storage()
+        .persistent()
+        .set(&crate::DataKey::StopLoss(StopLossKey::Order(order_id)), &order);
+
+    _remove_active_order(env, order_id);
+
+    // Transfer escrowed tokens back to owner (position closed)
+    token::Client::new(env, &order.token).transfer(
+        &env.current_contract_address(),
+        &order.owner,
+        &order.amount,
+    );
+
+    env.events().publish(
+        (symbol_short!("sl_exec"),),
+        (order_id, order.amount, execution_price),
+    );
+}
+
+/// Cancels an active stop loss order and refunds escrowed tokens to the owner.
+///
+/// Only the order owner may cancel.
+/// Emits `("sl_cncl",)` with data `(order_id,)`.
+pub fn cancel_order(env: &Env, owner: &Address, order_id: u64) {
+    owner.require_auth();
+
+    let mut order: StopOrder = _get_order_or_panic(env, order_id);
+
+    if order.owner != *owner {
+        panic_with_error!(env, StopLossError::Unauthorized);
+    }
+    if order.status != StopOrderStatus::Active && order.status != StopOrderStatus::Triggered {
+        panic_with_error!(env, StopLossError::OrderNotActive);
+    }
+
+    order.status = StopOrderStatus::Cancelled;
+    env.storage()
+        .persistent()
+        .set(&crate::DataKey::StopLoss(StopLossKey::Order(order_id)), &order);
+
+    _remove_active_order(env, order_id);
+
+    // Refund escrowed tokens
+    token::Client::new(env, &order.token).transfer(
+        &env.current_contract_address(),
+        &order.owner,
+        &order.amount,
+    );
+
+    env.events()
+        .publish((symbol_short!("sl_cncl"),), (order_id,));
+}
+
+/// Returns a stop order by ID.
+pub fn get_order(env: &Env, order_id: u64) -> Option<StopOrder> {
+    env.storage()
+        .persistent()
+        .get(&crate::DataKey::StopLoss(StopLossKey::Order(order_id)))
+}
+
+/// Returns all order IDs owned by `owner`.
+pub fn get_owner_orders(env: &Env, owner: &Address) -> Vec<u64> {
+    env.storage()
+        .persistent()
+        .get(&crate::DataKey::StopLoss(StopLossKey::OwnerOrders(owner.clone())))
+        .unwrap_or_else(|| Vec::new(env))
+}
+
+/// Returns all currently active order IDs.
+pub fn get_active_orders(env: &Env) -> Vec<u64> {
+    env.storage()
+        .persistent()
+        .get(&crate::DataKey::StopLoss(StopLossKey::ActiveOrders))
+        .unwrap_or_else(|| Vec::new(env))
+}
+
+// ── Internal helpers ─────────────────────────────────────────────────────────
+
+fn _get_order_or_panic(env: &Env, order_id: u64) -> StopOrder {
+    env.storage()
+        .persistent()
+        .get(&crate::DataKey::StopLoss(StopLossKey::Order(order_id)))
+        .unwrap_or_else(|| panic_with_error!(env, StopLossError::OrderNotFound))
+}
+
+fn _add_owner_order(env: &Env, owner: &Address, order_id: u64) {
+    let mut orders: Vec<u64> = env
+        .storage()
+        .persistent()
+        .get(&crate::DataKey::StopLoss(StopLossKey::OwnerOrders(owner.clone())))
+        .unwrap_or_else(|| Vec::new(env));
+    if !orders.contains(&order_id) {
+        orders.push_back(order_id);
+        env.storage().persistent().set(
+            &crate::DataKey::StopLoss(StopLossKey::OwnerOrders(owner.clone())),
+            &orders,
+        );
+    }
+}
+
+fn _add_active_order(env: &Env, order_id: u64) {
+    let mut orders: Vec<u64> = env
+        .storage()
+        .persistent()
+        .get(&crate::DataKey::StopLoss(StopLossKey::ActiveOrders))
+        .unwrap_or_else(|| Vec::new(env));
+    if !orders.contains(&order_id) {
+        orders.push_back(order_id);
+        env.storage()
+            .persistent()
+            .set(&crate::DataKey::StopLoss(StopLossKey::ActiveOrders), &orders);
+    }
+}
+
+fn _remove_active_order(env: &Env, order_id: u64) {
+    let orders: Vec<u64> = env
+        .storage()
+        .persistent()
+        .get(&crate::DataKey::StopLoss(StopLossKey::ActiveOrders))
+        .unwrap_or_else(|| Vec::new(env));
+    let mut remaining = Vec::new(env);
+    for id in orders.iter() {
+        if id != order_id {
+            remaining.push_back(id);
+        }
+    }
+    env.storage()
+        .persistent()
+        .set(&crate::DataKey::StopLoss(StopLossKey::ActiveOrders), &remaining);
+}

--- a/contracts/tipjar/tests/market_making_tests.rs
+++ b/contracts/tipjar/tests/market_making_tests.rs
@@ -1,0 +1,258 @@
+#![cfg(test)]
+
+extern crate std;
+
+use soroban_sdk::{testutils::Address as _, Address, Env};
+use tipjar::{
+    market_making::MakerStatus,
+    TipJarContract, TipJarContractClient,
+};
+
+fn setup() -> (Env, TipJarContractClient<'static>, Address, Address, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, TipJarContract);
+    let client = TipJarContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let base_token = env.register_stellar_asset_contract(token_admin.clone());
+    let quote_token = env.register_stellar_asset_contract(token_admin.clone());
+
+    client.init(&admin);
+    client.add_token(&admin, &base_token);
+    client.add_token(&admin, &quote_token);
+
+    (env, client, admin, base_token, quote_token)
+}
+
+fn mint(env: &Env, token: &Address, to: &Address, amount: i128) {
+    soroban_sdk::token::StellarAssetClient::new(env, token).mint(to, &amount);
+}
+
+fn balance(env: &Env, token: &Address, of: &Address) -> i128 {
+    soroban_sdk::token::Client::new(env, token).balance(of)
+}
+
+// ── Market Making ────────────────────────────────────────────────────────────
+
+#[test]
+fn test_register_maker_and_get_quote() {
+    let (env, client, _admin, base, quote) = setup();
+    let maker = Address::generate(&env);
+    mint(&env, &base, &maker, 1_000_000);
+    mint(&env, &quote, &maker, 1_000_000);
+
+    let maker_id = client.mm_register(
+        &maker,
+        &base,
+        &quote,
+        &100u32,       // 1% spread
+        &500_000i128,  // base deposit
+        &500_000i128,  // quote deposit
+        &100_000i128,  // max trade size
+    );
+
+    let mm = client.mm_get_maker(&maker_id).unwrap();
+    assert_eq!(mm.spread_bps, 100);
+    assert_eq!(mm.base_inventory, 500_000);
+    assert_eq!(mm.quote_inventory, 500_000);
+    assert_eq!(mm.status, MakerStatus::Active);
+
+    // Quote at mid_price = 1_000_000
+    let q = client.mm_get_quote(&maker_id, &1_000_000i128);
+    assert_eq!(q.mid_price, 1_000_000);
+    // bid = 1_000_000 - 1_000_000*100/(2*10_000) = 1_000_000 - 5_000 = 995_000
+    assert_eq!(q.bid_price, 995_000);
+    // ask = 1_000_000 + 5_000 = 1_005_000
+    assert_eq!(q.ask_price, 1_005_000);
+}
+
+#[test]
+fn test_buy_trade() {
+    let (env, client, _admin, base, quote) = setup();
+    let maker_addr = Address::generate(&env);
+    let taker = Address::generate(&env);
+
+    mint(&env, &base, &maker_addr, 1_000_000);
+    mint(&env, &quote, &maker_addr, 2_000_000);
+    mint(&env, &quote, &taker, 2_000_000);
+
+    let maker_id = client.mm_register(
+        &maker_addr, &base, &quote,
+        &100u32, &1_000_000i128, &2_000_000i128, &500_000i128,
+    );
+
+    let mid_price = 1_000_000i128;
+    let base_amount = 100_000i128;
+
+    // ask = 1_005_000; quote_needed = 100_000 * 1_005_000 / 1_000_000 = 100_500
+    // fee = 100_500 * 10 / 10_000 = 100 (rounded down)
+    // total_quote = 100_600
+    let result = client.mm_buy(&taker, &maker_id, &base_amount, &mid_price, &200_000i128);
+
+    assert_eq!(result.base_amount, base_amount);
+    assert!(result.quote_amount > 0);
+    assert!(result.fee_amount > 0);
+
+    // Taker received base tokens
+    assert_eq!(balance(&env, &base, &taker), base_amount);
+
+    // Maker's base inventory decreased
+    let mm = client.mm_get_maker(&maker_id).unwrap();
+    assert_eq!(mm.base_inventory, 1_000_000 - base_amount);
+    assert!(mm.fees_earned > 0);
+    assert_eq!(mm.trade_count, 1);
+}
+
+#[test]
+fn test_sell_trade() {
+    let (env, client, _admin, base, quote) = setup();
+    let maker_addr = Address::generate(&env);
+    let taker = Address::generate(&env);
+
+    mint(&env, &base, &maker_addr, 1_000_000);
+    mint(&env, &quote, &maker_addr, 2_000_000);
+    mint(&env, &base, &taker, 500_000);
+
+    let maker_id = client.mm_register(
+        &maker_addr, &base, &quote,
+        &100u32, &1_000_000i128, &2_000_000i128, &500_000i128,
+    );
+
+    let mid_price = 1_000_000i128;
+    let base_amount = 100_000i128;
+
+    let result = client.mm_sell(&taker, &maker_id, &base_amount, &mid_price, &0i128);
+
+    assert_eq!(result.base_amount, base_amount);
+    assert!(result.quote_amount > 0);
+
+    // Taker's base decreased
+    assert_eq!(balance(&env, &base, &taker), 500_000 - base_amount);
+    // Taker received quote
+    assert!(balance(&env, &quote, &taker) > 0);
+
+    let mm = client.mm_get_maker(&maker_id).unwrap();
+    assert_eq!(mm.base_inventory, 1_000_000 + base_amount);
+    assert_eq!(mm.trade_count, 1);
+}
+
+#[test]
+fn test_deposit_and_withdraw_inventory() {
+    let (env, client, _admin, base, quote) = setup();
+    let maker_addr = Address::generate(&env);
+
+    mint(&env, &base, &maker_addr, 2_000_000);
+    mint(&env, &quote, &maker_addr, 2_000_000);
+
+    let maker_id = client.mm_register(
+        &maker_addr, &base, &quote,
+        &50u32, &500_000i128, &500_000i128, &100_000i128,
+    );
+
+    // Deposit more
+    client.mm_deposit(&maker_addr, &maker_id, &200_000i128, &200_000i128);
+    let mm = client.mm_get_maker(&maker_id).unwrap();
+    assert_eq!(mm.base_inventory, 700_000);
+    assert_eq!(mm.quote_inventory, 700_000);
+
+    // Withdraw some
+    client.mm_withdraw(&maker_addr, &maker_id, &100_000i128, &100_000i128);
+    let mm = client.mm_get_maker(&maker_id).unwrap();
+    assert_eq!(mm.base_inventory, 600_000);
+    assert_eq!(mm.quote_inventory, 600_000);
+}
+
+#[test]
+fn test_update_spread() {
+    let (env, client, _admin, base, quote) = setup();
+    let maker_addr = Address::generate(&env);
+
+    mint(&env, &base, &maker_addr, 1_000_000);
+    mint(&env, &quote, &maker_addr, 1_000_000);
+
+    let maker_id = client.mm_register(
+        &maker_addr, &base, &quote,
+        &100u32, &500_000i128, &500_000i128, &100_000i128,
+    );
+
+    client.mm_update_spread(&maker_addr, &maker_id, &200u32);
+    let mm = client.mm_get_maker(&maker_id).unwrap();
+    assert_eq!(mm.spread_bps, 200);
+}
+
+#[test]
+fn test_pause_and_resume_maker() {
+    let (env, client, _admin, base, quote) = setup();
+    let maker_addr = Address::generate(&env);
+
+    mint(&env, &base, &maker_addr, 1_000_000);
+    mint(&env, &quote, &maker_addr, 1_000_000);
+
+    let maker_id = client.mm_register(
+        &maker_addr, &base, &quote,
+        &100u32, &500_000i128, &500_000i128, &100_000i128,
+    );
+
+    client.mm_set_status(&maker_addr, &maker_id, &false);
+    let mm = client.mm_get_maker(&maker_id).unwrap();
+    assert_eq!(mm.status, MakerStatus::Paused);
+
+    client.mm_set_status(&maker_addr, &maker_id, &true);
+    let mm = client.mm_get_maker(&maker_id).unwrap();
+    assert_eq!(mm.status, MakerStatus::Active);
+}
+
+#[test]
+fn test_close_maker_returns_inventory() {
+    let (env, client, _admin, base, quote) = setup();
+    let maker_addr = Address::generate(&env);
+
+    mint(&env, &base, &maker_addr, 1_000_000);
+    mint(&env, &quote, &maker_addr, 1_000_000);
+
+    let maker_id = client.mm_register(
+        &maker_addr, &base, &quote,
+        &100u32, &500_000i128, &500_000i128, &100_000i128,
+    );
+
+    client.mm_close(&maker_addr, &maker_id);
+
+    let mm = client.mm_get_maker(&maker_id).unwrap();
+    assert_eq!(mm.status, MakerStatus::Closed);
+    assert_eq!(mm.base_inventory, 0);
+    assert_eq!(mm.quote_inventory, 0);
+
+    // All inventory returned
+    assert_eq!(balance(&env, &base, &maker_addr), 1_000_000);
+    assert_eq!(balance(&env, &quote, &maker_addr), 1_000_000);
+
+    // No longer in active list
+    let active = client.mm_get_active_makers();
+    assert!(!active.contains(&maker_id));
+}
+
+#[test]
+fn test_get_pair_makers() {
+    let (env, client, _admin, base, quote) = setup();
+    let maker1 = Address::generate(&env);
+    let maker2 = Address::generate(&env);
+
+    mint(&env, &base, &maker1, 1_000_000);
+    mint(&env, &quote, &maker1, 1_000_000);
+    mint(&env, &base, &maker2, 1_000_000);
+    mint(&env, &quote, &maker2, 1_000_000);
+
+    let id1 = client.mm_register(
+        &maker1, &base, &quote, &100u32, &500_000i128, &500_000i128, &100_000i128,
+    );
+    let id2 = client.mm_register(
+        &maker2, &base, &quote, &200u32, &500_000i128, &500_000i128, &100_000i128,
+    );
+
+    let pair_makers = client.mm_get_pair_makers(&base, &quote);
+    assert!(pair_makers.contains(&id1));
+    assert!(pair_makers.contains(&id2));
+}

--- a/contracts/tipjar/tests/stop_loss_tests.rs
+++ b/contracts/tipjar/tests/stop_loss_tests.rs
@@ -1,0 +1,198 @@
+#![cfg(test)]
+
+extern crate std;
+
+use soroban_sdk::{
+    testutils::{Address as _, Ledger},
+    Address, Env,
+};
+use tipjar::{
+    stop_loss::{StopOrderKind, StopOrderStatus},
+    TipJarContract, TipJarContractClient,
+};
+
+fn setup() -> (Env, TipJarContractClient<'static>, Address, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, TipJarContract);
+    let client = TipJarContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let token_id = env.register_stellar_asset_contract(token_admin.clone());
+
+    client.init(&admin);
+    client.add_token(&admin, &token_id);
+
+    (env, client, admin, token_id)
+}
+
+fn mint(env: &Env, token: &Address, to: &Address, amount: i128) {
+    soroban_sdk::token::StellarAssetClient::new(env, token).mint(to, &amount);
+}
+
+// ── Stop Loss ────────────────────────────────────────────────────────────────
+
+#[test]
+fn test_place_and_cancel_stop_loss() {
+    let (env, client, _admin, token) = setup();
+    let owner = Address::generate(&env);
+    mint(&env, &token, &owner, 1_000_000);
+
+    let order_id = client.sl_place_order(
+        &owner,
+        &token,
+        &500_000i128,
+        &900_000i128, // stop_price
+        &0i128,       // limit_price (unused for StopLoss)
+        &0i128,       // trail_amount (unused)
+        &StopOrderKind::StopLoss,
+        &1_000_000i128, // current_price
+    );
+
+    let order = client.sl_get_order(&order_id).unwrap();
+    assert_eq!(order.status, StopOrderStatus::Active);
+    assert_eq!(order.amount, 500_000);
+    assert_eq!(order.stop_price, 900_000);
+
+    // Cancel returns tokens
+    client.sl_cancel_order(&owner, &order_id);
+    let order = client.sl_get_order(&order_id).unwrap();
+    assert_eq!(order.status, StopOrderStatus::Cancelled);
+
+    let bal = soroban_sdk::token::Client::new(&env, &token).balance(&owner);
+    assert_eq!(bal, 1_000_000); // fully refunded
+}
+
+#[test]
+fn test_stop_loss_trigger_and_execute() {
+    let (env, client, _admin, token) = setup();
+    let owner = Address::generate(&env);
+    mint(&env, &token, &owner, 1_000_000);
+
+    let order_id = client.sl_place_order(
+        &owner,
+        &token,
+        &500_000i128,
+        &800_000i128, // stop_price
+        &0i128,
+        &0i128,
+        &StopOrderKind::StopLoss,
+        &1_000_000i128,
+    );
+
+    // Price above stop — not triggered
+    let triggered = client.sl_check_trigger(&order_id, &900_000i128);
+    assert!(!triggered);
+
+    // Price at or below stop — triggered
+    let triggered = client.sl_check_trigger(&order_id, &800_000i128);
+    assert!(triggered);
+
+    let order = client.sl_get_order(&order_id).unwrap();
+    assert_eq!(order.status, StopOrderStatus::Triggered);
+
+    // Execute the order
+    client.sl_execute_order(&owner, &order_id, &800_000i128);
+    let order = client.sl_get_order(&order_id).unwrap();
+    assert_eq!(order.status, StopOrderStatus::Executed);
+
+    // Tokens returned to owner
+    let bal = soroban_sdk::token::Client::new(&env, &token).balance(&owner);
+    assert_eq!(bal, 1_000_000);
+}
+
+#[test]
+fn test_stop_limit_requires_limit_price() {
+    let (env, client, _admin, token) = setup();
+    let owner = Address::generate(&env);
+    mint(&env, &token, &owner, 1_000_000);
+
+    let order_id = client.sl_place_order(
+        &owner,
+        &token,
+        &500_000i128,
+        &800_000i128, // stop_price
+        &750_000i128, // limit_price
+        &0i128,
+        &StopOrderKind::StopLimit,
+        &1_000_000i128,
+    );
+
+    // Trigger the order
+    client.sl_check_trigger(&order_id, &790_000i128);
+
+    // Execution price below limit — should fail
+    let result = std::panic::catch_unwind(|| {
+        client.sl_execute_order(&owner, &order_id, &700_000i128);
+    });
+    assert!(result.is_err(), "Should panic when execution price < limit price");
+
+    // Execution price meets limit — should succeed
+    client.sl_execute_order(&owner, &order_id, &760_000i128);
+    let order = client.sl_get_order(&order_id).unwrap();
+    assert_eq!(order.status, StopOrderStatus::Executed);
+}
+
+#[test]
+fn test_trailing_stop_adjusts_with_price() {
+    let (env, client, _admin, token) = setup();
+    let owner = Address::generate(&env);
+    mint(&env, &token, &owner, 1_000_000);
+
+    // Trail amount = 100_000; initial stop = 900_000 (peak 1_000_000 - trail)
+    let order_id = client.sl_place_order(
+        &owner,
+        &token,
+        &500_000i128,
+        &900_000i128,   // initial stop_price
+        &0i128,
+        &100_000i128,   // trail_amount
+        &StopOrderKind::TrailingStop,
+        &1_000_000i128, // current_price (peak)
+    );
+
+    // Price rises to 1_200_000 — stop should trail up to 1_100_000
+    client.sl_update_price(&order_id, &1_200_000i128);
+    let order = client.sl_get_order(&order_id).unwrap();
+    assert_eq!(order.stop_price, 1_100_000);
+    assert_eq!(order.peak_price, 1_200_000);
+
+    // Price drops to 1_050_000 — still above new stop, not triggered
+    let triggered = client.sl_check_trigger(&order_id, &1_050_000i128);
+    assert!(!triggered);
+
+    // Price drops to 1_100_000 — exactly at stop, triggered
+    let triggered = client.sl_check_trigger(&order_id, &1_100_000i128);
+    assert!(triggered);
+}
+
+#[test]
+fn test_get_owner_and_active_orders() {
+    let (env, client, _admin, token) = setup();
+    let owner = Address::generate(&env);
+    mint(&env, &token, &owner, 3_000_000);
+
+    let id0 = client.sl_place_order(
+        &owner, &token, &1_000_000i128, &800_000i128, &0i128, &0i128,
+        &StopOrderKind::StopLoss, &1_000_000i128,
+    );
+    let id1 = client.sl_place_order(
+        &owner, &token, &1_000_000i128, &700_000i128, &0i128, &0i128,
+        &StopOrderKind::StopLoss, &1_000_000i128,
+    );
+
+    let owner_orders = client.sl_get_owner_orders(&owner);
+    assert_eq!(owner_orders.len(), 2);
+
+    let active = client.sl_get_active_orders();
+    assert!(active.contains(&id0));
+    assert!(active.contains(&id1));
+
+    // Cancel one; it should leave active list
+    client.sl_cancel_order(&owner, &id0);
+    let active = client.sl_get_active_orders();
+    assert!(!active.contains(&id0));
+    assert!(active.contains(&id1));
+}


### PR DESCRIPTION
## Summary

Implements two new features for the tipjar contract.

## Changes

### #320 — Tip Stop Loss Orders
- New module `contracts/tipjar/src/stop_loss/mod.rs`
- Three order kinds: `StopLoss`, `StopLimit`, `TrailingStop`
- Price monitoring via `sl_check_trigger` / `sl_update_price`
- Trigger execution with limit price enforcement for stop-limit orders
- Trailing stop peak tracking with automatic stop price adjustment
- Token escrow on placement; refunded on execute or cancel
- Full order tracking (per-owner list, global active list)

### #321 — Tip Market Making
- New module `contracts/tipjar/src/market_making/mod.rs`
- Maker registration with base/quote inventory deposit
- Bid/ask quote calculation from mid-price + configurable spread
- Buy/sell trade execution with 0.1% fee collection
- Inventory deposit/withdraw and fee withdrawal
- Spread management, pause/resume, and full close
- Pair-based and owner-based maker lookup
- Performance tracking (volume, trade count, fees earned)

### Integration
- `pub mod stop_loss` and `pub mod market_making` in `lib.rs`
- `DataKey::StopLoss` and `DataKey::MarketMaking` variants
- `sl_*` and `mm_*` contract entry points
- Tests registered in `Cargo.toml`

## Tests
- `tests/stop_loss_tests.rs` — 5 tests covering place, cancel, trigger, execute, trailing stop
- `tests/market_making_tests.rs` — 7 tests covering register, quote, buy, sell, deposit/withdraw, spread, close

Closes #320 
Closes #321 