### PR TITLE
feat: add configurable minimum tip amount to prevent dust spam

### DIFF
--- a/contracts/tipjar/src/lib.rs
+++ b/contracts/tipjar/src/lib.rs
@@ -1320,6 +1320,8 @@ pub enum DataKey {
     RecoveryAttempts(Address),
     /// Global counter for recovery request IDs.
     RecoveryCounter,
+    /// Minimum tip amount in stroops (i128).
+    MinTipAmount,
 }
 
 /// Granular operation scopes that can be independently paused.
@@ -1470,6 +1472,8 @@ pub enum TipJarError {
     FeeBpsTooHigh = 290,
     /// No accumulated platform fees are available to withdraw.
     NoFeesToWithdraw = 291,
+    /// Tip amount is below the configured minimum.
+    BelowMinimumTip = 292,
 }
 
 impl From<CoreError> for TipJarError {
@@ -2360,6 +2364,9 @@ impl TipJarContract {
             .instance()
             .set(&DataKey::Fee(FeeKey::BasisPoints), &0u32);
         env.storage().instance().set(&DataKey::RefundWindow, &0u64);
+        env.storage()
+            .instance()
+            .set(&DataKey::MinTipAmount, &10_000i128);
 
         // Store semantic version string for on-chain queryability and upgrade tooling.
         let version_str = soroban_sdk::String::from_str(&env, CONTRACT_VERSION);
@@ -2447,6 +2454,35 @@ impl TipJarContract {
             .instance()
             .get(&DataKey::Fee(FeeKey::BasisPoints))
             .unwrap_or(0)
+    }
+
+    /// Returns the current minimum tip amount in stroops (defaults to `10_000`).
+    ///
+    /// Read-only: performs no state changes.
+    pub fn get_min_tip(env: Env) -> i128 {
+        env.storage()
+            .instance()
+            .get(&DataKey::MinTipAmount)
+            .unwrap_or(10_000)
+    }
+
+    /// Sets the minimum tip amount in stroops. Admin only.
+    ///
+    /// Tips below this threshold are rejected with [`TipJarError::BelowMinimumTip`].
+    /// Emits `("min_tip",)` with data `amount`.
+    pub fn set_min_tip(env: Env, admin: Address, amount: i128) {
+        admin.require_auth();
+        let stored_admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+        if admin != stored_admin {
+            panic_with_error!(&env, TipJarError::Unauthorized);
+        }
+        if amount <= 0 {
+            panic_with_error!(&env, TipJarError::InvalidAmount);
+        }
+        env.storage()
+            .instance()
+            .set(&DataKey::MinTipAmount, &amount);
+        env.events().publish((symbol_short!("min_tip"),), amount);
     }
 
     /// Returns the accumulated platform fee balance for `token` (defaults to `0`).
@@ -3015,6 +3051,14 @@ impl TipJarContract {
         sender.require_auth();
         if amount <= 0 {
             panic_with_error!(&env, TipJarError::InvalidAmount);
+        }
+        let min_tip: i128 = env
+            .storage()
+            .instance()
+            .get(&DataKey::MinTipAmount)
+            .unwrap_or(10_000);
+        if amount < min_tip {
+            panic_with_error!(&env, TipJarError::BelowMinimumTip);
         }
         // Enforce compliance / creator-preference access lists.
         access_lists::check_allowed(&env, &creator, &sender);


### PR DESCRIPTION
feat: add configurable minimum tip amount to prevent dust spam
Problem
The tipjar contract only rejected amounts <= 0, meaning a sender could submit a tip of 1 stroop and it would be accepted as valid. On Soroban, every contract invocation consumes ledger storage entries and compute budget regardless of the tip value. This creates a low-cost spam vector — an attacker can flood the contract with dust tips (e.g. 1 stroop each), bloating persistent storage, inflating creator tip history, triggering leaderboard updates, and burning compute budget, all at negligible cost to the sender.

Solution
Introduce a configurable minimum tip amount stored in instance storage. Tips below the threshold are rejected early — before any state mutations, token transfers, or event emissions — keeping the attack surface tight.

Changes
lib.rs
 — 44 insertions

1. DataKey::MinTipAmount (storage key)
/// Minimum tip amount in stroops (i128).
MinTipAmount,
Added to the DataKey enum. Uses instance storage so it shares the contract's TTL bump and is cheap to read on every tip() call.

2. TipJarError::BelowMinimumTip = 292 (new error variant)
/// Tip amount is below the configured minimum.
BelowMinimumTip = 292,
Assigned 292 to continue the existing sequential error block without conflicting with any existing codes. The issue suggested 6 but that value is already occupied by MilestoneNotFound.

3. init() — default minimum set on deployment
env.storage()
    .instance()
    .set(&DataKey::MinTipAmount, &10_000i128);
Every fresh deployment now has a 10_000 stroop (0.001 XLM) minimum out of the box. No manual admin action required.

4. tip() — enforcement guard
if amount <= 0 {
    panic_with_error!(&env, TipJarError::InvalidAmount);
}
let min_tip: i128 = env
    .storage()
    .instance()
    .get(&DataKey::MinTipAmount)
    .unwrap_or(10_000);
if amount < min_tip {
    panic_with_error!(&env, TipJarError::BelowMinimumTip);
}
The check is placed immediately after the existing <= 0 guard and before any state writes, token transfers, access list checks, or event emissions. Failing fast here means zero ledger mutations on a rejected dust tip. The unwrap_or(10_000) fallback makes this safe on any pre-existing deployment that hasn't yet stored the key.

5. get_min_tip() — view function
pub fn get_min_tip(env: Env) -> i128 {
    env.storage()
        .instance()
        .get(&DataKey::MinTipAmount)
        .unwrap_or(10_000)
}
Read-only. Returns the current minimum, defaulting to 10_000 if not set. Allows frontends and integrators to surface the minimum to users before submitting a transaction.

6. set_min_tip(admin, amount) — admin setter
pub fn set_min_tip(env: Env, admin: Address, amount: i128) {
    admin.require_auth();
    // admin identity check ...
    if amount <= 0 {
        panic_with_error!(&env, TipJarError::InvalidAmount);
    }
    env.storage()
        .instance()
        .set(&DataKey::MinTipAmount, &amount);
    env.events().publish((symbol_short!("min_tip"),), amount);
}
Admin-only with full auth and identity verification, consistent with every other admin setter in the contract (set_fee_bps, pause, etc.). Emits a ("min_tip",) event so off-chain indexers and the analytics service can track minimum changes over time.

Behaviour Matrix
Scenario	Result
amount == 0	InvalidAmount (existing guard)
amount == 1 (below default min)	BelowMinimumTip
amount == 9_999 (below default min)	BelowMinimumTip
amount == 10_000 (at default min)	✅ proceeds
amount > 10_000	✅ proceeds
Admin raises min to 100_000, tip of 50_000 sent	BelowMinimumTip
Non-admin calls set_min_tip	Unauthorized
get_min_tip on uninitialised contract	returns 10_000 (safe default)
Backwards Compatibility
No existing storage keys are modified or removed
unwrap_or(10_000) in both tip() and get_min_tip() means existing deployed contracts without the key stored will silently adopt the default — no migration needed
No changes to function signatures of any existing public functions
Error code 292 does not conflict with any existing TipJarError variant
Security Considerations
The guard fires before sender.require_auth() is skipped but after the pause/circuit-breaker checks, preserving the existing security ordering
No new trust assumptions introduced — set_min_tip follows the identical admin auth pattern used throughout the contract
Default of 10_000 stroops is conservative enough to deter spam while being negligible for real users (~$0.0001 at current XLM prices)

Closes #334 