### PR TITLE
`PAYOUT_DELAY_LEDGERS` (~1 day) pending-payout-address change — confirm the delay can't be bypassed by combining with a guardian pause/unpause sequence

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,19 @@ CONTRIBUTING.md
 
 See `contracts/tipjar/src/lib.rs` for the full function list, including operator delegation and payout-address rotation.
 
+### Payout-address delay threat model
+
+Payout-address rotation uses an approximately one-day ledger delay before a
+new payout address can receive withdrawals. This protects against an attacker
+who gets a creator/operator key and tries to redirect future withdrawals to a
+new destination. It does **not** lock existing escrow: an authorized creator,
+or an authorized operator within its allowance and expiry, can still withdraw
+immediately to the currently valid payout address while a payout-address change
+is pending. Pausing and unpausing withdrawals does not change the pending
+change's absolute effective ledger; after unpause, `withdraw` still applies the
+change only when the ledger sequence has reached that original checkpoint.
+
+
 ## Storage Model
 
 `DataKey` (instance/persistent storage):

--- a/contracts/tipjar/src/test_exhaustive.rs
+++ b/contracts/tipjar/src/test_exhaustive.rs
@@ -10,6 +10,7 @@ struct Ctx {
     env: Env,
     contract_id: Address,
     token: Address,
+    admin: Address,
 }
 
 impl Ctx {
@@ -28,6 +29,7 @@ impl Ctx {
             env,
             contract_id,
             token,
+            admin,
         }
     }
 
@@ -206,6 +208,78 @@ fn test_payout_delay_and_cancellation() {
         token::TokenClient::new(&ctx.env, &ctx.token).balance(&new_payout),
         100
     );
+}
+
+#[test]
+fn test_payout_delay_uses_absolute_ledgers_across_pause_unpause() {
+    let ctx = Ctx::new();
+    let client = ctx.client();
+    let creator = Address::generate(&ctx.env);
+    let new_payout = Address::generate(&ctx.env);
+    let sender = ctx.fund(1000);
+
+    client.tip(&sender, &creator, &ctx.token, &1000);
+    let proposed_at = ctx.env.ledger().sequence();
+    client.set_payout_address(&creator, &new_payout);
+    let effective_ledger = proposed_at + 17280;
+
+    // Pausing withdrawals blocks withdraws, but it must not reset, shorten, or
+    // otherwise mutate the pending payout change's absolute effective ledger.
+    ctx.env.ledger().with_mut(|li| li.sequence_number += 100);
+    client.pause_withdrawals(&ctx.admin);
+    ctx.env.ledger().with_mut(|li| li.sequence_number += 1000);
+    assert_eq!(
+        client
+            .try_withdraw(&creator, &creator, &ctx.token, &new_payout, &Some(100))
+            .unwrap_err()
+            .unwrap(),
+        Error::WithdrawalsPaused.into()
+    );
+    client.unpause_withdrawals(&ctx.admin);
+
+    // Before the original effective ledger, the new payout still cannot be used.
+    ctx.env
+        .ledger()
+        .with_mut(|li| li.sequence_number = effective_ledger - 1);
+    assert_eq!(
+        client
+            .try_withdraw(&creator, &creator, &ctx.token, &new_payout, &Some(100))
+            .unwrap_err()
+            .unwrap(),
+        Error::InvalidTarget.into()
+    );
+
+    // At the original effective ledger, the pending change applies normally.
+    ctx.env
+        .ledger()
+        .with_mut(|li| li.sequence_number = effective_ledger);
+    client.withdraw(&creator, &creator, &ctx.token, &new_payout, &Some(100));
+    assert_eq!(
+        token::TokenClient::new(&ctx.env, &ctx.token).balance(&new_payout),
+        100
+    );
+}
+
+#[test]
+fn test_compromised_creator_can_withdraw_to_existing_payout_before_delay() {
+    let ctx = Ctx::new();
+    let client = ctx.client();
+    let creator = Address::generate(&ctx.env);
+    let attacker_payout = Address::generate(&ctx.env);
+    let sender = ctx.fund(1000);
+
+    client.tip(&sender, &creator, &ctx.token, &1000);
+    client.set_payout_address(&creator, &attacker_payout);
+
+    // The delay protects only a pending destination change. The authenticated
+    // creator key can still withdraw the escrowed balance immediately to the
+    // current payout address, which defaults to the creator address.
+    client.withdraw(&creator, &creator, &ctx.token, &creator, &None);
+    assert_eq!(
+        token::TokenClient::new(&ctx.env, &ctx.token).balance(&creator),
+        1000
+    );
+    assert_eq!(client.get_balance(&creator, &ctx.token), 0);
 }
 
 #[test]

--- a/security/THREAT_MODEL.md
+++ b/security/THREAT_MODEL.md
@@ -65,6 +65,36 @@ This document outlines the TipJar contract's trust assumptions, security invaria
 2. **Monitoring**: Alert on suspicious patterns (e.g., bulk withdrawals from cold addresses).
 3. **Incident response**: Have a pre-signed pause transaction ready for rapid deployment.
 
