### PR TITLE
Contract test snapshot files (`test_snapshots/tests/*.1.json`) across `derivatives`/`risk-management`/`limit-orders`/`arbitrage` — confirm snapshot content is actually reviewed on change, not blindly regenerated and accepted

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,22 @@
+## Summary
+
+- 
+
+## Testing
+
+- [ ] `cargo test --workspace`
+- [ ] `cargo fmt --all -- --check`
+- [ ] `cargo clippy --all-targets -- -D warnings`
+
+## Snapshot diff review
+
+If this PR changes any of these human-readable contract snapshots, reviewers must inspect the JSON diff before approval:
+
+- `contracts/derivatives/test_snapshots/tests/*.1.json`
+- `contracts/risk-management/test_snapshots/tests/*.1.json`
+- `contracts/limit-orders/test_snapshots/tests/*.1.json`
+- `contracts/arbitrage/test_snapshots/tests/*.1.json`
+
+- [ ] No snapshot files changed in those directories.
+- [ ] Snapshot files changed, and the PR description explains the intended storage/event diff.
+- [ ] Snapshot files changed, and a reviewer has explicitly confirmed the JSON diff is expected.

--- a/.github/workflows/snapshot-review.yml
+++ b/.github/workflows/snapshot-review.yml
@@ -1,0 +1,37 @@
+name: Snapshot Review Gate
+
+on:
+  pull_request:
+    branches: [main, develop]
+    paths:
+      - 'contracts/derivatives/test_snapshots/tests/*.1.json'
+      - 'contracts/risk-management/test_snapshots/tests/*.1.json'
+      - 'contracts/limit-orders/test_snapshots/tests/*.1.json'
+      - 'contracts/arbitrage/test_snapshots/tests/*.1.json'
+      - '.github/workflows/snapshot-review.yml'
+
+jobs:
+  require-review-note:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Confirm snapshot review checklist is acknowledged
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          set -eu
+          if printf '%s\n' "$PR_BODY" | grep -Eiq '\[[xX]\].*snapshot files changed'; then
+            exit 0
+          fi
+
+          cat <<'MSG'
+          This PR changes a DeFi contract test snapshot under one of:
+            - contracts/derivatives/test_snapshots/tests/*.1.json
+            - contracts/risk-management/test_snapshots/tests/*.1.json
+            - contracts/limit-orders/test_snapshots/tests/*.1.json
+            - contracts/arbitrage/test_snapshots/tests/*.1.json
+
+          Snapshot diffs must not be blindly regenerated. Update the PR body's
+          Snapshot diff review checklist to explain the intended storage/event
+          diff and confirm the JSON diff was reviewed.
+          MSG
+          exit 1

--- a/contracts/arbitrage/src/lib.rs
+++ b/contracts/arbitrage/src/lib.rs
@@ -275,11 +275,17 @@ mod tests {
 
         let profit =
             client.execute_arbitrage(&executor, &token, &buy_market, &sell_market, &100i128);
-        assert!(profit > 0);
+        assert_eq!(profit, 20);
 
         let records = client.get_performance(&executor);
         assert_eq!(records.len(), 1);
-        assert_eq!(records.get(0).unwrap().profit, profit);
+        let record = records.get(0).unwrap();
+        assert_eq!(record.id, 1);
+        assert_eq!(record.executor, executor);
+        assert_eq!(record.token, token);
+        assert_eq!(record.buy_market, buy_market);
+        assert_eq!(record.sell_market, sell_market);
+        assert_eq!(record.profit, profit);
     }
 
     #[test]
@@ -322,8 +328,14 @@ mod tests {
 
         let executor_records = client.get_performance(&executor);
         assert_eq!(executor_records.len(), 2);
+        assert_eq!(executor_records.get(0).unwrap().id, 1);
+        assert_eq!(executor_records.get(0).unwrap().profit, 20);
+        assert_eq!(executor_records.get(1).unwrap().id, 2);
+        assert_eq!(executor_records.get(1).unwrap().profit, 40);
 
         let other_records = client.get_performance(&other);
         assert_eq!(other_records.len(), 1);
+        assert_eq!(other_records.get(0).unwrap().id, 3);
+        assert_eq!(other_records.get(0).unwrap().profit, 10);
     }
 }

--- a/contracts/derivatives/src/lib.rs
+++ b/contracts/derivatives/src/lib.rs
@@ -319,9 +319,14 @@ mod tests {
         let buy_pos = client.get_position(&buyer, &buy_id);
         assert_eq!(buy_pos.quantity, 10);
         assert_eq!(buy_pos.entry_price, 100);
+        assert_eq!(buy_pos.owner, buyer);
+        assert_eq!(buy_pos.derivative_id, buy_id);
 
         let sell_pos = client.get_position(&seller, &sell_id);
         assert_eq!(sell_pos.quantity, 10);
+        assert_eq!(sell_pos.entry_price, 100);
+        assert_eq!(sell_pos.owner, seller);
+        assert_eq!(sell_pos.derivative_id, sell_id);
     }
 
     #[test]
@@ -363,6 +368,9 @@ mod tests {
                 .unwrap()
         });
         assert!(order.settled);
+        assert_eq!(order.id, order_id);
+        assert_eq!(order.quantity, 5);
+        assert_eq!(order.strike_price, 50);
     }
 
     #[test]
@@ -437,5 +445,7 @@ mod tests {
                 .unwrap()
         });
         assert!(order.settled);
+        assert_eq!(order.owner, owner);
+        assert_eq!(order.quantity, 1);
     }
 }

--- a/contracts/limit-orders/src/lib.rs
+++ b/contracts/limit-orders/src/lib.rs
@@ -262,6 +262,9 @@ mod tests {
 
         let order = client.get_order(&order_id);
         assert_eq!(order.filled, 100);
+        assert_eq!(order.amount_in, 100);
+        assert_eq!(order.limit_price, 50);
+        assert_eq!(order.owner, buyer);
     }
 
     #[test]
@@ -301,6 +304,8 @@ mod tests {
 
         let order = client.get_order(&order_id);
         assert_eq!(order.filled, 100); // full fill since match_order fills all remaining
+        assert_eq!(order.id, order_id);
+        assert!(!order.cancelled);
     }
 
     #[test]
@@ -324,6 +329,8 @@ mod tests {
 
         let order = client.get_order(&order_id);
         assert!(order.cancelled);
+        assert_eq!(order.filled, 0);
+        assert_eq!(order.amount_in, 500);
     }
 
     #[test]

--- a/contracts/risk-management/src/lib.rs
+++ b/contracts/risk-management/src/lib.rs
@@ -240,6 +240,8 @@ mod tests {
         let profile = client.check_exposure(&user);
         assert_eq!(profile.exposure, 500);
         assert_eq!(profile.risk_score, 50); // 500*100/1000 = 50
+        assert_eq!(profile.alert_threshold, 1000);
+        assert_eq!(profile.owner, user);
     }
 
     #[test]
@@ -252,6 +254,7 @@ mod tests {
         client.update_exposure(&user, &200i128); // 200% -> capped at 100
 
         let profile = client.check_exposure(&user);
+        assert_eq!(profile.exposure, 200);
         assert_eq!(profile.risk_score, 100);
     }
 
@@ -304,6 +307,7 @@ mod tests {
         let profile = client.check_exposure(&user);
         assert_eq!(profile.exposure, 0);
         assert_eq!(profile.risk_score, 0);
+        assert_eq!(profile.alert_threshold, 1000);
     }
 
     #[test]
@@ -317,5 +321,6 @@ mod tests {
 
         let metrics = client.get_risk_metrics();
         assert_eq!(metrics.total_exposure, 300);
+        assert_eq!(metrics.high_risk_count, 0);
     }
 }


### PR DESCRIPTION
closes #417 


Motivation
Prevent silent acceptance of regenerated human-readable snapshot JSON diffs by ensuring reviewers acknowledge and inspect changes to test_snapshots for the four flagged DeFi contracts.
Make snapshot-backed tests more robust by adding explicit assertions for critical stored values and computed outputs so behavioral regressions fail even if a snapshot diff is missed.


Description
Add a PR template (.github/pull_request_template.md) with a Snapshot diff review checklist that calls out the four snapshot directories contracts/derivatives/test_snapshots/tests/*.1.json, contracts/risk-management/test_snapshots/tests/*.1.json, contracts/limit-orders/test_snapshots/tests/*.1.json, and contracts/arbitrage/test_snapshots/tests/*.1.json and requires reviewers to confirm inspection.
Add a GitHub Actions workflow (.github/workflows/snapshot-review.yml) that gates PRs touching those snapshot JSON files and fails until the PR body contains an explicit acknowledgement that snapshot diffs were reviewed.
Strengthen unit tests in the four contracts by adding concrete assertions: in contracts/arbitrage assert exact profit and all ArbitrageRecord fields and per-record profits; in contracts/derivatives assert matched Position owner/ID and settled Order fields; in contracts/limit-orders assert amount_in, limit_price, owner, filled, cancellation and original amount; in contracts/risk-management assert RiskProfile.alert_threshold/owner and RiskMetrics.high_risk_count alongside existing checks.


Testing
Ran cargo fmt --all / cargo fmt --all -- --check and formatting checks passed.
Ran unit tests with cargo test -p derivatives -p risk-management -p limit-orders -p arbitrage and all tests passed.
Added CI workflow for PR-time enforcement of snapshot review (the workflow itself will execute on GitHub for PRs that modify snapshot files).
