### PR TITLE
`partial_pause_tests.rs` exists as a distinct test target in *both* the `tipjar` and `tipjar-legacy` packages — confirm they're not accidentally the same suite copy-pasted across a fork point

### DIFF
--- a/contracts/tipjar-legacy/tests/partial_pause_tests.rs
+++ b/contracts/tipjar-legacy/tests/partial_pause_tests.rs
@@ -1,5 +1,12 @@
 #![cfg(test)]
 
+//! Partial-pause coverage for the legacy contract's `PauseScope`-keyed
+//! `pause_feature` circuit breaker. This is intentionally distinct from the
+//! modern `tipjar` package's repo-root `tests/partial_pause_tests.rs`, which
+//! exercises admin/guardian `PauseState` bitmask flags and entrypoint-to-flag
+//! gating. The shared target/file name reflects analogous behavior in sibling
+//! crates, not a copy-paste duplicate.
+
 extern crate std;
 
 use soroban_sdk::{testutils::Address as _, token, Address, Env, String as SorobanString};

--- a/tests/partial_pause_tests.rs
+++ b/tests/partial_pause_tests.rs
@@ -1,6 +1,14 @@
-//! Full (flag, entrypoint) test matrix for the granular circuit breaker,
-//! plus the acceptance-criteria tests for independent pause scopes:
+//! Full (flag, entrypoint) test matrix for the modern tipjar granular circuit
+//! breaker, plus the acceptance-criteria tests for independent pause scopes:
 //! withdrawals stay live while tips are paused, and vice versa.
+//!
+//! This is intentionally distinct from
+//! `contracts/tipjar-legacy/tests/partial_pause_tests.rs`: the modern contract
+//! stores admin/guardian `PauseState` flags (`PAUSE_FLAG_TIPS` and
+//! `PAUSE_FLAG_WITHDRAWALS`) and maps each public entrypoint to one of those
+//! bitmask gates. The legacy suite covers its older `PauseScope`-keyed
+//! `pause_feature` API instead, so the shared file name is not a copy-paste
+//! duplicate across packages.
 
 mod common;
 


### PR DESCRIPTION
closes #415

Motivation
Clarify that tests/partial_pause_tests.rs (modern tipjar) and contracts/tipjar-legacy/tests/partial_pause_tests.rs (legacy) are intentionally different test suites exercising different pause implementations (PauseState bitmask with PAUSE_FLAG_TIPS/PAUSE_FLAG_WITHDRAWALS vs PauseScope-keyed pause_feature) so they are not mistaken for accidental copies.


Description
Add explanatory module-level comments to tests/partial_pause_tests.rs and contracts/tipjar-legacy/tests/partial_pause_tests.rs documenting the distinction and why the identical file name is intentional.


Testing
Ran cargo test -p tipjar --test partial_pause_tests, which completed successfully (5 tests passed).
Ran cargo test -p tipjar-legacy --test partial_pause_tests, which failed due to pre-existing compile errors in the tipjar-legacy crate unrelated to these comment-only changes (legacy lending/recovery compile errors).