### PR TITLE
Verify tipjar pause test targets

### DIFF
--- a/.github/workflows/contract-ci.yml
+++ b/.github/workflows/contract-ci.yml
@@ -33,6 +33,12 @@ jobs:
         # disk before `cargo test -p tipjar` runs.
         run: cargo build -p tipjar-v2-fixture --target wasm32v1-none --release
 
+      - name: Verify pause_tests / partial_pause_tests wiring
+        # Guard against the orphaned-test-tree failure mode: confirm the two
+        # root-level integration tests are still registered as real [[test]]
+        # targets of the `tipjar` package (see tests/README.md).
+        run: cargo test -p tipjar --test pause_tests --test partial_pause_tests -- --list
+
       - name: Run tests
         run: cargo test -p tipjar
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,12 @@ jobs:
         # disk before `cargo test -p tipjar` runs.
         run: cargo build -p tipjar-v2-fixture --target wasm32v1-none --release
 
+      - name: Verify pause_tests / partial_pause_tests wiring
+        # Guard against the orphaned-test-tree failure mode: confirm the two
+        # root-level integration tests are still registered as real [[test]]
+        # targets of the `tipjar` package (see tests/README.md).
+        run: cargo test -p tipjar --test pause_tests --test partial_pause_tests -- --list
+
       - name: Run unit & integration tests
         run: cargo test -p tipjar -- --test-threads=4
 

--- a/contracts/tipjar/src/lib.rs
+++ b/contracts/tipjar/src/lib.rs
@@ -8,13 +8,13 @@ use soroban_sdk::{
 #[cfg(test)]
 mod test;
 #[cfg(test)]
+mod test_coverage_gaps;
+#[cfg(test)]
 mod test_exhaustive;
 #[cfg(test)]
 mod test_invariants;
 #[cfg(test)]
 mod test_upgrade;
-#[cfg(test)]
-mod test_coverage_gaps;
 
 /// Ledger TTL bump applied to instance and persistent storage on every write.
 const LEDGER_THRESHOLD: u32 = 100_000;

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -8,6 +8,17 @@ COVERAGE=${COVERAGE:-0}
 echo "==> Building contract (WASM)..."
 cargo build -p tipjar --target wasm32v1-none --release
 
+echo "==> Building v2 upgrade test fixture (WASM)..."
+# contracts/tipjar/src/test_upgrade.rs embeds this via contractimport! at
+# compile time, so it must exist on disk before `cargo test -p tipjar` runs.
+cargo build -p tipjar-v2-fixture --target wasm32v1-none --release
+
+echo "==> Verifying pause_tests / partial_pause_tests wiring..."
+# Guard against the orphaned-test-tree failure mode: confirm the two
+# root-level integration tests are still registered as real [[test]]
+# targets of the `tipjar` package (see tests/README.md).
+cargo test -p tipjar --test pause_tests --test partial_pause_tests -- --list
+
 echo "==> Running unit & integration tests (threads=${THREADS})..."
 cargo test -p tipjar -- --test-threads="${THREADS}"
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,5 +1,61 @@
 # Tests Directory
 
-This folder is reserved for integration and end-to-end tests as the project grows.
+This folder holds **integration tests that are compiled as part of the
+`tipjar` package** (`contracts/tipjar`), even though the files live at the
+repo root rather than under `contracts/tipjar/tests/`.
 
-Current contract unit tests live in `contracts/tipjar/src/lib.rs` and use Soroban's testing framework.
+## Why the files are here, not under `contracts/tipjar/tests/`
+
+`pause_tests.rs` and `partial_pause_tests.rs` share a common harness in
+`tests/common/mod.rs`. Cargo compiles `mod common;` fresh into each
+`[[test]]` binary, so a single shared `tests/common/` directory is the
+simplest way to avoid duplicating the harness across two packages.
+
+Because Cargo's test auto-discovery only looks in a package's *own*
+`tests/` directory, these root-level files are **not** auto-discovered.
+They are wired in explicitly via `[[test]]` entries in
+`contracts/tipjar/Cargo.toml`:
+
+```toml
+[[test]]
+name = "pause_tests"
+path = "../../tests/pause_tests.rs"
+
+[[test]]
+name = "partial_pause_tests"
+path = "../../tests/partial_pause_tests.rs"
+```
+
+## How to verify the wiring
+
+These targets are real `[[test]]` targets of the `tipjar` package — they
+are **not** orphaned. You can confirm this directly:
+
+```bash
+# 1. They appear as `test` targets of the `tipjar` package in cargo metadata:
+cargo metadata --no-deps --format-version 1 \
+  | jq -r '.packages[] | select(.name=="tipjar") | .targets[] | select(.kind[0]=="test") | .name'
+# => pause_tests
+# => partial_pause_tests
+
+# 2. They enumerate their expected test functions:
+cargo test -p tipjar --test pause_tests --test partial_pause_tests -- --list
+
+# 3. They pass:
+cargo test -p tipjar --test pause_tests --test partial_pause_tests
+```
+
+> Note: `cargo test -p tipjar` (the full suite) additionally compiles the
+> in-tree unit tests under `contracts/tipjar/src/`, which embed a v2 upgrade
+> fixture WASM via `soroban_sdk::contractimport!`. That fixture must be built
+> first — see `docs/UPGRADE_GUIDE.md` and `.github/workflows/test.yml`.
+> The two integration targets above do **not** depend on that fixture and can
+> be run independently.
+
+## Other files in this directory
+
+The remaining `*.rs` files (`core_functionality.rs`, `edge_cases.rs`,
+`security_tests.rs`, etc.) are **not** wired to any package and are not
+compiled by `cargo test`. They are legacy/scratch integration tests kept
+for reference; see `tests/README.md` history and the audit notes in
+`docs/SECURITY.md` for the orphaned-test-tree context.


### PR DESCRIPTION

## Summary

- Confirmed `pause_tests.rs` and `partial_pause_tests.rs` are explicit `[[test]]` targets of the `tipjar` package.
- Documented that the files live in the repository-level `tests` directory, not `tests`.
- Added CI and script checks to detect orphaned test targets.
- Ensured the v2 fixture is built before the full `tipjar` test suite.

## Testing

- `git diff --cached --check` passed.
- Rust test execution was unavailable because `cargo` is not installed in the current shell.
closes #421