+
+### 4. Creator / Operator Keys and Payout-Address Delay
+
+**Assumption**: A creator/operator key that can authorize withdrawals is protected.
+The `PAYOUT_DELAY_LEDGERS` delay protects only changes to the destination of
+future withdrawals; it is not a withdrawal timelock.
+
+**What the delay protects**:
+- A compromised creator key cannot immediately redirect withdrawals to a newly
+  proposed payout address. The pending payout address is stored with an absolute
+  `effective_ledger`, and `withdraw()` applies it only when
+  `env.ledger().sequence() >= effective_ledger`.
+- Pausing or unpausing withdrawals does not recompute, shorten, extend, or clear
+  the pending payout change. While withdrawals are paused, `withdraw()` and
+  payout-management entrypoints are blocked; after unpause, the same absolute
+  ledger comparison determines whether the pending payout has matured.
+
+**What the delay does not protect**:
+- A compromised creator key can withdraw the existing escrowed balance
+  immediately to the currently valid payout address before the pending payout
+  change matures.
+- A compromised operator key can do the same within its remaining allowance and
+  expiry, but only to the currently valid payout address.
+
+**Operational guidance**: Product copy should describe payout-address delay as
+protection against malicious destination rotation for future withdrawals, not as
+protection against immediate draining by an already-authorized creator/operator
+key. Creators should still secure withdrawal-authorizing keys, keep operator
+allowances narrow, and monitor payout-change events.
+
 ---
 
 ## Storage Invariants


### PR DESCRIPTION
closes #406 

# Summary

### Motivation

* Clarify the exact threat model of the `PAYOUT_DELAY_LEDGERS` (approximately 1 day) payout-address rotation so product documentation and auditors understand that it protects the destination of **future withdrawals**, not immediate withdrawals made using an already-authorized creator/operator key.
* Ensure automated regression coverage confirms that pausing and unpausing withdrawals does not mutate, reset, or bypass a pending payout change's absolute `effective_ledger`.
* Confirm that an authenticated creator can still withdraw to the current payout address before a pending payout-address change matures.
* Preserve and document the existing `remove_token` semantics, which ensure pre-existing balances remain withdrawable.

### Scope

* [x] Soroban contract
* [ ] Backend/API or indexing
* [ ] Mobile app
* [ ] Web app
* [x] Documentation or contributor process

### Description

* Added a new **"Payout-address delay threat model"** subsection to `README.md` documenting what the payout-address delay protects and clarifying that pause/unpause does not change the pending change's absolute effective ledger.
* Extended `security/THREAT_MODEL.md` with a **"Creator / Operator Keys and Payout-Address Delay"** section covering:

  * What `PAYOUT_DELAY_LEDGERS` protects.
  * What the delay does not protect against.
  * The ability of a compromised authorized creator/operator key to withdraw using the currently valid payout address before the delay expires.
  * Operational guidance for creators and operators.
* Added `test_payout_delay_uses_absolute_ledgers_across_pause_unpause` to `contracts/tipjar/src/test_exhaustive.rs` to verify that pausing and unpausing withdrawals does not alter the pending payout change's absolute `effective_ledger`.
* Added `test_compromised_creator_can_withdraw_to_existing_payout_before_delay` to document and verify that an authenticated creator can withdraw to the existing payout target while a payout-address change is still pending.
* Kept the existing multi-token/remove-token regression in `contracts/tipjar/src/test_multitoken.rs`, which verifies that removing a token does not strand pre-existing balances or prevent their withdrawal.

### Validation

* [x] Tests were added or updated for changed behavior.
* [ ] Relevant local test command fully passed.
* [x] Documentation was updated for the clarified security model.

### Testing

* `cargo fmt -p tipjar` — completed successfully.
* `git diff --check` — passed with no whitespace or diff errors.
* `cargo test -p tipjar` — attempted but blocked because `contracts/tipjar/src/test_upgrade.rs` references a missing `tipjar_v2_fixture.wasm`. The fixture requires the `wasm32v1-none` Rust target.
* Attempted to build the `wasm32v1-none` target and `tipjar-v2-fixture`, but the environment could not install the required Rust target because of a network/download error.
* As a result, the full `tipjar` test suite could not be executed in this environment.

### Security and data handling

* [x] Wallet/session/auth changes preserve existing access controls.
* [x] User data, secrets, and payment-related values are not logged or exposed.
* [x] Error responses avoid leaking private implementation details.
* [ ] Not applicable for this PR.

### Reviewer notes

* `PAYOUT_DELAY_LEDGERS` is an anti-takeover measure specifically for **payout-address rotation**. It delays when a newly configured payout destination can receive funds from subsequent withdrawals.
* The delay does **not** prevent an already-authorized creator/operator key from withdrawing to the currently valid payout address before the pending change matures.
* The pending payout change uses an absolute `effective_ledger`; pausing and unpausing withdrawals does not extend, reset, or otherwise modify that scheduled ledger.
* The existing `remove_token` behavior remains covered by the multi-token regression test and continues to allow withdrawal of pre-existing balances.
