### PR TITLE
feat: add public view functions for contract configuration

### DIFF
--- a/contracts/tipjar/src/lib.rs
+++ b/contracts/tipjar/src/lib.rs
@@ -2343,6 +2343,38 @@ impl TipJarContract {
             .unwrap_or(false)
     }
 
+    // ── configuration view functions ─────────────────────────────────────────
+
+    /// Returns the contract administrator, or `None` if not yet initialized.
+    ///
+    /// Read-only: performs no state changes.
+    pub fn get_admin(env: Env) -> Option<Address> {
+        env.storage().instance().get(&DataKey::Admin)
+    }
+
+    /// Returns the platform fee in basis points (defaults to `0`).
+    ///
+    /// Read-only: performs no state changes.
+    pub fn get_fee_bps(env: Env) -> u32 {
+        env.storage()
+            .instance()
+            .get(&DataKey::Fee(FeeKey::BasisPoints))
+            .unwrap_or(0)
+    }
+
+    /// Returns the accumulated platform fee balance for `token` (defaults to `0`).
+    ///
+    /// Fees are tracked per token because the contract accepts any whitelisted
+    /// token (see [`is_whitelisted`]) rather than a single fixed one.
+    ///
+    /// Read-only: performs no state changes.
+    pub fn get_platform_fees(env: Env, token: Address) -> i128 {
+        env.storage()
+            .instance()
+            .get(&DataKey::Fee(FeeKey::Balance(token)))
+            .unwrap_or(0)
+    }
+
     /// Pauses all state-changing operations. Admin only.
     ///
     /// `reason` is stored on-chain for transparency.


### PR DESCRIPTION
closes #332

## What
Adds read-only view functions so callers (frontends, indexers, contract
inspectors) can query the TipJar's configuration without any state change.

- `get_admin(env) -> Option<Address>` — the contract administrator, or `None`
  before initialization.
- `get_fee_bps(env) -> u32` — the platform fee in basis points, defaulting to 0.
- `get_platform_fees(env, token: Address) -> i128` — the accumulated platform
  fee balance for a given token, defaulting to 0.

## Notes on adaptation
The issue's suggested snippet was written against a simpler single-token design
that no longer matches this contract. The implementation was adapted to the
contract's actual storage model so it integrates cleanly without conflicts:

- The contract accepts any whitelisted token rather than one fixed token, so
  there is no single `read_token`/`get_token` value to return. Token acceptance
  is already queryable via the existing `is_whitelisted(token)` function.
- Fee basis points are stored under `DataKey::Fee(FeeKey::BasisPoints)` (the key
  `init` writes and the tip flow reads), not a bare `FeeBps` key.
- Platform fees are accumulated per token under `DataKey::Fee(FeeKey::Balance(token))`,
  so `get_platform_fees` takes a `token` argument to return the correct balance.

All three functions are pure reads (no `set`/`require_auth`/mutation) and follow
the existing storage-access patterns used throughout the contract.
